### PR TITLE
Write Arnold nodes as USD builtins when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ custom*.py
 dist
 build
 install
+bin
+lib
+include
+procedural
 
 # Eclipse
 .settings

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -196,7 +196,7 @@ const ParamConversionMap& _ParamConversionMap()
 class UsdArnoldBuiltinParamWriter
 {
 public:
-    UsdArnoldBuiltinParamWriter(const AtNode *node, UsdPrim &prim, const AtParamEntry *paramEntry, UsdAttribute &attr) : 
+    UsdArnoldBuiltinParamWriter(const AtNode *node, UsdPrim &prim, const AtParamEntry *paramEntry, const UsdAttribute &attr) : 
                     _node(node),
                     _prim(prim),
                     _paramEntry(paramEntry), 
@@ -221,7 +221,7 @@ private:
     const AtNode *_node;
     UsdPrim &_prim;
     const AtParamEntry *_paramEntry;
-    UsdAttribute &_attr;
+    UsdAttribute _attr;
 };
 
 /** 
@@ -611,7 +611,7 @@ void UsdArnoldWriteUnsupported::write(const AtNode* node, UsdArnoldWriter& write
     AiMsgWarning("UsdArnoldWriter : %s nodes not supported, cannot write %s", _type.c_str(), AiNodeGetName(node));
 }
 
-bool UsdArnoldPrimWriter::writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, UsdAttribute &attr, UsdArnoldWriter &writer)
+bool UsdArnoldPrimWriter::writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer)
 {
     const AtParamEntry* paramEntry = AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), AtString(paramName));
     if (!paramEntry)

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -227,12 +227,216 @@ std::string UsdArnoldPrimWriter::GetArnoldNodeName(const AtNode* node)
     return name;
 }
 
+/** 
+ *   Internal function to convert an arnold attribute to USD, whether it's an existing UsdAttribute or 
+ *   a custom one that we need to create
+ **/
+
+bool UsdArnoldPrimWriter::writeAttribute(const AtNode *node, const AtParamEntry *paramEntry, UsdPrim &prim, UsdArnoldWriter &writer, UsdAttribute *usdAttr, const std::string &scope, bool writeDefaultValues)
+{
+    int paramType = AiParamGetType(paramEntry);
+    const char* paramName(AiParamGetName(paramEntry));
+    UsdAttribute attr;
+    bool createAttr = true;
+    
+    if (usdAttr) {
+        createAttr = false;
+        attr = *usdAttr;
+    }
+
+    std::string usdParamName = (scope.empty()) ? std::string(paramName) : scope + std::string(":") + std::string(paramName);
+
+    if (paramType == AI_TYPE_ARRAY) {
+        AtArray* array = AiNodeGetArray(node, paramName);
+        if (array == nullptr) {
+            return false;
+        }
+        int arrayType = AiArrayGetType(array);
+        unsigned int arraySize = AiArrayGetNumElements(array);
+        if (arraySize == 0) {
+            return false;
+        }
+
+        SdfValueTypeName usdTypeName;
+
+        switch (arrayType) {
+            {
+                case AI_TYPE_BYTE:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->UCharArray, false);
+                    VtArray<unsigned char> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        vtArr[i] = AiArrayGetByte(array, i);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_INT:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->IntArray, false);
+                    VtArray<int> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        vtArr[i] = AiArrayGetInt(array, i);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_UINT:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->UIntArray, false);
+                    VtArray<unsigned int> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        vtArr[i] = AiArrayGetUInt(array, i);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_BOOLEAN:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->BoolArray, false);
+                    VtArray<bool> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        vtArr[i] = AiArrayGetBool(array, i);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_FLOAT:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->FloatArray, false);
+                    VtArray<float> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        vtArr[i] = AiArrayGetFlt(array, i);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_RGB:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Color3fArray, false);
+                    VtArray<GfVec3f> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtRGB col = AiArrayGetRGB(array, i);
+                        vtArr[i] = GfVec3f(col.r, col.g, col.b);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_VECTOR:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Vector3fArray, false);
+                    VtArray<GfVec3f> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtVector vec = AiArrayGetVec(array, i);
+                        vtArr[i] = GfVec3f(vec.x, vec.y, vec.z);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_RGBA:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Color4fArray, false);
+                    VtArray<GfVec4f> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtRGBA col = AiArrayGetRGBA(array, i);
+                        vtArr[i] = GfVec4f(col.r, col.g, col.b, col.a);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_VECTOR2:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Float2Array, false);
+                    VtArray<GfVec2f> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtVector2 vec = AiArrayGetVec2(array, i);
+                        vtArr[i] = GfVec2f(vec.x, vec.y);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_STRING:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->StringArray, false);
+                    VtArray<std::string> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtString str = AiArrayGetStr(array, i);
+                        vtArr[i] = str.c_str();
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_MATRIX:
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Matrix4dArray, false);
+                    VtArray<GfMatrix4d> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        const AtMatrix mat = AiArrayGetMtx(array, i);
+                        GfMatrix4f matFlt(mat.data);
+                        vtArr[i] = GfMatrix4d(matFlt);
+                    }
+                    attr.Set(vtArr);
+                    break;
+            }
+            {
+                case AI_TYPE_NODE:
+                    // only export the first element for now
+                    if (createAttr)
+                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->StringArray, false);
+                    VtArray<std::string> vtArr(arraySize);
+                    for (unsigned int i = 0; i < arraySize; ++i) {
+                        AtNode* target = (AtNode*)AiArrayGetPtr(array, i);
+                        vtArr[i] = (target) ? AiNodeGetName(target) : "";
+                    }
+                    attr.Set(vtArr);
+            }
+        }
+    } else {
+        const auto iterType = getParamConversion(paramType);
+
+        bool isLinked = AiNodeIsLinked(node, paramName);
+
+        if (!writeDefaultValues) {
+            if (!isLinked && iterType != nullptr && iterType->d(node, paramName, AiParamGetDefault(paramEntry))) {
+                return false;
+            }
+        }
+        
+        if (createAttr)
+            attr = prim.CreateAttribute(TfToken(usdParamName), iterType->type, false);
+        
+
+        if (iterType != nullptr && iterType->f != nullptr) {
+            attr.Set(iterType->f(node, paramName));
+        }
+        if (isLinked) {
+            AtNode* target = AiNodeGetLink(node, paramName);
+            if (target) {
+                writer.writePrimitive(target);
+                attr.AddConnection(SdfPath(GetArnoldNodeName(target)));
+            }
+        }
+    }
+    return true;
+
+}
 void UsdArnoldPrimWriter::writeArnoldParameters(
     const AtNode* node, UsdArnoldWriter& writer, UsdPrim& prim, const std::string& scope)
 {
     // Loop over the arnold parameters, and write them
     const AtNodeEntry* nodeEntry = AiNodeGetNodeEntry(node);
     AtParamIterator* paramIter = AiNodeEntryGetParamIterator(nodeEntry);
+    std::unordered_set<std::string> attrs;
 
     while (!AiParamIteratorFinished(paramIter)) {
         const AtParamEntry* paramEntry = AiParamIteratorGetNext(paramIter);
@@ -240,179 +444,17 @@ void UsdArnoldPrimWriter::writeArnoldParameters(
         if (strcmp(paramName, "name") == 0) { // "name" is an exception and shouldn't be saved
             continue;
         }
+        // This parameter was already exported, let's skip it
+        if (!_exportedAttrs.empty() && std::find(_exportedAttrs.begin(), _exportedAttrs.end(), std::string(paramName)) != _exportedAttrs.end())
+          continue;
 
-        int paramType = AiParamGetType(paramEntry);
-        // for now all attributes are in the "arnold:" namespace
-        std::string usdParamName =
-            (scope.empty()) ? std::string(paramName) : scope + std::string(":") + std::string(paramName);
-
-        if (paramType == AI_TYPE_ARRAY) {
-            AtArray* array = AiNodeGetArray(node, paramName);
-            if (array == nullptr) {
-                continue;
-            }
-            int arrayType = AiArrayGetType(array);
-            unsigned int arraySize = AiArrayGetNumElements(array);
-            if (arraySize == 0) {
-                continue; // no need to export empty arrays
-            }
-
-            UsdAttribute attr;
-            SdfValueTypeName usdTypeName;
-
-            switch (arrayType) {
-                {
-                    case AI_TYPE_BYTE:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->UCharArray, false);
-                        VtArray<unsigned char> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            vtArr[i] = AiArrayGetByte(array, i);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_INT:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->IntArray, false);
-                        VtArray<int> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            vtArr[i] = AiArrayGetInt(array, i);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_UINT:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->UIntArray, false);
-                        VtArray<unsigned int> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            vtArr[i] = AiArrayGetUInt(array, i);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_BOOLEAN:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->BoolArray, false);
-                        VtArray<bool> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            vtArr[i] = AiArrayGetBool(array, i);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_FLOAT:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->FloatArray, false);
-                        VtArray<float> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            vtArr[i] = AiArrayGetFlt(array, i);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_RGB:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Color3fArray, false);
-                        VtArray<GfVec3f> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtRGB col = AiArrayGetRGB(array, i);
-                            vtArr[i] = GfVec3f(col.r, col.g, col.b);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_VECTOR:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Vector3fArray, false);
-                        VtArray<GfVec3f> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtVector vec = AiArrayGetVec(array, i);
-                            vtArr[i] = GfVec3f(vec.x, vec.y, vec.z);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_RGBA:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Color4fArray, false);
-                        VtArray<GfVec4f> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtRGBA col = AiArrayGetRGBA(array, i);
-                            vtArr[i] = GfVec4f(col.r, col.g, col.b, col.a);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_VECTOR2:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Float2Array, false);
-                        VtArray<GfVec2f> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtVector2 vec = AiArrayGetVec2(array, i);
-                            vtArr[i] = GfVec2f(vec.x, vec.y);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_STRING:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->StringArray, false);
-                        VtArray<std::string> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtString str = AiArrayGetStr(array, i);
-                            vtArr[i] = str.c_str();
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_MATRIX:
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->Matrix4dArray, false);
-                        VtArray<GfMatrix4d> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            const AtMatrix mat = AiArrayGetMtx(array, i);
-                            GfMatrix4f matFlt(mat.data);
-                            vtArr[i] = GfMatrix4d(matFlt);
-                        }
-                        attr.Set(vtArr);
-                        break;
-                }
-                {
-                    case AI_TYPE_NODE:
-                        // only export the first element for now
-                        attr = prim.CreateAttribute(TfToken(usdParamName), SdfValueTypeNames->StringArray, false);
-                        VtArray<std::string> vtArr(arraySize);
-                        for (unsigned int i = 0; i < arraySize; ++i) {
-                            AtNode* target = (AtNode*)AiArrayGetPtr(array, i);
-                            vtArr[i] = (target) ? AiNodeGetName(target) : "";
-                        }
-                        attr.Set(vtArr);
-                }
-            }
-        } else {
-            const auto iterType = getParamConversion(paramType);
-
-            bool isLinked = AiNodeIsLinked(node, paramName);
-
-            if (!isLinked && iterType != nullptr && iterType->d(node, paramName, AiParamGetDefault(paramEntry))) {
-                continue; // default value, no need to write it
-            }
-
-            UsdAttribute attr = prim.CreateAttribute(TfToken(usdParamName), iterType->type, false);
-            if (iterType != nullptr && iterType->f != nullptr) {
-                attr.Set(iterType->f(node, paramName));
-            }
-            if (isLinked) {
-                AtNode* target = AiNodeGetLink(node, paramName);
-                if (target) {
-                    writer.writePrimitive(target);
-                    attr.AddConnection(SdfPath(GetArnoldNodeName(target)));
-                }
-            }
-        }
+        attrs.insert(paramName);
+        writeAttribute(node, paramEntry, prim, writer, nullptr, scope, false);
     }
     AiParamIteratorDestroy(paramIter);
