### PR TITLE
[Render Delegate] Update hdarnold.h for 0.19.11.

### DIFF
--- a/render_delegate/hdarnold.h
+++ b/render_delegate/hdarnold.h
@@ -31,3 +31,8 @@
 #define USD_HAS_UPDATED_COMPOSITOR
 #endif
 #endif
+
+#if USED_USD_VERSION_GREATER_EQ(19, 12)
+/// Hydra has the new compositor functions
+#define USD_HAS_UPDATED_COMPOSITOR
+#endif


### PR DESCRIPTION
Don't require setting USD_1910_UPDATED_COMPOSITOR when USD is newer than 0.19.11.

**Changes proposed in this pull request**
- Setting USD_HAS_UPDATED_COMPOSITOR macro when USD version newer than 0.19.12.

**Issues fixed in this pull request**
There are no issues created for this change.