### PR TITLE
Changing the type of progressive_min_AA_samples from bool to int.

### DIFF
--- a/render_delegate/config.h
+++ b/render_delegate/config.h
@@ -113,7 +113,7 @@ public:
 
     /// Use HDARNOLD_progressive_min_AA_samples to set the value.
     ///
-    bool progressive_min_AA_samples;
+    int progressive_min_AA_samples;
 
     /// Use HDARNOLD_enable_adaptive_sampling to set the value.
     ///


### PR DESCRIPTION
Changing the type of progressive_min_AA_samples from bool to int.

**Changes proposed in this pull request**
- Changing the type of progressive_min_AA_samples from bool to int.

**Issues fixed in this pull request**
Fixes #131