### PR TITLE
Fix parsing of HOUDINI_PATH

### DIFF
--- a/render_delegate/volume.cpp
+++ b/render_delegate/volume.cpp
@@ -105,7 +105,6 @@ struct HtoAFnSet {
         // this method in the future.
         constexpr auto convertVdbName = "HtoAConvertPrimVdbToArnold";
         const auto HOUDINI_PATH = ArchGetEnv("HOUDINI_PATH");
-        void* htoaPygeo = nullptr;
         auto searchForPygeo = [&](const std::string& path) -> bool {
             if (path == "&") {
                 return false;
@@ -118,7 +117,7 @@ struct HtoAFnSet {
                                 ".so"
 #endif
                 ;
-            htoaPygeo = ArchLibraryOpen(dsoPath, ARCH_LIBRARY_NOW);
+            void* htoaPygeo = ArchLibraryOpen(dsoPath, ARCH_LIBRARY_NOW);
             if (htoaPygeo == nullptr) {
                 return false;
             }
@@ -144,6 +143,7 @@ struct HtoAFnSet {
             }
 #endif
         }
+        std::cerr << "[HdArnold] Cannot load _htoa_pygeo library required for volume rendering in Solaris" << std::endl;
     }
 };
 

--- a/render_delegate/volume.cpp
+++ b/render_delegate/volume.cpp
@@ -106,30 +106,44 @@ struct HtoAFnSet {
         constexpr auto convertVdbName = "HtoAConvertPrimVdbToArnold";
         const auto HOUDINI_PATH = ArchGetEnv("HOUDINI_PATH");
         void* htoaPygeo = nullptr;
-        const auto houdiniPaths = TfStringSplit(HOUDINI_PATH, TfStringContains(HOUDINI_PATH, ";") ? ";" : ARCH_PATH_LIST_SEP);
-        for (const auto& houdiniPath : houdiniPaths) {
-            if (houdiniPath == "&")
-                continue;
-            const auto dsoPath = houdiniPath + ARCH_PATH_SEP + "python2.7libs" + ARCH_PATH_SEP + "_htoa_pygeo" +
+        auto searchForPygeo = [&](const std::string& path) -> bool {
+            if (path == "&") {
+                return false;
+            }
+            const auto dsoPath = path + ARCH_PATH_SEP + "python2.7libs" + ARCH_PATH_SEP + "_htoa_pygeo" +
 // HTOA sets this library's extension to .so even on linux.
 #ifdef ARCH_OS_WINDOWS
-                                 ".dll"
+                                ".dll"
 #else
-                                 ".so"
+                                ".so"
 #endif
                 ;
             htoaPygeo = ArchLibraryOpen(dsoPath, ARCH_LIBRARY_NOW);
-            if (htoaPygeo != nullptr) {
-                break;
+            if (htoaPygeo == nullptr) {
+                return false;
             }
+            convertPrimVdbToArnold = reinterpret_cast<HtoAConvertPrimVdbToArnold>(GETSYM(htoaPygeo, convertVdbName));
+            if (convertPrimVdbToArnold == nullptr) {
+                TF_WARN("Error loading %s from %s", convertVdbName, dsoPath.c_str());
+            }
+            return true;
+        };
+        const auto houdiniPaths = TfStringSplit(HOUDINI_PATH, ARCH_PATH_LIST_SEP);
+        for (const auto& houdiniPath : houdiniPaths) {
+            if (searchForPygeo(houdiniPath)) {
+                return;
+            }
+#ifndef ARCH_OS_WINDOWS
+            if (TfStringContains(houdiniPath, ";")) {
+                const auto subPaths = TfStringSplit(houdiniPath, ";");
+                for (const auto& subPath : subPaths) {
+                    if (searchForPygeo(subPath)) {
+                        return;
+                    }
+                }
+            }
+#endif
         }
-
-        if (htoaPygeo == nullptr) {
-            std::cout << "[HdArnold] Cannot load htoa_pygeo required for volume rendering in Solaris" << std::endl;
-            return;
-        }
-
-        convertPrimVdbToArnold = reinterpret_cast<HtoAConvertPrimVdbToArnold>(GETSYM(htoaPygeo, convertVdbName));
     }
 };
 

--- a/render_delegate/volume.cpp
+++ b/render_delegate/volume.cpp
@@ -104,8 +104,10 @@ struct HtoAFnSet {
         constexpr auto convertVdbName = "HtoAConvertPrimVdbToArnold";
         const auto HOUDINI_PATH = ArchGetEnv("HOUDINI_PATH");
         void* htoaPygeo = nullptr;
-        const auto houdiniPaths = TfStringSplit(HOUDINI_PATH, ARCH_PATH_LIST_SEP);
+        const auto houdiniPaths = TfStringSplit(HOUDINI_PATH, TfStringContains(HOUDINI_PATH, ";") ? ";" : ARCH_PATH_LIST_SEP);
         for (const auto& houdiniPath : houdiniPaths) {
+            if (houdiniPath == "&")
+                continue;
             const auto dsoPath = houdiniPath + ARCH_PATH_SEP + "python2.7libs" + ARCH_PATH_SEP + "_htoa_pygeo" +
 // HTOA sets this library's extension to .so even on linux.
 #ifdef ARCH_OS_WINDOWS

--- a/render_delegate/volume.cpp
+++ b/render_delegate/volume.cpp
@@ -38,6 +38,8 @@
 #include "openvdb_asset.h"
 #include "utils.h"
 
+#include <iostream>
+
 #ifdef BUILD_HOUDINI_TOOLS
 #include <pxr/base/arch/defines.h>
 #include <pxr/base/arch/env.h>
@@ -123,6 +125,7 @@ struct HtoAFnSet {
         }
 
         if (htoaPygeo == nullptr) {
+            std::cout << "[HdArnold] Cannot load htoa_pygeo required for volume rendering in Solaris" << std::endl;
             return;
         }
 


### PR DESCRIPTION
Fix parsing of HOUDINI_PATH.  This allows the path separator to contain ; on OSX for example.

On windows the path may contain : in the path e.g. C:\plugin_path so here ; is used as the separator.  But ; may still be used on non-windows.