### PR TITLE
Re-rendering when visibility of an object changes.

### DIFF
--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -91,6 +91,7 @@ void HdArnoldMesh::Sync(
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
+        param->End();
         _UpdateVisibility(delegate, dirtyBits);
         AiNodeSetByte(_shape.GetShape(), str::visibility, _sharedData.visible ? AI_RAY_ALL : uint8_t{0});
     }

--- a/render_delegate/points.cpp
+++ b/render_delegate/points.cpp
@@ -90,6 +90,7 @@ void HdArnoldPoints::Sync(
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
+        param->End();
         _UpdateVisibility(delegate, dirtyBits);
         AiNodeSetByte(_shape.GetShape(), str::visibility, _sharedData.visible ? AI_RAY_ALL : uint8_t{0});
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Restarting renders when visibility is dirtied.

**Issues fixed in this pull request**
Fixes #95