### PR TITLE
Checking for root layer validity when loading the file.

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -62,6 +62,10 @@ void UsdArnoldReader::read(const std::string &filename, AtArray *overrides, cons
     }
 
     SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(filename);
+    if (rootLayer == nullptr) {
+        AiMsgError("[usd] Failed to open file (%s)", filename.c_str());
+        return;
+    }
 
     if (overrides == nullptr || AiArrayGetNumElements(overrides) == 0) {
         UsdStageRefPtr stage = UsdStage::Open(rootLayer, UsdStage::LoadAll);


### PR DESCRIPTION
**Changes proposed in this pull request**
- When the reader loads the file, we are returning early if the rootLayer is nullptr.

**Issues fixed in this pull request**
Fixes #74