### PR TITLE
Removing USD_HAS_PYTHON_SUPPORT flag.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -91,7 +91,6 @@ vars.AddVariables(
     BoolVariable('BUILD_DOCS', 'Wether or not to build the documentation.', True),
     BoolVariable('BUILD_HOUDINI_TOOLS', 'Wether or not to build the Houdini tools.', False),
     BoolVariable('DISABLE_CXX11_ABI', 'Disable the use of the CXX11 abi for gcc/clang', False),
-    BoolVariable('USD_HAS_PYTHON_SUPPORT', 'Wether or not the usd build has python support enabled', False),
     BoolVariable('BUILD_FOR_KATANA', 'Wether or not buildinf the plugins for Katana', False),
     StringVariable('BOOST_LIB_NAME', 'Boost library name pattern', 'boost_%s'),
     StringVariable('USD_MONOLITHIC_LIBRARY', 'Name of the USD monolithic library', 'usd_ms'),
@@ -181,7 +180,9 @@ if env['SHCXX'] != '$CXX':
 env['ARNOLD_VERSION'] = get_arnold_version(ARNOLD_API_INCLUDES)
 
 # Get USD Version
-env['USD_VERSION'] = get_usd_version(USD_INCLUDE)
+header_info = get_usd_header_info(USD_INCLUDE) 
+env['USD_VERSION'] = header_info['USD_VERSION']
+env['USD_HAS_PYTHON_SUPPORT'] = header_info['USD_HAS_PYTHON_SUPPORT']
 
 if env['COMPILER'] in ['gcc', 'clang'] and env['SHCXX'] != '$CXX':
    env['GCC_VERSION'] = os.path.splitext(os.popen(env['SHCXX'] + ' -dumpversion').read())[0]

--- a/docs/building.md
+++ b/docs/building.md
@@ -59,7 +59,6 @@ are the following.
 - PYTHON_INCLUDE: Where to find the Python Includes. This is only required if USD is built with Python support. See below.
 - PYTHON_LIB: Where to find the Python Library. This is only required if USD is built with Python support. See below.
 - PYTHON_LIB_NAME: Name of the python library. By default it is `python27`.
-- USD_HAS_PYTHON_SUPPORT: Whether or not USD was built with Python support. If it was, Boost and Python dependencies are required.
 - TBB_INCLUDE: Where to find TBB headers.
 - TBB_LIB: Where to find TBB libraries.
 
@@ -79,7 +78,6 @@ This builds the project on Linux, against the Distro supplied Python libraries a
 ```
 ARNOLD_PATH='/opt/autodesk/arnold-5.4.0.0'
 USD_PATH='/opt/pixar/USD'
-USD_HAS_PYTHON_SUPPORT=True
 USD_BUILD_MODE='monolithic'
 BOOST_INCLUDE='/usr/include'
 PYTHON_INCLUDE='/usr/include/python2.7'
@@ -97,7 +95,6 @@ ARNOLD_PATH='/opt/autodesk/arnold-5.4.0.0'
 USD_PATH='./'
 USD_INCLUDE='/opt/Katana3.2v1/include'
 USD_LIB='/opt/Katana3.2v1/bin'
-USD_HAS_PYTHON_SUPPORT=True
 BOOST_INCLUDE='/usr/include'
 PYTHON_INCLUDE='/usr/include/python2.7'
 PYTHON_LIB='/usr/lib'


### PR DESCRIPTION
**Changes proposed in this pull request**
- Removing the USD_HAS_PYTHON_SUPPORT flag from scons and using the `pxr.h` header to decide if USD was built with python support enabled.

**Issues fixed in this pull request**
Fixes #5 