+
+    // Remember that all these attributes were exported to USD
+    _exportedAttrs.insert(attrs.begin(), attrs.end());
 }
 //=================  Unsupported primitives
 /**
@@ -427,4 +469,35 @@ void UsdArnoldWriteUnsupported::write(const AtNode* node, UsdArnoldWriter& write
     }
 
     AiMsgWarning("UsdArnoldWriter : %s nodes not supported, cannot write %s", _type.c_str(), AiNodeGetName(node));
+}
+
+bool UsdArnoldPrimWriter::writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, UsdAttribute &attr, UsdArnoldWriter &writer)
+{
+    const AtParamEntry* paramEntry = AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), AtString(paramName));
+    if (!paramEntry)
+        return false;
+
+    writeAttribute(node, paramEntry, prim, writer, &attr);
+    _exportedAttrs.insert(std::string(paramName)); // remember that we've explicitely exported this arnold attribute
+
+
+    return true;
+}
+
+void UsdArnoldPrimWriter::writeMatrix(UsdGeomXformable &xformable, const AtNode *node, UsdArnoldWriter &writer)
+{
+    AtMatrix matrix = AiNodeGetMatrix(node, "matrix");
+    _exportedAttrs.insert("matrix");
+
+    if (AiM4IsIdentity(matrix))
+        return; // no need to set this matrix
+
+    UsdGeomXformOp xformOp = xformable.MakeMatrixXform();
+
+    double m[4][4];
+    for (unsigned int i = 0; i < 4; ++i)
+        for (unsigned int j = 0; j < 4; ++j)
+            m[i][j] = matrix[i][j];
+
+    xformOp.Set(GfMatrix4d(m));
 }

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -60,7 +60,7 @@ public:
     // converted to USD
     static std::string GetArnoldNodeName(const AtNode *node);
     
-    bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, UsdAttribute &attr, UsdArnoldWriter &writer);
+    bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
 
 protected:

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -19,7 +19,7 @@
 #include <ai_params.h>
 
 #include <pxr/usd/usd/prim.h>
-
+#include <pxr/usd/usdGeom/xformable.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -59,9 +59,19 @@ public:
     // This function returns the name we want to give to this AtNode when it's
     // converted to USD
     static std::string GetArnoldNodeName(const AtNode *node);
+    
+    bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, UsdAttribute &attr, UsdArnoldWriter &writer);
+    void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
 
 protected:
-    void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
+    bool writeAttribute(const AtNode *node, const AtParamEntry *paramEntry, UsdPrim &prim, UsdArnoldWriter &writer, 
+            UsdAttribute *usdAttr = nullptr, const std::string &scope = "", bool writeDefaultValues = true);
+
+    void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
+
+    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported 
+
+    
 };
 
 /**

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -64,9 +64,7 @@ public:
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
 
 protected:
-    bool writeAttribute(const AtNode *node, const AtParamEntry *paramEntry, UsdPrim &prim, UsdArnoldWriter &writer, 
-            UsdAttribute *usdAttr = nullptr, const std::string &scope = "", bool writeDefaultValues = true);
-
+        
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
 
     std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported 

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -19,8 +19,7 @@
 #include "write_arnold_type.h"
 #include "write_shader.h"
 #include "write_light.h"
-
-
+#include "write_geometry.h"
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -31,33 +30,23 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 // For now we're not registering any writer
-UsdArnoldWriterRegistry::UsdArnoldWriterRegistry()
+UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
 {
     // TODO: write to builtin USD types. For now we're creating these nodes as
     // Arnold-Typed primitives at the end of this function
-    /*
-       // First, let's register all the prim writers that we've hardcoded for
-       USD builtin types registerWriter("polymesh", new UsdArnoldWriteMesh());
-       registerWriter("curves", new UsdArnoldWriteCurves());
-       registerWriter("points", new UsdArnoldWritePoints());
-       registerWriter("box", new UsdArnoldWriteCube());
-       registerWriter("sphere", new UsdArnoldWritephere());
-       registerWriter("cylinder", new UsdArnoldWriteCylinder());
-       registerWriter("cone", new UsdArnoldWriteCone());
-       registerWriter("nurbs", new UsdArnoldWriteUnsupported("nurbs"));
-
-       // Arnold nodes that can be exported as USD builtin Lights
-       
-       ;
     
-       
-    */
-    registerWriter("distant_light", new UsdArnoldWriteDistantLight());
-    registerWriter("skydome_light", new UsdArnoldWriteDomeLight());
-    registerWriter("disk_light", new UsdArnoldWriteDiskLight());
-    registerWriter("point_light", new UsdArnoldWriteSphereLight());
-    registerWriter("quad_light", new UsdArnoldWriteRectLight());
-    registerWriter("mesh_light", new UsdArnoldWriteGeometryLight());
+    if (writeBuiltin)
+    {
+        registerWriter("polymesh", new UsdArnoldWriteMesh());
+    
+        // Register light writers
+        registerWriter("distant_light", new UsdArnoldWriteDistantLight());
+        registerWriter("skydome_light", new UsdArnoldWriteDomeLight());
+        registerWriter("disk_light", new UsdArnoldWriteDiskLight());
+        registerWriter("point_light", new UsdArnoldWriteSphereLight());
+        registerWriter("quad_light", new UsdArnoldWriteRectLight());
+        registerWriter("mesh_light", new UsdArnoldWriteGeometryLight());
+    }
 
     // Now let's iterate over all the arnold classes known at this point
     bool universeCreated = false;

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -18,6 +18,8 @@
 #include "../utils/utils.h"
 #include "write_arnold_type.h"
 #include "write_shader.h"
