### PR TITLE
Raise a runtime error if usdGenSchema can't be found and the schema build is enabled.

### DIFF
--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -80,8 +80,7 @@ FIXME Current issues to address the generation of the schema files :
 
 genSchema = os.path.join(env['USD_PATH'], 'bin', 'usdGenSchema')
 if not os.path.exists(genSchema):
-    print 'Command {} not found. Impossible to generate Schemas'.format(genSchema)
-    Return ([])
+    raise RuntimeError('Command {} not found. Impossible to generate Schemas'.format(genSchema))
 
 if not os.path.exists(schemasBuildFolder):
     os.makedirs(schemasBuildFolder)


### PR DESCRIPTION
**Changes proposed in this pull request**
- Raise a runtime error if `usdGenSchema` can't be found and the schema build is enabled

**Issues fixed in this pull request**
Fixes #105 
