### PR TITLE
Adding ARNOLD_BINARIES to the dynamic library path to fix linking issues

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -219,6 +219,7 @@ env_separator = ';' if IS_WINDOWS else ':'
 
 env.AppendENVPath(dylib, USD_LIB, envname='ENV', sep=env_separator, delete_existing=1)
 env.AppendENVPath(dylib, USD_BIN, envname='ENV', sep=env_separator, delete_existing=1)
+env.AppendENVPath(dylib, ARNOLD_BINARIES, envname='ENV', sep=env_separator, delete_existing=1)
 env.AppendENVPath('PYTHONPATH', os.path.join(USD_LIB, 'python'), envname='ENV', sep=env_separator, delete_existing=1)
 env.AppendENVPath('PXR_PLUGINPATH_NAME', os.path.join(USD_PATH, 'plugin', 'usd'), envname='ENV', sep=env_separator, delete_existing=1)
 os.environ['PATH'] = env['ENV']['PATH']


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding ARNOLD_BINARIES to the dynamic library path environment variable, so the linker can find symbols from libraries next to libai.

**Issues fixed in this pull request**
Fixes #107
