### PR TITLE
Supporting building against prefixed USD libraries.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -59,7 +59,7 @@ vars.AddVariables(
     PathVariable('USD_LIB', 'Where to find USD libraries', os.path.join('$USD_PATH', 'lib'), PathVariable.PathIsDir),
     PathVariable('USD_BIN', 'Where to find USD binaries', os.path.join('$USD_PATH', 'bin'), PathVariable.PathIsDir),   
     EnumVariable('USD_BUILD_MODE', 'Build mode of USD libraries', 'monolithic', allowed_values=('shared_libs', 'monolithic', 'static')),
-    StringVariable('USD_LIB_PREFIX', 'USD library prefix', '' if IS_WINDOWS else 'lib'),
+    StringVariable('USD_LIB_PREFIX', 'USD library prefix', 'lib'),
     # 'static'  will expect a static monolithic library "libusd_m". When doing a monolithic build of USD, this 
     # library can be found in the build/pxr folder
     PathVariable('BOOST_INCLUDE', 'Where to find Boost includes', os.path.join('$USD_PATH', 'include', 'boost-1_61'), PathVariable.PathIsDir),
@@ -232,6 +232,10 @@ os.putenv('PXR_PLUGINPATH_NAME', os.environ['PXR_PLUGINPATH_NAME'])
 # Compiler settings
 if env['COMPILER'] in ['gcc', 'clang']:
     env.Append(CCFLAGS = Split('-fno-operator-names -std=c++11'))
+    if IS_DARWIN:
+        env.Append(LINKFLAGS = '-Wl,-undefined,error')
+    else:
+        env.Append(LINKFLAGS = '-Wl,--no-undefined')
     if env['DISABLE_CXX11_ABI']:
         env.Append(CCFLAGS = Split('-D_GLIBCXX_USE_CXX11_ABI=0'))
     # Warning level

--- a/cmd/SConscript
+++ b/cmd/SConscript
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from utils import system
-from utils.build_tools import find_files_recursive
+from utils.build_tools import find_files_recursive, link_usd_libraries
 import os
 import os.path
 
@@ -29,27 +29,23 @@ src_translator_dir  = os.path.join(local_env['ROOT_DIR'], 'translator', 'writer'
 # Include paths
 includePaths = [
     '.',
-    env['USD_INCLUDE'],
-    env['BOOST_INCLUDE'],
-    env['PYTHON_INCLUDE'],
     src_translator_dir
 ]
 local_env.Append(CPPPATH = includePaths)
-
 local_env.Append(LIBS = ['ai'])
 
 # Library paths and libraries
 libPaths = [
-    env['PYTHON_LIB']
+    local_env['PYTHON_LIB']
 ]
 
 usd_deps = []
-if env['USD_BUILD_MODE'] == 'monolithic':
+if local_env['USD_BUILD_MODE'] == 'monolithic':
     usd_deps = [
-        env['USD_MONOLITHIC_LIBRARY'],
+        local_env['USD_MONOLITHIC_LIBRARY'],
         'tbb',
     ]
-elif env['USD_BUILD_MODE'] == 'static':
+elif local_env['USD_BUILD_MODE'] == 'static':
     # static builds rely on a monolithic static library
     if system.IS_WINDOWS:
         usd_deps = [
@@ -66,7 +62,7 @@ elif env['USD_BUILD_MODE'] == 'static':
             'tbb',
         ]
 else:  # shared libs
-    usd_deps = [
+    usd_libs = [
         'sdf',
         'tf',
         'usd',
@@ -78,27 +74,19 @@ else:  # shared libs
         'gf',
     ]
 
-translatorLibPath = os.path.abspath(os.path.join(env['BUILD_BASE_DIR'], 'translator'))
+    usd_libs, usd_sources = link_usd_libraries(local_env, usd_libs)
+    usd_deps = usd_deps + usd_libs
+    source_files = source_files + usd_sources
+
+translatorLibPath = os.path.abspath(os.path.join(local_env['BUILD_BASE_DIR'], 'translator'))
 libPaths.append(translatorLibPath)
+local_env.Append(LIBPATH = libPaths)
+
 local_env.Append(LIBS = ['usd_translator'])
-
-
 local_env.Append(LIBS = usd_deps)
 
-local_env.Append(LIBPATH = libPaths)
 if local_env['USD_HAS_PYTHON_SUPPORT']:
-    local_env.Append(LIBS = [env['PYTHON_LIB_NAME'], env['BOOST_LIB_NAME'] % 'python'])
-
-print '/////////////////////////////////////////////////////////'
+    local_env.Append(LIBS = [local_env['PYTHON_LIB_NAME'], local_env['BOOST_LIB_NAME'] % 'python'])
 
 ARNOLD_TO_USD = local_env.Program('arnold_to_usd', source_files)
-'''
-if system.os() == 'darwin':
-    local_env.Append(CPPDEFINES = Split('DARWIN'))
-    local_env.Append(FRAMEWORKS=Split('OpenGl AGL'))
-    local_env.Append(CPPPATH = '/System/Library/Frameworks/OpenGL.framework/Headers')
-'''
 Return('ARNOLD_TO_USD')
-
-
-

--- a/procedural/SConscript
+++ b/procedural/SConscript
@@ -14,7 +14,7 @@
 # limitations under the License.
 ## load our own python modules
 from utils import system
-from utils.build_tools import find_files_recursive
+from utils.build_tools import find_files_recursive, link_usd_libraries
 
 import os
 
@@ -71,7 +71,7 @@ elif myenv['USD_BUILD_MODE'] == 'static':
         else:
             myenv.Append(LINKFLAGS=['-Wl,-all_load,%s,-noall_load' % whole_archives])
 else:  # shared libs
-    usd_deps = [
+    usd_libs = [
         'sdf',
         'tf',
         'usd',
@@ -81,6 +81,10 @@ else:  # shared libs
         'vt',
         'usdLux',
     ]
+
+    usd_libs, usd_sources = link_usd_libraries(myenv, usd_libs)
+    usd_deps = usd_deps + usd_libs
+    source_files = source_files + usd_sources
 
 translatorLibPath = os.path.abspath(os.path.join(myenv['BUILD_BASE_DIR'], 'translator'))
 myenv.Append(LIBPATH = [translatorLibPath])

--- a/render_delegate/SConscript
+++ b/render_delegate/SConscript
@@ -42,7 +42,7 @@ source_files = [
     os.path.join('nodes', 'nodes.cpp'),
 ]
 
-if system.os != 'windows':
+if not system.IS_WINDOWS:
     local_env.Append(CXXFLAGS = Split('-fPIC'))
 
 if local_env['USD_HAS_UPDATED_COMPOSITOR']:
@@ -81,6 +81,9 @@ else:
     usd_libs, usd_sources = build_tools.link_usd_libraries(local_env, usd_libs)
     usd_deps = usd_deps + usd_libs
     source_files = source_files + usd_sources
+
+if system.IS_LINUX:
+    local_env.Append(LIBS = 'dl')
 
 local_env.Append(LIBS = usd_deps)
 if local_env['USD_HAS_PYTHON_SUPPORT']:

--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -14,7 +14,7 @@
 # limitations under the License.
 ## load our own python modules
 from utils import system
-from utils.build_tools import find_files_recursive
+from utils.build_tools import find_files_recursive, link_usd_libraries
 from utils.system import IS_WINDOWS, IS_DARWIN, IS_LINUX
 
 import os
@@ -162,7 +162,7 @@ libPaths = [
 ]
 
 if env['USD_BUILD_MODE'] == 'shared_libs':
-    usd_deps = [
+    usd_libs = [
         'arch',
         'sdf',
         'tf',
@@ -174,6 +174,10 @@ if env['USD_BUILD_MODE'] == 'shared_libs':
         'usdLux',
         'tbb',
     ]
+
+    usd_deps, usd_sources = link_usd_libraries(myenv, usd_libs)
+    source_files = source_files + usd_sources
+    wrapper_source_files = wrapper_source_files + usd_sources
 else:
     usd_deps = [
         env['USD_MONOLITHIC_LIBRARY'],

--- a/translator/SConscript
+++ b/translator/SConscript
@@ -14,7 +14,7 @@
 # limitations under the License.
 ## load our own python modules
 from utils import system
-from utils.build_tools import find_files_recursive
+from utils.build_tools import find_files_recursive, link_usd_libraries
 
 import os
 
@@ -41,7 +41,7 @@ if myenv['USD_BUILD_MODE'] == 'monolithic':
         myenv['USD_MONOLITHIC_LIBRARY'],
     ]
 elif myenv['USD_BUILD_MODE'] == 'shared_libs':
-    usd_deps = [
+    usd_libs = [
         'sdf',
         'tf',
         'usd',
@@ -51,6 +51,10 @@ elif myenv['USD_BUILD_MODE'] == 'shared_libs':
         'vt',
         'usdLux',
     ]
+
+    usd_libs, usd_sources = link_usd_libraries(myenv, usd_libs)
+    usd_deps = usd_deps + usd_libs
+    source_files = source_files + usd_sources
 
 myenv.Append(LIBS = usd_deps)
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding a new USD_LIB_PREFIX flag.
- Adding example custom.py files to the documentation.
- Extending building.md about using abuild and configuring the build.
- Fixing a typo in the render delegate that turns on -fPIC on windows.
- Adding a warning about the python app shortcut on Windows 10.
- Adding dl to the dependencies when building the render delegate on Linux.
- Adding a new utility function for SCons scripts, link_usd_libraries that handles adding dependencies to builds.

**Issues fixed in this pull request**
Fixes #48