### PR TITLE
Don't build typed schemas for shaders

### DIFF
--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -84,19 +84,19 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry()
             continue;
         }
         usdName[0] = toupper(usdName[0]);
-        usdName = std::string("Arnold") + usdName;
-
-        /*
-                if (entryTypeName == "shader") {
-                    // We want to export all shaders as a UsdShader primitive,
-                    // and set the shader type in info:id
-                    registerWriter(
-                        entryName, new UsdArnoldWriteShader(entryName, usdName));
-                } else */
+        if (entryTypeName == "shader") {
+            // We want to export all shaders as a UsdShader primitive,
+            // and set the shader type in info:id
+            usdName = std::string("arnold:") + entryName;
+            registerWriter(
+                entryName, new UsdArnoldWriteShader(entryName, usdName));
+        } else 
         {
+            usdName = std::string("Arnold") + usdName;
             // Generic writer for arnold nodes.
             registerWriter(entryName, new UsdArnoldWriteArnoldType(entryName, usdName, entryTypeName));
         }
+
     }
     AiNodeEntryIteratorDestroy(nodeEntryIter);
 


### PR DESCRIPTION
**Changes proposed in this pull request**
No longer build typed schemas for shaders since we rely on `UsdShade` schemas, with the `info:id` token returning the arnold shader name.
This allows to get rid of several special cases during the schemas generation, some of which are explained in #65 

**Issues fixed in this pull request**
Fixes #96

**Additional c