### PR TITLE
Create a new Xform cache for animated xforms

### DIFF
--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -70,7 +70,7 @@ public:
     bool getDebug() const { return _debug; }
     bool getConvertPrimitives() const {return _convert;}
     const TimeSettings &getTimeSettings() const { return _time; }
-    UsdGeomXformCache *getXformCache() {return _xformCache;}
+    UsdGeomXformCache *getXformCache(float frame);
 
     static unsigned int RenderThread(void *data);
 
@@ -86,5 +86,6 @@ private:
     UsdStageRefPtr _stage; // current stage being read. Will be cleared once
                            // finished reading
     std::vector<AtNode *> _nodes;
-    UsdGeomXformCache *_xformCache;
+    UsdGeomXformCache *_xformCache; // main xform cache for current frame
+    std::unordered_map<float, UsdGeomXformCache*> _xformCacheMap; // map of xform caches for animated keys
 };

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 
-#include <ai_nodes.h>
+#include <ai.h>
 
 #include <pxr/usd/usd/prim.h>
 #include <string>
@@ -32,13 +32,14 @@ class UsdArnoldReaderRegistry;
 
 class UsdArnoldReader {
 public:
-    UsdArnoldReader() : _procParent(NULL), 
-                        _universe(NULL), 
-                        _registry(NULL), 
+    UsdArnoldReader() : _procParent(nullptr), 
+                        _universe(nullptr), 
+                        _registry(nullptr), 
                         _convert(true),
                         _debug(false), 
                         _threadCount(1),
-                        _xformCache(NULL) {}
+                        _xformCache(nullptr),
+                        _readerLock(nullptr) {}
     ~UsdArnoldReader();
 
     void read(const std::string &filename, AtArray *overrides,
@@ -88,4 +89,5 @@ private:
     std::vector<AtNode *> _nodes;
     UsdGeomXformCache *_xformCache; // main xform cache for current frame
     std::unordered_map<float, UsdGeomXformCache*> _xformCacheMap; // map of xform caches for animated keys
+    AtCritSec _readerLock; // arnold mutex for multi-threaded translator
 };

--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -44,13 +44,7 @@ static inline void getMatrix(const UsdPrim &prim, AtMatrix &matrix, float frame,
 {
     GfMatrix4d xform;
     bool dummyBool = false;
-    UsdGeomXformCache *xformCache = reader.getXformCache();
-
-    // The frame is different than the one used for the xform cache, we're 
-    // probably dealing with animated xforms. Let's reset our pointer in 
-    // this case, so that we generate a new one below. 
-    if (xformCache && std::abs(frame - (float)xformCache->GetTime().GetValue()) > AI_EPSILON)
-        xformCache = NULL;
+    UsdGeomXformCache *xformCache = reader.getXformCache(frame);
     
     bool createXformCache = (xformCache == NULL);
     if (createXformCache)

--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -39,14 +39,19 @@
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
+
 static inline void getMatrix(const UsdPrim &prim, AtMatrix &matrix, float frame, UsdArnoldReader &reader)
 {
     GfMatrix4d xform;
     bool dummyBool = false;
     UsdGeomXformCache *xformCache = reader.getXformCache();
 
-    // The reader should have a xform cache, if not let's create one 
-    // just for this purpose (not optimized)
+    // The frame is different than the one used for the xform cache, we're 
+    // probably dealing with animated xforms. Let's reset our pointer in 
+    // this case, so that we generate a new one below. 
+    if (xformCache && std::abs(frame - (float)xformCache->GetTime().GetValue()) > AI_EPSILON)
+        xformCache = NULL;
+    
     bool createXformCache = (xformCache == NULL);
     if (createXformCache)
         xformCache = new UsdGeomXformCache(frame);


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR is meant to address the regression about animated xforms in #80.
I see different solutions to address this issue, and I'm not totally sure which one is best :

- 1 )  every time one primitive has keys on a different frame than the current one, create one `UsdGeomXformCache` just to compute the world matrix and delete it. 

- 2 ) Create on-demand one `UsdGeomXformCache` per requested frame. The `UsdReader` would store a map of xform caches, and would create them dynamically when needed.

- 3 ) Change the time of the `UsdGeomXformCache` every time we need to get a new matrix.

///////////////////////////// 

In this commit I went for the simplest solution 1), but I'm fine with implementing a different solution if better.

3 ) would be very simple to implement but changing the cache time will clear its data under the hood, so if there are a lot of animated xforms in the scene we might loose the benefits from the cache.

If there are a lot of animated xforms in the hierarchy that have values at the same keys, it would be more efficient to store each xform cache in a map as in 2), so that these intermediate matrices aren't computed over and over. But if the xforms have keys at different time values, we could end up with a lot of xform caches being computed, and maybe it could get overkill ?

**Issues fixed in this pull request**
Fixes #80

