### PR TITLE
Compute world matrix for xformable primitives #51

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -103,7 +103,7 @@ void UsdArnoldReadMesh::read(const UsdPrim &prim, UsdArnoldReader &reader, bool 
             "[usd] %s subdivision scheme not supported for mesh on path %s", subdiv.GetString().c_str(),
             mesh.GetPath().GetString().c_str());
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
 
     exportPrimvars(prim, node, time, &mesh_orientation);
     exportMaterialBinding(prim, node, reader);
@@ -148,7 +148,7 @@ void UsdArnoldReadCurves::read(const UsdPrim &prim, UsdArnoldReader &reader, boo
     // Widths
     exportArray<float, float>(curves.GetWidthsAttr(), node, "radius", time);
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
 
@@ -170,7 +170,7 @@ void UsdArnoldReadPoints::read(const UsdPrim &prim, UsdArnoldReader &reader, boo
     // Points radius
     exportArray<float, float>(points.GetWidthsAttr(), node, "radius", time);
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
 
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
@@ -200,7 +200,7 @@ void UsdArnoldReadCube::read(const UsdPrim &prim, UsdArnoldReader &reader, bool 
         AiNodeSetVec(node, "max", size_value / 2.f, size_value / 2.f, size_value / 2.f);
     }
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
     readArnoldParameters(prim, reader, node, time);
@@ -219,7 +219,7 @@ void UsdArnoldReadSphere::read(const UsdPrim &prim, UsdArnoldReader &reader, boo
     if (sphere.GetRadiusAttr().Get(&radius_attr))
         AiNodeSetFlt(node, "radius", (float)radius_attr.Get<double>());
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
     readArnoldParameters(prim, reader, node, time);
@@ -272,7 +272,7 @@ void UsdArnoldReadCylinder::read(const UsdPrim &prim, UsdArnoldReader &reader, b
     const TimeSettings &time = reader.getTimeSettings();
     float frame = time.frame;
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
     readArnoldParameters(prim, reader, node, time);
@@ -287,7 +287,7 @@ void UsdArnoldReadCone::read(const UsdPrim &prim, UsdArnoldReader &reader, bool 
     exportCylindricalShape<UsdGeomCone>(prim, node, "bottom_radius");
 
     const TimeSettings &time = reader.getTimeSettings();
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
     readArnoldParameters(prim, reader, node, time);
@@ -304,7 +304,7 @@ void UsdArnoldReadCapsule::read(const UsdPrim &prim, UsdArnoldReader &reader, bo
 
     exportCylindricalShape<UsdGeomCapsule>(prim, node, "radius");
     const TimeSettings &time = reader.getTimeSettings();
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     exportPrimvars(prim, node, time);
     exportMaterialBinding(prim, node, reader);
     readArnoldParameters(prim, reader, node, time);

--- a/translator/reader/read_light.cpp
+++ b/translator/reader/read_light.cpp
@@ -79,7 +79,7 @@ void UsdArnoldReadDistantLight::read(const UsdPrim &prim, UsdArnoldReader &reade
     const TimeSettings &time = reader.getTimeSettings();
 
     exportLightCommon(light, node);
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     readArnoldParameters(prim, reader, node, time);
 }
 
@@ -131,7 +131,7 @@ void UsdArnoldReadDomeLight::read(const UsdPrim &prim, UsdArnoldReader &reader, 
     }
     AiNodeSetFlt(node, "camera", 0.f);
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     readArnoldParameters(prim, reader, node, time);
 }
 
@@ -158,7 +158,7 @@ void UsdArnoldReadDiskLight::read(const UsdPrim &prim, UsdArnoldReader &reader, 
         AiNodeSetBool(node, "normalize", normalize_attr.Get<bool>());
     }
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     readArnoldParameters(prim, reader, node, time);
 }
 
@@ -188,7 +188,7 @@ void UsdArnoldReadSphereLight::read(const UsdPrim &prim, UsdArnoldReader &reader
 
     const TimeSettings &time = reader.getTimeSettings();
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     readArnoldParameters(prim, reader, node, time);
 }
 
@@ -249,7 +249,7 @@ void UsdArnoldReadRectLight::read(const UsdPrim &prim, UsdArnoldReader &reader, 
         AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
     }
 
-    exportMatrix(prim, node, time);
+    exportMatrix(prim, node, time, reader);
     readArnoldParameters(prim, reader, node, time);
 }
 
@@ -302,7 +302,7 @@ void UsdArnoldReadGeometryLight::read(const UsdPrim &prim, UsdArnoldReader &read
             AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
         }
 
-        exportMatrix(prim, node, time);
+        exportMatrix(prim, node, time, reader);
         readArnoldParameters(prim, reader, node, time);
     }
 }

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <vector>
 #include "utils.h"
+#include <pxr/usd/usdGeom/xformCache.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -31,7 +32,12 @@ class UsdArnoldReaderRegistry;
 
 class UsdArnoldReader {
 public:
-    UsdArnoldReader() : _procParent(NULL), _universe(NULL), _registry(NULL), _debug(false), _threadCount(1) {}
+    UsdArnoldReader() : _procParent(NULL), 
+                        _universe(NULL), 
+                        _registry(NULL), 
+                        _debug(false), 
+                        _threadCount(1),
+                        _xformCache(NULL) {}
     ~UsdArnoldReader();
 
     void read(const std::string &filename, AtArray *overrides,
@@ -61,6 +67,7 @@ public:
     const AtNode *getProceduralParent() const { return _procParent; }
     bool getDebug() const { return _debug; }
     const TimeSettings &getTimeSettings() const { return _time; }
+    UsdGeomXformCache *getXformCache() {return _xformCache;}
 
     static unsigned int RenderThread(void *data);
 
@@ -75,4 +82,5 @@ private:
     UsdStageRefPtr _stage; // current stage being read. Will be cleared once
                            // finished reading
     std::vector<AtNode *> _nodes;
+    UsdGeomXformCache *_xformCache;
 };

--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -33,11 +33,23 @@
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-static inline void getMatrix(const UsdGeomXformable &xformable, AtMatrix &matrix, float frame)
+static inline void getMatrix(const UsdPrim &prim, AtMatrix &matrix, float frame, UsdArnoldReader &reader)
 {
     GfMatrix4d xform;
     bool dummyBool = false;
-    xformable.GetLocalTransformation(&xform, &dummyBool, frame);
+    UsdGeomXformCache *xformCache = reader.getXformCache();
+
+    // The reader should have a xform cache, if not let's create one 
+    // just for this purpose (not optimized)
+    bool createXformCache = (xformCache == NULL);
+    if (createXformCache)
+        xformCache = new UsdGeomXformCache(frame);
+    
+    xform = xformCache->GetLocalToWorldTransform(prim);
+    
+    if (createXformCache)
+        delete xformCache;
+
     const double *array = xform.GetArray();
     for (unsigned int i = 0; i < 4; ++i)
         for (unsigned int j = 0; j < 4; ++j)
@@ -45,7 +57,7 @@ static inline void getMatrix(const UsdGeomXformable &xformable, AtMatrix &matrix
 }
 /** Export Xformable transform as an arnold shape "matrix"
  */
-void exportMatrix(const UsdPrim &prim, AtNode *node, const TimeSettings &time)
+void exportMatrix(const UsdPrim &prim, AtNode *node, const TimeSettings &time, UsdArnoldReader &reader)
 {
     UsdGeomXformable xformable(prim);
     bool animated = xformable.TransformMightBeTimeVarying();
@@ -61,14 +73,14 @@ void exportMatrix(const UsdPrim &prim, AtNode *node, const TimeSettings &time)
         float timeStep = float(interval.GetMax() - interval.GetMin()) / int(numKeys - 1);
         float timeVal = interval.GetMin();
         for (size_t i = 0; i < numKeys; i++, timeVal += timeStep) {
-            getMatrix(xformable, matrix, timeVal);
+            getMatrix(prim, matrix, timeVal, reader);
             AiArraySetMtx(array, i, matrix);
         }
         AiNodeSetArray(node, "matrix", array);
         AiNodeSetFlt(node, "motion_start", time.motion_start);
         AiNodeSetFlt(node, "motion_end", time.motion_end);
     } else {
-        getMatrix(xformable, matrix, time.frame);
+        getMatrix(prim, matrix, time.frame, reader);
         // set the attribute
         AiNodeSetMatrix(node, "matrix", matrix);
     }

--- a/translator/reader/utils.h
+++ b/translator/reader/utils.h
@@ -70,9 +70,8 @@ void MeshOrientation::orient_face_index_attribute(T& attr)
 }
 
 /** Export Xformable transform as an arnold shape "matrix"
- *  TODO:  motion blur
  */
-void exportMatrix(const UsdPrim& prim, AtNode* node, const TimeSettings& time);
+void exportMatrix(const UsdPrim& prim, AtNode* node, const TimeSettings& time, UsdArnoldReader &reader);
 
 /** Convert a USD array attribute (type U), to an Arnold array (type A).
  *  When both types are identical, we can simply their pointer to create the


### PR DESCRIPTION
Use a global UsdGeomXformCache to compute the world matrices of xformable primitives, in order to get their world matrix, instead of the local one as of today

Fixes #51 