+#include "write_light.h"
+
 
 #include <cstdio>
 #include <cstring>
@@ -45,13 +47,17 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry()
        registerWriter("nurbs", new UsdArnoldWriteUnsupported("nurbs"));
 
        // Arnold nodes that can be exported as USD builtin Lights
-       registerWriter("distant_light", new UsdArnoldWriteDistantLight());
-       registerWriter("skydome_light", new UsdArnoldWriteDomeLight());
-       registerWriter("disk_light", new UsdArnoldWriteDiskLight());
-       registerWriter("point_light", new UsdArnoldWriteSphereLight());
-       registerWriter("quad_light", new UsdArnoldWriteRectLight());
-       registerWriter("mesh_light", new UsdArnoldWriteGeometryLight());
+       
+       ;
+    
+       
     */
+    registerWriter("distant_light", new UsdArnoldWriteDistantLight());
+    registerWriter("skydome_light", new UsdArnoldWriteDomeLight());
+    registerWriter("disk_light", new UsdArnoldWriteDiskLight());
+    registerWriter("point_light", new UsdArnoldWriteSphereLight());
+    registerWriter("quad_light", new UsdArnoldWriteRectLight());
+    registerWriter("mesh_light", new UsdArnoldWriteGeometryLight());
 
     // Now let's iterate over all the arnold classes known at this point
     bool universeCreated = false;

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -38,6 +38,8 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
     if (writeBuiltin)
     {
         registerWriter("polymesh", new UsdArnoldWriteMesh());
+        registerWriter("curves", new UsdArnoldWriteCurves());
+        registerWriter("points", new UsdArnoldWritePoints());
     
         // Register light writers
         registerWriter("distant_light", new UsdArnoldWriteDistantLight());

--- a/translator/writer/registry.h
+++ b/translator/writer/registry.h
@@ -33,7 +33,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 class UsdArnoldWriterRegistry {
 public:
-    UsdArnoldWriterRegistry();
+    UsdArnoldWriterRegistry(bool writeBuiltin = true);
     virtual ~UsdArnoldWriterRegistry();
 
     // Register a new prim writer to this type of usd primitive.

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "write_geometry.h"
+
+#include <ai.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usdGeom/mesh.h>
+
+
+//-*************************************************************************
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdGeomMesh mesh = UsdGeomMesh::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = mesh.GetPrim();
+
+    writeMatrix(mesh, node, writer);    
+    mesh.GetOrientationAttr().Set(UsdGeomTokens->rightHanded);
+    AtArray *vidxs = AiNodeGetArray(node, "vidxs");
+    if (vidxs) {
+        unsigned int nelems = AiArrayGetNumElements(vidxs);
+        VtArray<int> vtArr(nelems);
+        for (unsigned int i = 0; i < nelems; ++i) {
+            vtArr[i] = (int)AiArrayGetUInt(vidxs, i);
+        }
+        mesh.GetFaceVertexIndicesAttr().Set(vtArr);
+        _exportedAttrs.insert("vidxs");
+    }
+    AtArray *nsides = AiNodeGetArray(node, "nsides");
+    if (nsides) {
+        unsigned int nelems = AiArrayGetNumElements(nsides);
+        VtArray<int> vtArr(nelems);
+        for (unsigned int i = 0; i < nelems; ++i) {
+            vtArr[i] = (unsigned char) AiArrayGetUInt(nsides, i);
+        }
+        mesh.GetFaceVertexCountsAttr().Set(vtArr);
+        _exportedAttrs.insert("nsides");
+    }
+
+    writeAttribute(node, "vlist", prim, mesh.GetPointsAttr(), writer);    
+    writeMatrix(mesh, node, writer);
+    // TODO : export material binding
+    writeArnoldParameters(node, writer, prim, "arnold");
+}

--- a/translator/writer/write_geometry.h
+++ b/translator/writer/write_geometry.h
@@ -27,3 +27,5 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 // Register writers for USD builtin geometries
 REGISTER_PRIM_WRITER(UsdArnoldWriteMesh);
+REGISTER_PRIM_WRITER(UsdArnoldWriteCurves);
+REGISTER_PRIM_WRITER(UsdArnoldWritePoints);

--- a/translator/writer/write_geometry.h
+++ b/translator/writer/write_geometry.h
@@ -1,0 +1,29 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ai_nodes.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "prim_writer.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// Register writers for USD builtin geometries
+REGISTER_PRIM_WRITER(UsdArnoldWriteMesh);

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -1,0 +1,220 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "write_light.h"
+
+#include <ai.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usdGeom/mesh.h>
+#include <pxr/usd/usdLux/diskLight.h>
+#include <pxr/usd/usdLux/distantLight.h>
+#include <pxr/usd/usdLux/domeLight.h>
+#include <pxr/usd/usdLux/geometryLight.h>
+#include <pxr/usd/usdLux/rectLight.h>
+#include <pxr/usd/usdLux/sphereLight.h>
+
+
+//-*************************************************************************
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static void writeLightCommon(const AtNode *node, UsdLuxLight &light, UsdArnoldPrimWriter &primWriter, UsdArnoldWriter &writer)
+{
+    UsdPrim prim = light.GetPrim();
+    primWriter.writeAttribute(node, "intensity", prim, light.GetIntensityAttr(), writer);
+    primWriter.writeAttribute(node, "exposure", prim, light.GetExposureAttr(), writer);
+    primWriter.writeAttribute(node, "color", prim, light.GetColorAttr(), writer);
+    primWriter.writeAttribute(node, "diffuse", prim, light.GetDiffuseAttr(), writer);
+    primWriter.writeAttribute(node, "specular", prim, light.GetSpecularAttr(), writer);
+}
+
+void UsdArnoldWriteDistantLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxDistantLight light = UsdLuxDistantLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeAttribute(node, "angle", prim, light.GetAngleAttr(), writer);
+    writeLightCommon(node, light, *this, writer);
+    writeMatrix(light, node, writer);    
+    writeArnoldParameters(node, writer, prim, "arnold");
+}
+
+void UsdArnoldWriteDomeLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeLightCommon(node, light, *this, writer);
+    writeMatrix(light, node, writer);    
+
+    AtNode *linkedTexture = AiNodeGetLink(node, "color");
+    static AtString imageStr("image");
+    if (linkedTexture && AiNodeIs(linkedTexture, imageStr))
+    {
+        // a texture is connected to the color attribute, so we want to export it to 
+        // the Dome's TextureFile attribute
+        AtString filename = AiNodeGetStr(linkedTexture, "filename");
+        SdfAssetPath assetPath(filename.c_str());
+        light.GetTextureFileAttr().Set(assetPath);
+        light.GetColorAttr().ClearConnections();
+        light.GetColorAttr().Set(GfVec3f(1.f, 1.f, 1.f));
+        _exportedAttrs.insert("color");
+    }
+    AtString textureFormat = AiNodeGetStr(node, "format");
+    static AtString latlongStr("latlong");
+    static AtString mirrored_ballStr("mirrored_ball");
+    static AtString angularStr("angular");
+    if (textureFormat == latlongStr)
+        light.GetTextureFormatAttr().Set(UsdLuxTokens->latlong);
+    else if (textureFormat == mirrored_ballStr)
+        light.GetTextureFormatAttr().Set(UsdLuxTokens->mirroredBall);
+    else if (textureFormat == angularStr)
+        light.GetTextureFormatAttr().Set(UsdLuxTokens->angular);
+
+    _exportedAttrs.insert("format");
+
+    writeArnoldParameters(node, writer, prim, "arnold");
+
+}
+
+void UsdArnoldWriteDiskLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeLightCommon(node, light, *this, writer);
+    writeAttribute(node, "radius", prim, light.GetRadiusAttr(), writer);
+    writeAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
+    writeMatrix(light, node, writer);    
+    writeArnoldParameters(node, writer, prim, "arnold");
+}
+
+void UsdArnoldWriteSphereLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeLightCommon(node, light, *this, writer);
+
+    float radius = AiNodeGetFlt(node, "radius");
+    if (radius > AI_EPSILON) {
+        light.GetTreatAsPointAttr().Set(false);
+        writeAttribute(node, "radius", prim, light.GetRadiusAttr(), writer);
+        writeAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
+    } else {
+        light.GetTreatAsPointAttr().Set(true);
+        _exportedAttrs.insert("radius");
+    }
+    
+    writeMatrix(light, node, writer);    
+    writeArnoldParameters(node, writer, prim, "arnold");
+}
+
+void UsdArnoldWriteRectLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxRectLight light = UsdLuxRectLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeLightCommon(node, light, *this, writer);
+    
+    writeMatrix(light, node, writer); 
+    writeAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
+
+    AtNode *linkedTexture = AiNodeGetLink(node, "color");
+    static AtString imageStr("image");
+    if (linkedTexture && AiNodeIs(linkedTexture, imageStr))
+    {
+        // a texture is connected to the color attribute, so we want to export it to 
+        // the Dome's TextureFile attribute
+        AtString filename = AiNodeGetStr(linkedTexture, "filename");
+        SdfAssetPath assetPath(filename.c_str());
+        light.GetTextureFileAttr().Set(assetPath);
+        light.GetColorAttr().ClearConnections();
+        light.GetColorAttr().Set(GfVec3f(1.f, 1.f, 1.f));
+        _exportedAttrs.insert("color");
+    }
+
+    float width = 1.f;
+    float height = 1.f;
+
+    AtArray *vertices = AiNodeGetArray(node, "vertices");
+    if (vertices && AiArrayGetNumElements(vertices) >= 4) {
+        // Note that we can only export the simplest case to USD.
+        // Since the arnold attribute allows to do more than UsdLuxRectLight,
+        // we're not adding "vertices" to the list of exported nodes, so that it will
+        // also be exported with the arnold: namespace (if not default)
+        
+        AtVector vertexPos[4];
+        AtVector maxVertex(-AI_INFINITE, -AI_INFINITE, -AI_INFINITE);
+        AtVector minVertex(AI_INFINITE, AI_INFINITE, AI_INFINITE);
+        for (int i = 0; i < 4; ++i) {
+            vertexPos[i] = AiArrayGetVec(vertices, i);
+            maxVertex.x = AiMax(maxVertex.x, vertexPos[i].x);
+            minVertex.x = AiMin(minVertex.x, vertexPos[i].x);
+            maxVertex.y = AiMax(maxVertex.y, vertexPos[i].y);
+            minVertex.y = AiMin(minVertex.y, vertexPos[i].y);
+            maxVertex.z = AiMax(maxVertex.z, vertexPos[i].z);
+            minVertex.z = AiMin(minVertex.z, vertexPos[i].z);
+        }
+        width = maxVertex.x - minVertex.x;
+        height = maxVertex.y - minVertex.y;
+
+        light.GetWidthAttr().Set(width);
+        light.GetHeightAttr().Set(height);
+    }
+    
+    writeArnoldParameters(node, writer, prim, "arnold");    
+
+}
+
+void UsdArnoldWriteGeometryLight::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
+    
+    UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = light.GetPrim();
+
+    writeLightCommon(node, light, *this, writer);
+    writeAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
+    writeMatrix(light, node, writer);    
+
+    AtNode *mesh = (AtNode*)AiNodeGetPtr(node, "mesh");
+    if (mesh)
+    {
+        writer.writePrimitive(mesh);
+        std::string meshName = GetArnoldNodeName(mesh);
+        light.CreateGeometryRel().AddTarget(SdfPath(meshName));
+    }
+    writeArnoldParameters(node, writer, prim, "arnold");
+}

