### PR TITLE
Fix propagation of instance transform updates from dirty instancers

### DIFF
--- a/render_delegate/shape.cpp
+++ b/render_delegate/shape.cpp
@@ -60,7 +60,9 @@ void HdArnoldShape::_SyncInstances(
     HdDirtyBits dirtyBits, HdSceneDelegate* sceneDelegate, HdArnoldRenderParam* param, const SdfPath& id,
     const SdfPath& instancerId)
 {
-    if (instancerId.IsEmpty() || !HdChangeTracker::IsInstanceIndexDirty(dirtyBits, id)) {
+    if (instancerId.IsEmpty() ||
+            !(HdChangeTracker::IsInstancerDirty(dirtyBits, id) ||
+              HdChangeTracker::IsInstanceIndexDirty(dirtyBits, id))) {
         return;
     }
     param->End();


### PR DESCRIPTION
Fixes propagation of changes to instance "primvars" (e.g. transforms) in response to changes to instancer dirty state.

Marking an instancer dirty also sets the `DirtyInstancer` bit on its source Rprim. Since the delegate's current instancing implementation is looking at the Rprim dirty bits (as opposed to the instancer dirty bis), we need to make sure instance matrices are recomputed any time the instancer itself is marked dirty in order to get proper transform updates.