### PR TITLE
Viewport callbacks not working reliably

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -108,15 +108,15 @@ procedural_get_node
 //                    AtProcViewportMode mode, (AI_PROC_BOXES = 0, AI_PROC_POINTS, AI_PROC_POLYGONS)
 //                    AtParamValueMap* params)
 procedural_viewport
-{
-    // For now we always create a new reader for the viewport display, 
-    // can we reuse the eventual existing one ?
-    UsdArnoldReader *reader = new UsdArnoldReader();
-    
+{    
     std::string filename(AiNodeGetStr(node, "filename"));
     if (filename.empty()) {
         return false;
     }
+    // For now we always create a new reader for the viewport display, 
+    // can we reuse the eventual existing one ?
+    UsdArnoldReader *reader = new UsdArnoldReader();
+        
     std::string objectPath(AiNodeGetStr(node, "object_path"));
     // note that we must *not* set the parent procedural, as we'll be creating 
     // nodes in a separate universe

--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -187,7 +187,8 @@ void UsdArnoldPrimReader::readArnoldParameters(
                                 }
                                 // the  above call should have created the shader already
                                 arnoldVec[v] =
-                                    AiNodeLookUpByName(targetPrim.GetPath().GetText(), reader.getProceduralParent());
+                                    AiNodeLookUpByName(reader.getUniverse(), 
+                                        targetPrim.GetPath().GetText(), reader.getProceduralParent());
                             }
                             AiNodeSetArray(
                                 node, arnoldAttr.c_str(), AiArrayConvert(array.size(), 1, AI_TYPE_NODE, &arnoldVec[0]));
@@ -266,7 +267,7 @@ void UsdArnoldPrimReader::readArnoldParameters(
                                 // the  above call should have created the shader already
                                 AiNodeSetPtr(
                                     node, arnoldAttr.c_str(),
-                                    (AtNode *)AiNodeLookUpByName(
+                                    (AtNode *)AiNodeLookUpByName(reader.getUniverse(),
                                         targetPrim.GetPath().GetText(), reader.getProceduralParent()));
                             }
                             break;
@@ -285,7 +286,8 @@ void UsdArnoldPrimReader::readArnoldParameters(
                         reader.readPrimitive(targetPrim, true, false);
                         // the  above call should have created the shader already
                         AtNode *target =
-                            AiNodeLookUpByName(targetPrim.GetPath().GetText(), reader.getProceduralParent());
+                            AiNodeLookUpByName(reader.getUniverse(),
+                                targetPrim.GetPath().GetText(), reader.getProceduralParent());
                         if (target) {
                             AiNodeLink(target, arnoldAttr.c_str(), node);
                         }

--- a/translator/reader/read_light.cpp
+++ b/translator/reader/read_light.cpp
@@ -285,7 +285,8 @@ void UsdArnoldReadGeometryLight::read(const UsdPrim &prim, UsdArnoldReader &read
             }
             node = reader.createArnoldNode("mesh_light", lightName.c_str());
         } else {
-            node = AiNodeLookUpByName(targetPrim.GetPath().GetText(), reader.getProceduralParent());
+            node = AiNodeLookUpByName(reader.getUniverse(),
+                targetPrim.GetPath().GetText(), reader.getProceduralParent());
         }
         if (node == nullptr || !convert) {
             continue;

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -343,7 +343,7 @@ void UsdArnoldReader::setUniverse(AtUniverse *universe)
 
 AtNode *UsdArnoldReader::createArnoldNode(const char *type, const char *name, bool *existed)
 {
-    AtNode *node = AiNodeLookUpByName(name, _procParent);
+    AtNode *node = AiNodeLookUpByName(_universe, name, _procParent);
     if (existed) {
         *existed = (node != NULL);
     }

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -35,6 +35,7 @@ public:
     UsdArnoldReader() : _procParent(NULL), 
                         _universe(NULL), 
                         _registry(NULL), 
+                        _convert(true),
                         _debug(false), 
                         _threadCount(1),
                         _xformCache(NULL) {}

--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -320,7 +320,8 @@ void exportMaterialBinding(const UsdPrim &prim, AtNode *node, UsdArnoldReader &r
 
     if (surface) {
         reader.readPrimitive(surface.GetPrim(), true, false);
-        shader = AiNodeLookUpByName(surface.GetPath().GetText(), reader.getProceduralParent());
+        shader = AiNodeLookUpByName(reader.getUniverse(), 
+            surface.GetPath().GetText(), reader.getProceduralParent());
         if (shader)
             AiNodeSetPtr(node, "shader", shader);
     }
@@ -334,7 +335,8 @@ void exportMaterialBinding(const UsdPrim &prim, AtNode *node, UsdArnoldReader &r
 
         if (volume) {
             reader.readPrimitive(volume.GetPrim(), true, false);
-            shader = AiNodeLookUpByName(volume.GetPath().GetText(), reader.getProceduralParent());
+            shader = AiNodeLookUpByName(reader.getUniverse(), 
+                volume.GetPath().GetText(), reader.getProceduralParent());
             AiNodeSetPtr(node, "shader", shader);
         }
     }
@@ -347,7 +349,8 @@ void exportMaterialBinding(const UsdPrim &prim, AtNode *node, UsdArnoldReader &r
 
         if (displacement) {
             reader.readPrimitive(displacement.GetPrim(), true, false);
-            shader = AiNodeLookUpByName(displacement.GetPath().GetText(), reader.getProceduralParent());
+            shader = AiNodeLookUpByName(reader.getUniverse(),
+                displacement.GetPath().GetText(), reader.getProceduralParent());
             AiNodeSetPtr(node, "disp_map", shader);
         }
     }
@@ -395,7 +398,8 @@ void exportParameter(
             if (targetPrim && targetPrim.GetTypeName() == TfToken("Shader")) {
                 reader.readPrimitive(targetPrim, true, false);
                 // the  above call should have created the shader already
-                AtNode *target = AiNodeLookUpByName(targetPrim.GetPath().GetText(), reader.getProceduralParent());
+                AtNode *target = AiNodeLookUpByName(reader.getUniverse(),
+                    targetPrim.GetPath().GetText(), reader.getProceduralParent());
                 if (target) {
                     AiNodeLink(target, arnoldName.c_str(), node);
                 }
@@ -502,7 +506,8 @@ AtNode *getNodeToConvert(UsdArnoldReader &reader, const char *nodeType, const ch
         node = reader.createArnoldNode(nodeType, nodeName);
     } else {
         // check if the node already existed
-        node = AiNodeLookUpByName(nodeName, reader.getProceduralParent());
+        node = AiNodeLookUpByName(reader.getUniverse(), 
+            nodeName, reader.getProceduralParent());
     }
     if (!convert)
         return nullptr;


### PR DESCRIPTION
**Changes proposed in this pull request**
The viewport API is randomly failing with the usd procedural. 
The issue is caused by an uninitialized variable, which this PR fixes. The variable `_convert` that was added recently wasn't initialized to `true` and because of that, the usd translation was randomly skipped.

While inspecting the code, I also fixed a possible memory leak about a `UsdArnoldReader` being allocated but not deleted at early-out. 

I also noted that when calling `AiNodeLookUpByName` we were not passing the `AtUniverse` argument to the function, which could possibly cause issues with the viewport code that relies on a non-default universe.