--- a/translator/writer/write_light.h
+++ b/translator/writer/write_light.h
@@ -1,0 +1,34 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ai_nodes.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "prim_writer.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// Register writers for the USD builtin lights
+REGISTER_PRIM_WRITER(UsdArnoldWriteDistantLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteDomeLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteDiskLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteSphereLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteRectLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteGeometryLight);

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -46,7 +46,7 @@ void UsdArnoldWriter::write(const AtUniverse *universe)
     if (_registry == NULL) {
         // No registry was set (default), let's use the global one
         if (s_writerRegistry == NULL) {
-            s_writerRegistry = new UsdArnoldWriterRegistry(); // initialize the global registry
+            s_writerRegistry = new UsdArnoldWriterRegistry(_writeBuiltin); // initialize the global registry
         }
         _registry = s_writerRegistry;
     }

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -32,7 +32,7 @@ class UsdArnoldWriterRegistry;
 
 class UsdArnoldWriter {
 public:
-    UsdArnoldWriter() : _universe(NULL), _registry(NULL) {}
+    UsdArnoldWriter() : _universe(NULL), _registry(NULL), _writeBuiltin(true) {}
     ~UsdArnoldWriter() {}
 
     void write(const AtUniverse *universe);  // convert a given arnold universe
@@ -46,9 +46,14 @@ public:
     void setUniverse(const AtUniverse *universe) { _universe = universe; }
     const AtUniverse *getUniverse() const { return _universe; }
 
+    void setWriteBuiltin(bool b) { _writeBuiltin = b;}
+    bool getWriteBuiltin() const { return _writeBuiltin;}
+
+
 private:
     const AtUniverse *_universe;        // Arnold universe to be converted
     UsdArnoldWriterRegistry *_registry; // custom registry used for this writer. If null, a global
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
+    bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
Modify the writer module so that it can convert some arnold nodes (geometries, lights), as USD builtin nodes, instead of always creating Arnold-specific schemas.

**Issues fixed in this pull request**
Fixes #39 

**Additional context**
This is a first draft, that is still missing some rarely used arnold shapes (cube, sphere, cylinder), and also material bindings. We can address this in future tickets. 
