### PR TITLE
Fix #63: Define USD_HAS_UPDATED_COMPOSITOR for USD 19.11

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -60,7 +60,6 @@ vars.AddVariables(
     PathVariable('USD_BIN', 'Where to find USD binaries', os.path.join('$USD_PATH', 'bin'), PathVariable.PathIsDir),   
     EnumVariable('USD_BUILD_MODE', 'Build mode of USD libraries', 'monolithic', allowed_values=('shared_libs', 'monolithic', 'static')),
     StringVariable('USD_LIB_PREFIX', 'USD library prefix', '' if IS_WINDOWS else 'lib'),
-    BoolVariable('USD_1910_UPDATED_COMPOSITOR', 'USD-19.10 has the updated compositor interface', False),
     # 'static'  will expect a static monolithic library "libusd_m". When doing a monolithic build of USD, this 
     # library can be found in the build/pxr folder
     PathVariable('BOOST_INCLUDE', 'Where to find Boost includes', os.path.join('$USD_PATH', 'include', 'boost-1_61'), PathVariable.PathIsDir),
@@ -187,6 +186,7 @@ env['ARNOLD_VERSION'] = get_arnold_version(ARNOLD_API_INCLUDES)
 header_info = get_usd_header_info(USD_INCLUDE) 
 env['USD_VERSION'] = header_info['USD_VERSION']
 env['USD_HAS_PYTHON_SUPPORT'] = header_info['USD_HAS_PYTHON_SUPPORT']
+env['USD_HAS_UPDATED_COMPOSITOR'] = header_info['USD_HAS_UPDATED_COMPOSITOR']
 
 if env['COMPILER'] in ['gcc', 'clang'] and env['SHCXX'] != '$CXX':
    env['GCC_VERSION'] = os.path.splitext(os.popen(env['SHCXX'] + ' -dumpversion').read())[0]

--- a/render_delegate/SConscript
+++ b/render_delegate/SConscript
@@ -45,8 +45,8 @@ source_files = [
 if system.os != 'windows':
     local_env.Append(CXXFLAGS = Split('-fPIC'))
 
-if local_env['USD_1910_UPDATED_COMPOSITOR']:
-    local_env.Append(CPPDEFINES=['USD_1910_UPDATED_COMPOSITOR'])
+if local_env['USD_HAS_UPDATED_COMPOSITOR']:
+    local_env.Append(CPPDEFINES=['USD_HAS_UPDATED_COMPOSITOR'])
 
 if local_env['BUILD_HOUDINI_TOOLS']:
     local_env.Append(CPPDEFINES=['BUILD_HOUDINI_TOOLS'])

--- a/render_delegate/hdarnold.h
+++ b/render_delegate/hdarnold.h
@@ -32,7 +32,7 @@
 #endif
 #endif
 
-#if USED_USD_VERSION_GREATER_EQ(19, 12)
+#if USED_USD_VERSION_GREATER_EQ(19, 11)
 /// Hydra has the new compositor functions
 #define USD_HAS_UPDATED_COMPOSITOR
 #endif

--- a/render_delegate/hdarnold.h
+++ b/render_delegate/hdarnold.h
@@ -26,13 +26,4 @@
 #define USD_HAS_NEW_MATERIAL_TERMINAL_TOKENS
 /// Hydra has the new renderer plugin base class
 #define USD_HAS_NEW_RENDERER_PLUGIN
-/// Hydra has the new compositor functions
-#ifdef USD_1910_UPDATED_COMPOSITOR
-#define USD_HAS_UPDATED_COMPOSITOR
-#endif
-#endif
-
-#if USED_USD_VERSION_GREATER_EQ(19, 11)
-/// Hydra has the new compositor functions
-#define USD_HAS_UPDATED_COMPOSITOR
 #endif

--- a/tools/utils/build_tools.py
+++ b/tools/utils/build_tools.py
@@ -131,7 +131,7 @@ def get_usd_header_info(usd_include_dir):
     r = re.search('#if ([01]).#define PXR_PYTHON_SUPPORT_ENABLED', pxr_h, re.DOTALL)
     if r:
         HAS_PYTHON_SUPPORT = r.group(1) == '1'
-        
+
     # Detect updated Compositor
     compositor_h_path = os.path.join(usd_include_dir, "pxr", "imaging", "hdx", "compositor.h")
     if os.path.exists(compositor_h_path):
@@ -144,7 +144,7 @@ def get_usd_header_info(usd_include_dir):
                 # Assume new updated compositor UpdateColor() function
                 # introduced since 19.11 but not present in all, see #64
                 HAS_UPDATED_COMPOSITOR = True
-    
+
     return {
         'USD_VERSION': '.'.join(VERSION),
         'USD_HAS_PYTHON_SUPPORT': HAS_PYTHON_SUPPORT,

--- a/tools/utils/build_tools.py
+++ b/tools/utils/build_tools.py
@@ -117,6 +117,7 @@ def get_arnold_version(arnold_include_dir, components = 4):
 def get_usd_header_info(usd_include_dir):
     VERSION = [''] * 3
     HAS_PYTHON_SUPPORT = False
+    HAS_UPDATED_COMPOSITOR = False
 
     pxr_h = open(os.path.join(usd_include_dir, 'pxr', 'pxr.h'), 'r').read()
 
@@ -130,10 +131,23 @@ def get_usd_header_info(usd_include_dir):
     r = re.search('#if ([01]).#define PXR_PYTHON_SUPPORT_ENABLED', pxr_h, re.DOTALL)
     if r:
         HAS_PYTHON_SUPPORT = r.group(1) == '1'
-
+        
+    # Detect updated Compositor
+    compositor_h_path = os.path.join(usd_include_dir, "pxr", "imaging", "hdx", "compositor.h")
+    compositor_h = open(compositor_h_path, "r").read()
+    match = re.search("UpdateColor\(([^)]*)", compositor_h, re.DOTALL)
+    if match:
+        # Found UpdateColor function in compositor.h
+        args = match.group(1).split(",")
+        if len(args) == 4 and args[2].strip() == "HdFormat format":
+            # Assume new updated compositor UpdateColor() function
+            # introduced since 19.11 but not present in all, see #64
+            HAS_UPDATED_COMPOSITOR = True
+    
     return {
         'USD_VERSION': '.'.join(VERSION),
         'USD_HAS_PYTHON_SUPPORT': HAS_PYTHON_SUPPORT,
+        'USD_HAS_UPDATED_COMPOSITOR': HAS_UPDATED_COMPOSITOR
     }
 
 def convert_usd_version_to_int(usd_version):

--- a/tools/utils/build_tools.py
+++ b/tools/utils/build_tools.py
@@ -134,15 +134,16 @@ def get_usd_header_info(usd_include_dir):
         
     # Detect updated Compositor
     compositor_h_path = os.path.join(usd_include_dir, "pxr", "imaging", "hdx", "compositor.h")
-    compositor_h = open(compositor_h_path, "r").read()
-    match = re.search("UpdateColor\(([^)]*)", compositor_h, re.DOTALL)
-    if match:
-        # Found UpdateColor function in compositor.h
-        args = match.group(1).split(",")
-        if len(args) == 4 and args[2].strip() == "HdFormat format":
-            # Assume new updated compositor UpdateColor() function
-            # introduced since 19.11 but not present in all, see #64
-            HAS_UPDATED_COMPOSITOR = True
+    if os.path.exists(compositor_h_path):
+        compositor_h = open(compositor_h_path, "r").read()
+        match = re.search("UpdateColor\(([^)]*)", compositor_h, re.DOTALL)
+        if match:
+            # Found UpdateColor function in compositor.h
+            args = match.group(1).split(",")
+            if len(args) == 4 and args[2].strip() == "HdFormat format":
+                # Assume new updated compositor UpdateColor() function
+                # introduced since 19.11 but not present in all, see #64
+                HAS_UPDATED_COMPOSITOR = True
     
     return {
         'USD_VERSION': '.'.join(VERSION),


### PR DESCRIPTION
**Changes proposed in this pull request**

- Define `USD_HAS_UPDATED_COMPOSITOR` for USD 19.11+ instead of USD 19.12+

As far as I can tell the updated compositor API is already part of the [official 19.11 release](https://github.com/PixarAnimationStudios/USD/commit/4b1162957b2ad219e1635c81de8343be490e41fc) as described in #63. Similarly it's also in the [USD 19.11 archived release](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11)

**Issues fixed in this pull request**
Fixes #63 
