### PR TITLE
Adding an NDR plugin for arnold shaders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Contributions are welcome! Please make sure to read the [contribution guidelines
 Please follow the [building instructions](docs/building.md). To use the components, provided you installed in `<arnold-usd_dir>`, set the following environment variables:
 
 - Add `<arnold-usd_dir>/lib/python` to `PYTHONPATH` for the Python schema bindings.
-- Add `<arnold-usd_dir>/plugin` to `PXR_PLUGINPATH_NAME` for the Hydra render delegate.
+- Add `<arnold-usd_dir>/plugin` to `PXR_PLUGINPATH_NAME` for the Hydra render delegate and the Node Registry plugin.
 - Add `<arnold-usd_dir>/lib/usd` to `PXR_PLUGINPATH_NAME` for the USD schemas.
 - Add `<arnold-usd_dir>/lib` to `LD_LIBRARY_PATH` on Linux, `PATH` on Windows and `DYLD_LIBRARY_PATH` on Mac.
 
@@ -30,6 +30,7 @@ The render delegate currently supports the following features:
         - Support for the displayColor primvar
         - Subdivision settings
     - Volume
+    - Points
 - SPrim Support
     - Materials
         - Arnold shaders are supported, the `info:id` attribute is used to determine the shader type
@@ -70,9 +71,23 @@ The render delegate currently supports the following features:
 - Only converging renders are supported (ie. it’s not possible to block the viewport until the render finishes)
 - No HdExtComputation and UsdSkel computation via the render delegate
 - No of physical camera parameters
-- No points
 - No coordsys support
 
+## Node Registry Plugin
+
+The Node Registry plugin supports the current features:
+- Registering Sdr nodes for every built-in shader and custom shader
+    - Setting up the asset URI either to `<built-in>` or to the path of the shader library providing the shader.
+    - Creating all parameters.
+
+**Limitations**
+- No nodes registered for
+    - Shapes
+    - Lights
+    - Filters
+    - Drivers
+- No node is registered for the options node
+- Metadata is not converted for any node
 
 ## Arnold USD Procedural
 

--- a/SConstruct
+++ b/SConstruct
@@ -77,6 +77,7 @@ vars.AddVariables(
     PathVariable('PREFIX', 'Directory to install under', '.', PathVariable.PathIsDirCreate),
     PathVariable('PREFIX_PROCEDURAL', 'Directory to install the procedural under.', os.path.join('$PREFIX', 'procedural'), PathVariable.PathIsDirCreate),
     PathVariable('PREFIX_RENDER_DELEGATE', 'Directory to install the procedural under.', os.path.join('$PREFIX', 'plugin'), PathVariable.PathIsDirCreate),
+    PathVariable('PREFIX_NDR_PLUGIN', 'Directory to install the ndr plugin under.', os.path.join('$PREFIX', 'plugin'), PathVariable.PathIsDirCreate),
     PathVariable('PREFIX_HEADERS', 'Directory to install the headers under.', os.path.join('$PREFIX', 'include'), PathVariable.PathIsDirCreate),
     PathVariable('PREFIX_LIB', 'Directory to install the libraries under.', os.path.join('$PREFIX', 'lib'), PathVariable.PathIsDirCreate),
     PathVariable('PREFIX_BIN', 'Directory to install the binaries under.', os.path.join('$PREFIX', 'bin'), PathVariable.PathIsDirCreate),
@@ -85,6 +86,7 @@ vars.AddVariables(
     BoolVariable('SHOW_PLOTS', 'Display timing plots for the testsuite. gnuplot has to be found in the environment path.', False),
     BoolVariable('BUILD_SCHEMAS', 'Wether or not to build the schemas and their wrapper.', True),
     BoolVariable('BUILD_RENDER_DELEGATE', 'Wether or not to build the hydra render delegate.', True),
+    BoolVariable('BUILD_NDR_PLUGIN', 'Wether or not to build the node registry plugin.', True),
     BoolVariable('BUILD_USD_WRITER', 'Wether or not to build the arnold to usd writer tool.', True),
     BoolVariable('BUILD_PROCEDURAL', 'Wether or not to build the arnold procedural', True),
     BoolVariable('BUILD_TESTSUITE', 'Wether or not to build the testsuite', True),
@@ -108,6 +110,7 @@ def get_optional_env_var(env_name):
 
 BUILD_SCHEMAS         = env['BUILD_SCHEMAS']
 BUILD_RENDER_DELEGATE = env['BUILD_RENDER_DELEGATE']
+BUILD_NDR_PLUGIN      = env['BUILD_NDR_PLUGIN']
 BUILD_USD_WRITER      = env['BUILD_USD_WRITER']
 BUILD_PROCEDURAL      = env['BUILD_PROCEDURAL']
 BUILD_TESTSUITE       = env['BUILD_TESTSUITE']
@@ -144,6 +147,7 @@ ARNOLD_BINARIES     = env.subst(env['ARNOLD_BINARIES'])
 PREFIX                 = env.subst(env['PREFIX'])
 PREFIX_PROCEDURAL      = env.subst(env['PREFIX_PROCEDURAL'])
 PREFIX_RENDER_DELEGATE = env.subst(env['PREFIX_RENDER_DELEGATE'])
+PREFIX_NDR_PLUGIN      = env.subst(env['PREFIX_NDR_PLUGIN'])
 PREFIX_HEADERS         = env.subst(env['PREFIX_HEADERS'])
 PREFIX_LIB             = env.subst(env['PREFIX_LIB'])
 PREFIX_BIN             = env.subst(env['PREFIX_BIN'])
@@ -314,6 +318,10 @@ renderdelegate_script = os.path.join('render_delegate', 'SConscript')
 renderdelegate_build = os.path.join(BUILD_BASE_DIR, 'render_delegate')
 renderdelegate_plug_info = os.path.join('render_delegate', 'plugInfo.json')
 
+ndrplugin_script = os.path.join('ndr', 'SConscript')
+ndrplugin_build = os.path.join(BUILD_BASE_DIR, 'ndr')
+ndrplugin_plug_info = os.path.join('ndr', 'plugInfo.json')
+
 testsuite_build = os.path.join(BUILD_BASE_DIR, 'testsuite')
 
 # Define targets
@@ -328,6 +336,11 @@ if BUILD_PROCEDURAL or BUILD_USD_WRITER:
 else:
     TRANSLATOR = None
 
+if BUILD_PROCEDURAL or BUILD_RENDER_DELEGATE or BUILD_NDR_PLUGIN:
+    ARNOLDUSD_HEADER = env.Command(os.path.join(BUILD_BASE_DIR, 'arnold_usd.h'), 'arnold_usd.h.in', configure.configure_header_file) 
+else:
+    ARNOLDUSD_HEADER = None
+
 # Define targets
 # Target for the USD procedural
 if BUILD_PROCEDURAL:
@@ -335,11 +348,10 @@ if BUILD_PROCEDURAL:
         variant_dir = procedural_build,
         duplicate = 0, exports = 'env')
     SConscriptChdir(0)
-
     Depends(PROCEDURAL, TRANSLATOR[0])
+    Depends(PROCEDURAL, ARNOLDUSD_HEADER)
 else:
     PROCEDURAL = None
-
 
 if BUILD_SCHEMAS:
     SCHEMAS = env.SConscript(schemas_script,
@@ -357,13 +369,18 @@ else:
     ARNOLD_TO_USD = None
 
 if BUILD_RENDER_DELEGATE:
-    ARNOLDUSD_HEADER = env.Command(os.path.join(BUILD_BASE_DIR, 'arnold_usd.h'), 'arnold_usd.h.in', configure.configure_header_file) 
     RENDERDELEGATE = env.SConscript(renderdelegate_script, variant_dir = renderdelegate_build, duplicate = 0, exports = 'env')
     SConscriptChdir(0)
     Depends(RENDERDELEGATE, ARNOLDUSD_HEADER)
 else:
-    ARNOLDUSD_HEADER = None
     RENDERDELEGATE = None
+
+if BUILD_NDR_PLUGIN:
+    NDRPLUGIN = env.SConscript(ndrplugin_script, variant_dir = ndrplugin_build, duplicate = 0, exports = 'env')
+    SConscriptChdir(0)
+    Depends(NDRPLUGIN, ARNOLDUSD_HEADER)
+else:
+    NDRPLUGIN = None
 
 #Depends(PROCEDURAL, SCHEMAS)
 
@@ -380,7 +397,8 @@ else:
 # extension.
 
 plugInfos = [
-    renderdelegate_plug_info
+    renderdelegate_plug_info,
+    ndrplugin_plug_info,
 ]
 
 for plugInfo in plugInfos:
@@ -431,8 +449,18 @@ if RENDERDELEGATE:
     INSTALL_RENDERDELEGATE += env.Install(os.path.join(PREFIX_RENDER_DELEGATE, 'hdArnold', 'resources'), [os.path.join('render_delegate', 'plugInfo.json')])
     INSTALL_RENDERDELEGATE += env.Install(PREFIX_RENDER_DELEGATE, ['plugInfo.json'])
     INSTALL_RENDERDELEGATE += env.Install(os.path.join(PREFIX_HEADERS, 'render_delegate'), env.Glob(os.path.join('render_delegate', '*.h')))
-    INSTALL_RENDERDELEGATE += env.Install(PREFIX_HEADERS, ARNOLDUSD_HEADER)
     env.Alias('delegate-install', INSTALL_RENDERDELEGATE)
+
+if NDRPLUGIN:
+    INSTALL_NDRPLUGIN = env.Install(PREFIX_NDR_PLUGIN, NDRPLUGIN)
+    INSTALL_NDRPLUGIN += env.Install(os.path.join(PREFIX_NDR_PLUGIN, 'ndrArnold', 'resources'), [os.path.join('ndr', 'plugInfo.json')])
+    INSTALL_NDRPLUGIN += env.Install(PREFIX_NDR_PLUGIN, ['plugInfo.json'])
+    INSTALL_NDRPLUGIN += env.Install(os.path.join(PREFIX_HEADERS, 'ndr'), env.Glob(os.path.join('ndr', '*.h')))
+    env.Alias('ndrplugin-install', INSTALL_NDRPLUGIN)
+
+if ARNOLDUSD_HEADER:
+    INSTALL_ARNOLDUSDHEADER = env.Install(PREFIX_HEADERS, ARNOLDUSD_HEADER)
+    env.Alias('arnoldusdheader-install', INSTALL_ARNOLDUSDHEADER)
 
 '''
 # below are the other dlls we need

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -113,7 +113,7 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 # List input directories as strings and separate them by space.
-INPUT                  = "README.md" "LICENSE.md" "CONTRIBUTING.md" "render_delegate" "docs"
+INPUT                  = "README.md" "LICENSE.md" "CONTRIBUTING.md" "render_delegate" "ndr" "docs"
 USE_MDFILE_AS_MAINPAGE = "README.md"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cpp \

--- a/docs/building.md
+++ b/docs/building.md
@@ -33,6 +33,7 @@ are the following.
 - COMPILER: Compiler to use. `gcc` or `clang` (default is `gcc`) on Linux and Mac, and `msvc` on Windows.
 - BUILD_SCHEMAS: Wether or not to build the schemas and their wrapper.
 - BUILD_RENDER_DELEGATE: Wether or not to build the hydra render delegate.
+- BUILD_NDR_PLUGIN: Wether or not to build the node registry plugin.
 - BUILD_USD_WRITER: Wether or not to build the arnold to usd writer tool.
 - BUILD_PROCEDURAL: Wether or not to build the arnold procedural.
 - BUILD_TESTSUITE: Wether or not to build the testsuite.
@@ -64,13 +65,15 @@ are the following.
 - TBB_LIB: Where to find TBB libraries.
 
 ## Configuring Installation
-- PREFIX: Directory to install under. True by default.
-- PREFIX_PROCEDURAL: Directory to install the procedural under. True by default.
-- PREFIX_RENDER_DELEGATE: Directory to install the procedural under. True by default.
-- PREFIX_HEADERS: Directory to install the headers under. True by default.
-- PREFIX_LIB: Directory to install the libraries under. True by default.
-- PREFIX_BIN: Directory to install the binaries under. True by default.
-- PREFIX_DOCS: Directory to install the documentation under. True by default.
+- PREFIX: Directory to install under.
+- PREFIX_PROCEDURAL: Directory to install the procedural under. Defaults to `prefix/procedural`.
+- PREFIX_RENDER_DELEGATE: Directory to install the render delegate under. Defaults to `prefix/plugin`.
+- PREFIX_NDR_PLUGIN: Directory to install the ndr plugin under. Defaults to `prefix/plugin`.
+- PREFIX_HEADERS: Directory to install the headers under. Defaults to `prefix/include`.
+- PREFIX_LIB: Directory to install the libraries under. Defaults to `prefix/lib`.
+- PREFIX_BIN: Directory to install the binaries under. Defaults to `prefix/bin`.
+- PREFIX_DOCS: Directory to install the documentation under. Defaults to `prefix/docs`.
+- PREFIX_THIRD_PARTY: Directory to install the third party modules under. Defaults to `prefix/third_party`.
 
 ## Example configuration
 

--- a/ndr/SConscript
+++ b/ndr/SConscript
@@ -1,0 +1,63 @@
+# Copyright 2019 Autodesk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from utils import system, build_tools
+
+Import('env')
+local_env = env.Clone()
+
+from utils import configure
+
+src_dir = os.path.join(env['ROOT_DIR'], 'ndr')
+source_files = [
+    'discovery.cpp',
+    'parser.cpp',
+    'utils.cpp',
+]
+
+if system.os != 'windows':
+    local_env.Append(CXXFLAGS = Split('-fPIC'))
+
+local_env.Append(CPPDEFINES=['NDRARNOLD_EXPORTS'])
+local_env.Append(CPPPATH = [os.path.join(env['ROOT_DIR'], env['BUILD_BASE_DIR'], 'ndr')])
+local_env.Append(LIBS = ['ai'])
+
+if local_env['USD_BUILD_MODE'] == 'monolithic':
+    usd_deps = [
+        local_env['USD_MONOLITHIC_LIBRARY'],
+        'tbb',
+    ]
+else:
+    usd_libs = [
+        'arch',
+        'tf',
+        'gf',
+        'vt',
+        'ndr',
+        'sdr',
+        'sdf',
+        'usd',
+    ]
+
+    usd_deps = ['tbb']
+    usd_libs, usd_sources = build_tools.link_usd_libraries(local_env, usd_libs)
+    usd_deps = usd_deps + usd_libs
+    source_files = source_files + usd_sources
+
+local_env.Append(LIBS = usd_deps)
+if local_env['USD_HAS_PYTHON_SUPPORT']:
+    local_env.Append(LIBS = [local_env['PYTHON_LIB_NAME'], local_env['BOOST_LIB_NAME'] % 'python'])
+
+NDRPLUGIN = local_env.SharedLibrary('ndrArnold', source_files, SHLIBPREFIX='')
+Return('NDRPLUGIN')

--- a/ndr/api.h
+++ b/ndr/api.h
@@ -1,0 +1,48 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "pxr/base/arch/export.h"
+
+#if defined(PXR_STATIC)
+#define NDRARNOLD_API
+#define NDRARNOLD_API_TEMPLATE_CLASS(...)
+#define NDRARNOLD_API_TEMPLATE_STRUCT(...)
+#define NDRARNOLD_LOCAL
+#else
+#if defined(NDRARNOLD_EXPORTS)
+#define NDRARNOLD_API ARCH_EXPORT
+#define NDRARNOLD_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#define NDRARNOLD_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#else
+#define NDRARNOLD_API ARCH_IMPORT
+#define NDRARNOLD_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#define NDRARNOLD_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#endif
+#define NDRARNOLD_LOCAL ARCH_HIDDEN
+#endif

--- a/ndr/discovery.cpp
+++ b/ndr/discovery.cpp
@@ -1,0 +1,92 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "discovery.h"
+
+#include <pxr/base/arch/fileSystem.h>
+
+#include <pxr/base/tf/envSetting.h>
+#include <pxr/base/tf/getenv.h>
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/base/tf/stringUtils.h>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/primRange.h>
+
+#include "utils.h"
+
+#include <ai.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+        (shader)
+        (arnold)
+        (filename)
+);
+// clang-format on
+
+NDR_REGISTER_DISCOVERY_PLUGIN(NdrArnoldDiscoveryPlugin);
+
+NdrArnoldDiscoveryPlugin::NdrArnoldDiscoveryPlugin() {}
+
+NdrArnoldDiscoveryPlugin::~NdrArnoldDiscoveryPlugin() {}
+
+NdrNodeDiscoveryResultVec NdrArnoldDiscoveryPlugin::DiscoverNodes(const Context& context)
+{
+    NdrNodeDiscoveryResultVec ret;
+    auto shaderDefs = NdrArnoldGetShaderDefs();
+    for (const UsdPrim& prim : shaderDefs->Traverse()) {
+        const auto shaderName = prim.GetName();
+        TfToken filename("<built-in>");
+        prim.GetMetadata(_tokens->filename, &filename);
+        ret.emplace_back(
+            NdrIdentifier(TfStringPrintf("arnold:%s", shaderName.GetText())), // identifier
+            NdrVersion(AI_VERSION_ARCH_NUM, AI_VERSION_MAJOR_NUM),            // version
+            shaderName,                                                       // name
+            _tokens->shader,                                                  // family
+            _tokens->arnold,                                                  // discoveryType
+            _tokens->arnold,                                                  // sourceType
+            filename,                                                         // uri
+            filename                                                          // resolvedUri
+        );
+    }
+    return ret;
+}
+
+const NdrStringVec& NdrArnoldDiscoveryPlugin::GetSearchURIs() const
+{
+    static const auto result = []() -> NdrStringVec {
+        NdrStringVec ret = TfStringSplit(TfGetenv("ARNOLD_PLUGIN_PATH"), ARCH_PATH_LIST_SEP);
+        ret.push_back("<built-in>");
+        return ret;
+    }();
+    return result;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/ndr/discovery.h
+++ b/ndr/discovery.h
@@ -1,0 +1,70 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/// @file discovery.h
+///
+/// Ndr Discovery plugin for arnold shader nodes.
+#pragma once
+
+#include <pxr/pxr.h>
+#include "api.h"
+
+#include <pxr/usd/ndr/discoveryPlugin.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Ndr Discovery for arnold shader nodes.
+class NdrArnoldDiscoveryPlugin : public NdrDiscoveryPlugin {
+public:
+    using Context = NdrDiscoveryPluginContext;
+
+    /// Creates an instance of NdrArnoldDiscoveryPlugin.
+    NDRARNOLD_API
+    NdrArnoldDiscoveryPlugin();
+
+    /// Destructor for NdrArnoldNodeDiscoveryPlugin.
+    NDRARNOLD_API
+    ~NdrArnoldDiscoveryPlugin() override;
+
+    /// Discovers the arnold shaders.
+    ///
+    /// This includes all the built-in shaders, where the uri is set to <built-in>
+    /// and all the arnold shaders found in ARNOLD_PLUGIN_PATH, where the uri
+    /// is set to the library/osl file providing the shader.
+    ///
+    /// @param context NdrDiscvoeryPluginContext of the discovery process.
+    /// @return List of the discovered arnold nodes.
+    NDRARNOLD_API
+    NdrNodeDiscoveryResultVec DiscoverNodes(const Context& context) override;
+
+    /// Returns the URIs used to search for arnold shader nodes.
+    ///
+    /// @return All the paths from ARNOLD_PLUGIN_PATH.
+    const NdrStringVec& GetSearchURIs() const override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/ndr/ndrarnold.h
+++ b/ndr/ndrarnold.h
@@ -1,0 +1,21 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "../arnold_usd.h"
+
+#if USED_USD_VERSION_GREATER_EQ(20, 2)
+/// There is an additional parameter for the Ndr Node constructor.
+#define USD_HAS_NEW_SDR_NODE_CONSTRUCTOR
+#endif

--- a/ndr/parser.cpp
+++ b/ndr/parser.cpp
@@ -1,0 +1,158 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+ * TODO:
+ *  - Properly parse type and array size.
+ *  - Generate output types based on shader output type.
+ * */
+#include "parser.h"
+
+#include <pxr/base/tf/staticTokens.h>
+
+#include <pxr/usd/ndr/node.h>
+
+#include <pxr/usd/sdr/shaderNode.h>
+#include <pxr/usd/sdr/shaderProperty.h>
+
+#include <pxr/usd/sdf/propertySpec.h>
+
+#include <pxr/usd/usd/attribute.h>
+#include <pxr/usd/usd/property.h>
+
+#include "ndrarnold.h"
+#include "utils.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+NDR_REGISTER_PARSER_PLUGIN(NdrArnoldParserPlugin);
+
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (arnold)
+    ((arnoldPrefix, "arnold:"))
+    (binary));
+// clang-format on
+
+namespace {
+
+// We have to subclass SdrShaderProperty, because it tries to read the SdfType
+// from a token, and it doesn't support all the parameter types arnold does,
+// like the 4 component color. Besides this, we also guarantee that the default
+// value will match the SdfType, as the SdfType comes from the default value.
+class ArnoldShaderProperty : public SdrShaderProperty {
+public:
+    ArnoldShaderProperty(
+        const TfToken& name, const SdfValueTypeName& typeName, const VtValue& defaultValue, bool isOutput,
+        size_t arraySize, const NdrTokenMap& metadata, const NdrTokenMap& hints, const NdrOptionVec& options)
+        : SdrShaderProperty(name, typeName.GetAsToken(), defaultValue, isOutput, arraySize, metadata, hints, options),
+          _typeName(typeName)
+    {
+    }
+
+    const SdfTypeIndicator GetTypeAsSdfType() const override { return {_typeName, _typeName.GetAsToken()}; }
+
+private:
+    SdfValueTypeName _typeName;
+};
+
+} // namespace
+
+NdrArnoldParserPlugin::NdrArnoldParserPlugin() {}
+
+NdrArnoldParserPlugin::~NdrArnoldParserPlugin() {}
+
+NdrNodeUniquePtr NdrArnoldParserPlugin::Parse(const NdrNodeDiscoveryResult& discoveryResult)
+{
+    auto shaderDefs = NdrArnoldGetShaderDefs();
+    UsdPrim prim;
+    // All shader names should be prefixed with `arnold:` but we double-check,
+    // similarly to the render delegate, as older versions of Hydra did not validate
+    // the node ids against the shader registry.
+    if (TfStringStartsWith(discoveryResult.identifier.GetText(), _tokens->arnoldPrefix)) {
+        prim = shaderDefs->GetPrimAtPath(
+            SdfPath(TfStringPrintf("/%s", discoveryResult.identifier.GetText() + _tokens->arnoldPrefix.size())));
+    } else {
+        prim = shaderDefs->GetPrimAtPath(SdfPath(TfStringPrintf("/%s", discoveryResult.identifier.GetText())));
+    }
+    if (!prim) {
+        return nullptr;
+    }
+    NdrPropertyUniquePtrVec properties;
+    const auto props = prim.GetAuthoredProperties();
+    properties.reserve(props.size());
+    for (const auto& property : props) {
+        const auto& propertyName = property.GetName();
+        // In case `info:id` is set on the nodes.
+        if (TfStringContains(propertyName.GetString(), ":")) {
+            continue;
+        }
+        const auto propertyStack = property.GetPropertyStack();
+        if (propertyStack.empty()) {
+            continue;
+        }
+        const auto attr = prim.GetAttribute(propertyName);
+        VtValue v;
+        attr.Get(&v);
+        // The utility function takes care of the conversion and figuring out
+        // parameter types, so we just have to blindly pass all required
+        // parametrs.
+        // TODO(pal): Read metadata and hints.
+        properties.emplace_back(SdrShaderPropertyUniquePtr(new ArnoldShaderProperty(
+            propertyName,                        // name
+            propertyStack.back()->GetTypeName(), // type
+            v,                                   // defaultValue
+            false,                               // isOutput
+            0,                                   // arraySize
+            NdrTokenMap(),                       // metadata
+            NdrTokenMap(),                       // hints
+            NdrOptionVec()                       // options
+            )));
+    }
+    return NdrNodeUniquePtr(new SdrShaderNode(
+        discoveryResult.identifier,    // identifier
+        discoveryResult.version,       // version
+        discoveryResult.name,          // name
+        discoveryResult.family,        // family
+        discoveryResult.discoveryType, // context
+        discoveryResult.sourceType,    // sourceType
+        discoveryResult.uri,           // uri
+#ifdef USD_HAS_NEW_SDR_NODE_CONSTRUCTOR
+        discoveryResult.uri,           // resolvedUri
+#endif
+        std::move(properties)));
+}
+
+const NdrTokenVec& NdrArnoldParserPlugin::GetDiscoveryTypes() const
+{
+    static const NdrTokenVec ret = {_tokens->arnold};
+    return ret;
+}
+
+const TfToken& NdrArnoldParserPlugin::GetSourceType() const { return _tokens->arnold; }
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/ndr/parser.h
+++ b/ndr/parser.h
@@ -1,0 +1,71 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/// @file parser.h
+///
+/// Ndr Parser plugin for arnold shader nodes.
+#pragma once
+
+#include <pxr/pxr.h>
+#include "api.h"
+
+#include <pxr/usd/ndr/parserPlugin.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Ndr Parser for arnold shader nodes.
+class NdrArnoldParserPlugin : public NdrParserPlugin {
+public:
+    /// Creates an instance of NdrArnoldParserPlugin.
+    NDRARNOLD_API
+    NdrArnoldParserPlugin();
+
+    /// Destructor for NdrArnoldParserPlugin.
+    NDRARNOLD_API
+    ~NdrArnoldParserPlugin() override;
+
+    /// Parses a node discovery result to a NdrNode.
+    ///
+    /// @param discoveryResult NdrNodeDiscoveryResult returned by the discovery plugin.
+    /// @return The parsed Ndr Node.
+    NDRARNOLD_API
+    NdrNodeUniquePtr Parse(const NdrNodeDiscoveryResult& discoveryResult) override;
+
+    /// Returns all the supported discovery types.
+    ///
+    /// @return Returns "arnold" as the only supported discovery type.
+    NDRARNOLD_API
+    const NdrTokenVec& GetDiscoveryTypes() const override;
+
+    /// Returns all the supported source types.
+    ///
+    /// @return Returns "arnold" as the only supported source type.
+    NDRARNOLD_API 
+    const TfToken& GetSourceType() const override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/ndr/plugInfo.json.in
+++ b/ndr/plugInfo.json.in
@@ -1,0 +1,34 @@
+{
+    "Plugins": [
+        {
+            "Info": {
+                "SdfMetadata": {
+                    "filename": {
+                        "appliesTo": [
+                            "prims"
+                        ],
+                        "default": "<built-in>",
+                        "displayGroup": "Arnold",
+                        "documentation": "Arnold plugin location for a node.",
+                        "type": "token"
+                    }
+                },
+                "Types": {
+                    "NdrArnoldParserPlugin" : {
+                        "bases": ["NdrParserPlugin"],
+                        "displayName": "Arnold Node Parser"
+                    },
+                    "NdrArnoldDiscoveryPlugin" : {
+                        "bases": ["NdrDiscoveryPlugin"],
+                        "displayName": "Arnold Node Discovery"
+                    }
+                }
+            },
+            "LibraryPath": "../ndrArnold${LIB_EXTENSION}",
+            "Name": "ndrArnold",
+            "ResourcePath": "resources",
+            "Root": "..",
+            "Type": "library"
+        }
+    ]
+}

--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -1,0 +1,375 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "utils.h"
+
+#include <pxr/base/tf/getenv.h>
+
+#include <pxr/base/gf/matrix4f.h>
+
+#include <pxr/usd/usd/attribute.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <ai.h>
+
+#include <unordered_map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+ (filename));
+// clang-format on
+
+namespace {
+
+// TODO(pal): All this should be moved to a schema API.
+
+// The conversion classes store both the sdf type and a simple function pointer
+// that can do the conversion.
+struct DefaultValueConversion {
+    const SdfValueTypeName& type;
+    using Convert = VtValue (*)(const AtParamValue&, const AtParamEntry*);
+    Convert f = nullptr;
+
+    template <typename F>
+    DefaultValueConversion(const SdfValueTypeName& _type, F&& _f) : type(_type), f(std::move(_f))
+    {
+    }
+
+    DefaultValueConversion() = delete;
+};
+
+struct ArrayConversion {
+    const SdfValueTypeName& type;
+    using Convert = VtValue (*)(const AtArray*);
+    Convert f = nullptr;
+
+    template <typename F>
+    ArrayConversion(const SdfValueTypeName& _type, F&& _f) : type(_type), f(std::move(_f))
+    {
+    }
+
+    ArrayConversion() = delete;
+};
+
+inline GfMatrix4d _ConvertMatrix(const AtMatrix& mat) { return GfMatrix4d(mat.data); }
+
+inline GfMatrix4d _ArrayGetMatrix(const AtArray* arr, uint32_t i, const char* file, uint32_t line)
+{
+    const auto mat = AiArrayGetMtxFunc(arr, i, file, line);
+    return GfMatrix4d(mat.data);
+}
+
+// Most of the USD types line up with the arnold types, so memcpying is enough
+// except for strings, so we need to be able to specialize for that case.
+template <typename LHT, typename RHT>
+inline void _Convert(LHT& l, const RHT& r)
+{
+    static_assert(sizeof(LHT) == sizeof(RHT), "Input data for convert must has the same size");
+    memcpy(&l, &r, sizeof(r));
+};
+
+template <>
+inline void _Convert<std::string, AtString>(std::string& l, const AtString& r)
+{
+    const auto* c = r.c_str();
+    if (c != nullptr) {
+        l = c;
+    }
+};
+
+template <typename T, typename R = T>
+inline VtValue _ExportArray(const AtArray* arr, R (*f)(const AtArray*, uint32_t, const char*, int32_t))
+{
+    // we already check the validity of the array before this call
+    const auto nelements = AiArrayGetNumElements(arr);
+    if (nelements == 0) {
+        return VtValue(VtArray<T>());
+    }
+    VtArray<T> out_arr(nelements);
+    for (auto i = 0u; i < nelements; ++i) {
+        _Convert(out_arr[i], f(arr, i, __FILE__, __LINE__));
+    }
+    return VtValue(out_arr);
+}
+
+// While the type integers are continouos and we could use a vector of pairs
+// using an unordered map makes sure we handle cases when a type is not implemented.
+// We also don't have to make sure the order of the declarations are matching
+// the values of the defines.
+// TODO(pal): We could create a function that converts a generic initializer list
+//  input to an ordered vector, and fills in any gaps. This would give us slightly
+//  faster lookups, but unordered maps with a cheap hash (it is a no cost in this case)
+//  are quite fast, even compared to a vector.
+const std::unordered_map<uint8_t, DefaultValueConversion>& _DefaultValueConversionMap()
+{
+    const static std::unordered_map<uint8_t, DefaultValueConversion> ret{
+        {AI_TYPE_BYTE,
+         {SdfValueTypeNames->UChar,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.BYTE()); }}},
+        {AI_TYPE_INT,
+         {SdfValueTypeNames->Int,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.INT()); }}},
+        {AI_TYPE_UINT,
+         {SdfValueTypeNames->UInt,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.UINT()); }}},
+        {AI_TYPE_BOOLEAN,
+         {SdfValueTypeNames->Bool,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.BOOL()); }}},
+        {AI_TYPE_FLOAT,
+         {SdfValueTypeNames->Float,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.FLT()); }}},
+        {AI_TYPE_RGB,
+         {SdfValueTypeNames->Color3f,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue {
+              const auto& v = pv.RGB();
+              return VtValue(GfVec3f(v.r, v.g, v.b));
+          }}},
+        {AI_TYPE_RGBA,
+         {SdfValueTypeNames->Color4f,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue {
+              const auto& v = pv.RGBA();
+              return VtValue(GfVec4f(v.r, v.g, v.b, v.a));
+          }}},
+        {AI_TYPE_VECTOR,
+         {SdfValueTypeNames->Vector3f,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue {
+              const auto& v = pv.VEC();
+              return VtValue(GfVec3f(v.x, v.y, v.z));
+          }}},
+        {AI_TYPE_VECTOR2,
+         {SdfValueTypeNames->Float2,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue {
+              const auto& v = pv.VEC2();
+              return VtValue(GfVec2f(v.x, v.y));
+          }}},
+        {AI_TYPE_STRING,
+         {SdfValueTypeNames->String,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.STR().c_str()); }}},
+        {AI_TYPE_POINTER, {SdfValueTypeNames->String, nullptr}},
+        {AI_TYPE_NODE, {SdfValueTypeNames->String, nullptr}},
+        {AI_TYPE_MATRIX,
+         {SdfValueTypeNames->Matrix4d,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(_ConvertMatrix(*pv.pMTX())); }}},
+        {AI_TYPE_ENUM,
+         {SdfValueTypeNames->String,
+          [](const AtParamValue& pv, const AtParamEntry* pe) -> VtValue {
+              if (pe == nullptr) {
+                  return VtValue("");
+              }
+              const auto enums = AiParamGetEnum(pe);
+              return VtValue(AiEnumGetString(enums, pv.INT()));
+          }}},
+        {AI_TYPE_CLOSURE, {SdfValueTypeNames->String, nullptr}},
+        {AI_TYPE_USHORT,
+         {SdfValueTypeNames->UInt,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.UINT()); }}},
+        {AI_TYPE_HALF,
+         {SdfValueTypeNames->Half,
+          [](const AtParamValue& pv, const AtParamEntry*) -> VtValue { return VtValue(pv.FLT()); }}},
+    };
+    return ret;
+}
+
+const std::unordered_map<uint8_t, ArrayConversion>& _ArrayTypeConversionMap()
+{
+    const static std::unordered_map<uint8_t, ArrayConversion> ret{
+        {AI_TYPE_BYTE,
+         {SdfValueTypeNames->UCharArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<uint8_t>(a, AiArrayGetByteFunc); }}},
+        {AI_TYPE_INT,
+         {SdfValueTypeNames->IntArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<int32_t>(a, AiArrayGetIntFunc); }}},
+        {AI_TYPE_UINT,
+         {SdfValueTypeNames->UIntArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<uint32_t>(a, AiArrayGetUIntFunc); }}},
+        {AI_TYPE_BOOLEAN,
+         {SdfValueTypeNames->BoolArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<bool>(a, AiArrayGetBoolFunc); }}},
+        {AI_TYPE_FLOAT,
+         {SdfValueTypeNames->FloatArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<float>(a, AiArrayGetFltFunc); }}},
+        {AI_TYPE_RGB,
+         {SdfValueTypeNames->Color3fArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<GfVec3f, AtRGB>(a, AiArrayGetRGBFunc); }}},
+        {AI_TYPE_RGBA,
+         {SdfValueTypeNames->Color4fArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<GfVec4f, AtRGBA>(a, AiArrayGetRGBAFunc); }}},
+        {AI_TYPE_VECTOR,
+         {SdfValueTypeNames->Vector3fArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<GfVec3f, AtVector>(a, AiArrayGetVecFunc); }}},
+        {AI_TYPE_VECTOR2,
+         {SdfValueTypeNames->Float2Array,
+          [](const AtArray* a) -> VtValue { return _ExportArray<GfVec2f, AtVector2>(a, AiArrayGetVec2Func); }}},
+        {AI_TYPE_STRING,
+         {SdfValueTypeNames->StringArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<std::string, AtString>(a, AiArrayGetStrFunc); }}},
+        {AI_TYPE_POINTER, {SdfValueTypeNames->StringArray, nullptr}},
+        {AI_TYPE_NODE, {SdfValueTypeNames->StringArray, nullptr}},
+        // Not supporting arrays of arrays. I don't think it's even possible
+        // in the arnold core.
+        {AI_TYPE_MATRIX,
+         {SdfValueTypeNames->Matrix4dArray,
+          [](const AtArray* a) -> VtValue {
+              const auto nelements = AiArrayGetNumElements(a);
+              VtArray<GfMatrix4d> arr(nelements);
+              for (auto i = 0u; i < nelements; ++i) {
+                  arr[i] = _ArrayGetMatrix(a, i, __FILE__, __LINE__);
+              }
+              return VtValue(arr);
+          }}}, // TODO: implement
+        {AI_TYPE_ENUM,
+         {SdfValueTypeNames->IntArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<int32_t>(a, AiArrayGetIntFunc); }}},
+        {AI_TYPE_CLOSURE, {SdfValueTypeNames->StringArray, nullptr}},
+        {AI_TYPE_USHORT,
+         {SdfValueTypeNames->UIntArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<uint32_t>(a, AiArrayGetUIntFunc); }}},
+        {AI_TYPE_HALF,
+         {SdfValueTypeNames->HalfArray,
+          [](const AtArray* a) -> VtValue { return _ExportArray<float>(a, AiArrayGetFltFunc); }}},
+    };
+    return ret;
+}
+
+// These two utility functions either return a nullptr if the type is not supported
+// or the pointer to the conversion struct.
+const DefaultValueConversion* _GetDefaultValueConversion(uint8_t type)
+{
+    const auto& dvcm = _DefaultValueConversionMap();
+    const auto it = dvcm.find(type);
+    if (it != dvcm.end()) {
+        return &it->second;
+    } else {
+        return nullptr;
+    }
+}
+
+const ArrayConversion* _GetArrayConversion(uint8_t type)
+{
+    const auto& atm = _ArrayTypeConversionMap();
+    const auto it = atm.find(type);
+    if (it != atm.end()) {
+        return &it->second;
+    } else {
+        return nullptr;
+    }
+}
+
+// TODO(pal): Read in metadata
+// TODO(pal): We could also setup a metadata to store the raw arnold type,
+//  for cases where multiple arnold types map to a single sdf type.
+void _ReadArnoldShaderDef(UsdPrim& prim, const AtNodeEntry* nodeEntry)
+{
+    const auto filename = AiNodeEntryGetFilename(nodeEntry);
+    prim.SetMetadata(_tokens->filename, VtValue(TfToken(filename == nullptr ? "<built-in>" : filename)));
+
+    auto paramIter = AiNodeEntryGetParamIterator(nodeEntry);
+
+    while (!AiParamIteratorFinished(paramIter)) {
+        const auto* pentry = AiParamIteratorGetNext(paramIter);
+        const auto paramType = AiParamGetType(pentry);
+
+        if (paramType == AI_TYPE_ARRAY) {
+            const auto* defaultValue = AiParamGetDefault(pentry);
+            if (defaultValue == nullptr) {
+                continue;
+            }
+            const auto* array = defaultValue->ARRAY();
+            if (array == nullptr) {
+                continue;
+            }
+            const auto elemType = AiArrayGetType(array);
+            const auto* conversion = _GetArrayConversion(elemType);
+            if (conversion == nullptr) {
+                continue;
+            }
+            auto attr = prim.CreateAttribute(TfToken(AiParamGetName(pentry).c_str()), conversion->type, false);
+
+            if (conversion->f != nullptr) {
+                attr.Set(conversion->f(array));
+            }
+        } else {
+            const auto* conversion = _GetDefaultValueConversion(paramType);
+            if (conversion == nullptr) {
+                continue;
+            }
+            auto attr = prim.CreateAttribute(TfToken(AiParamGetName(pentry).c_str()), conversion->type, false);
+
+            if (conversion->f != nullptr) {
+                attr.Set(conversion->f(*AiParamGetDefault(pentry), pentry));
+            }
+        }
+    }
+
+    AiParamIteratorDestroy(paramIter);
+}
+
+} // namespace
+
+UsdStageRefPtr NdrArnoldGetShaderDefs()
+{
+    // This is guaranteed to be thread safe by the C++11 standard.
+    // It's also using a pretty fast lock guard, so checking the value
+    // is cheap. We also don't want to initiate global variables, as those
+    // could cause thread locks withing USD when initalizing libraries in
+    // an unusual order.
+    static auto ret = []() -> UsdStageRefPtr {
+        auto stage = UsdStage::CreateInMemory("__ndrArnoldShaderDefs.usda");
+
+        // We expect the existing arnold universe to load the plugins.
+        const auto hasActiveUniverse = AiUniverseIsActive();
+        if (!hasActiveUniverse) {
+            AiBegin(AI_SESSION_BATCH);
+            AiMsgSetConsoleFlags(AI_LOG_NONE);
+            auto arnoldPluginPath = TfGetenv("ARNOLD_PLUGIN_PATH", "");
+            if (!arnoldPluginPath.empty()) {
+                AiLoadPlugins(arnoldPluginPath.c_str());
+            }
+        }
+
+        auto* nodeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHADER);
+
+        while (!AiNodeEntryIteratorFinished(nodeIter)) {
+            auto* nodeEntry = AiNodeEntryIteratorGetNext(nodeIter);
+            auto prim = stage->DefinePrim(SdfPath(TfStringPrintf("/%s", AiNodeEntryGetName(nodeEntry))));
+            _ReadArnoldShaderDef(prim, nodeEntry);
+        }
+
+        AiNodeEntryIteratorDestroy(nodeIter);
+
+        if (!hasActiveUniverse) {
+            AiEnd();
+        }
+
+        return stage;
+    }();
+    return ret;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/ndr/utils.h
+++ b/ndr/utils.h
@@ -1,0 +1,56 @@
+// Copyright 2019 Luma Pictures
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/// @file ndr/utils.h
+///
+/// Utilities for the NDR Plugin.
+#pragma once
+
+#include <pxr/pxr.h>
+#include "api.h"
+
+#include <pxr/usd/usd/stage.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Returns a stage containing all the available arnold shaders.
+///
+/// The function returns a stage holding generic prims, each of them represting
+/// an arnold shader. The "filename" metadata specifies the source of the shader
+/// either `<built-in>` for built-in shaders or the path pointing to the
+/// shader library or the osl file defining the shader.
+///
+/// The function is either reuses an existing arnold universe, or creates/destroys
+/// one as part of the node entry iteration.
+///
+/// The result is cached, so multiple calls to the function won't result in
+/// multiple stage creations.
+///
+/// @return A UsdStage holding all the available arnold shader definitions.
+UsdStageRefPtr NdrArnoldGetShaderDefs();
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
The PR adds a Ndr Discovery and Parser plugin for arnold shaders to fix issues with the USD-0.20.02 and the UsdImagingSceneDelegate and allow users to access the shaders, their parameters and default values via a uniform API.

**Changes proposed in this pull request**
- Registering all the arnold shaders and setting up a filename metadata.
- Registering a filename metadata for prims.
- Updating Readme with the NDR plugin.
- Updating Readme regarding points support.
- Updating building docs with the NDR plugin.
- Fixing typos in the building docs.
- Generating the arnold_usd header for either the procedural, render delegate or ndr plugin and making all these three depend on it.

**Issues fixed in this pull request**
Fixes #13 