### PR TITLE
Writer clears the list of exported attributes for every node

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -354,13 +354,24 @@ const UsdArnoldPrimWriter::ParamConversion* UsdArnoldPrimWriter::getParamConvers
         return nullptr;
     }
 }
+/** 
+ *    Function invoked from the UsdArnoldWriter that exports an input arnold node to USD
+ **/ 
+void UsdArnoldPrimWriter::writeNode(const AtNode *node, UsdArnoldWriter &writer)
+{
+    // we're exporting a new node, 
+    // se we can clear the list of already exported attributes
+    _exportedAttrs.clear();
 
+    // Now call the virtual function write() defined for each primitive type
+    write(node, writer); 
+}
 /**
  *    Get the USD node name for this Arnold node. We need to replace the
  *forbidden characters from the names. Also, we must ensure that the first
  *character is a slash
  **/
-std::string UsdArnoldPrimWriter::GetArnoldNodeName(const AtNode* node)
+std::string UsdArnoldPrimWriter::getArnoldNodeName(const AtNode* node)
 {
     std::string name = AiNodeGetName(node);
     if (name.empty()) {
@@ -544,7 +555,7 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
             AtNode* target = AiNodeGetLink(node, paramName);
             if (target) {
                 writer.writePrimitive(target);
-                attrWriter.AddConnection(SdfPath(UsdArnoldPrimWriter::GetArnoldNodeName(target)));
+                attrWriter.AddConnection(SdfPath(UsdArnoldPrimWriter::getArnoldNodeName(target)));
             }
         }
     }

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -37,9 +37,9 @@ class UsdArnoldPrimWriter {
 public:
     UsdArnoldPrimWriter() {}
     virtual ~UsdArnoldPrimWriter() {}
-
-    virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;
-
+    
+    void writeNode(const AtNode *node, UsdArnoldWriter &writer);
+    
     // Helper structure to convert parameters
     struct ParamConversion {
         const SdfValueTypeName &type;
@@ -58,18 +58,16 @@ public:
     static const ParamConversion *getParamConversion(uint8_t type);
     // This function returns the name we want to give to this AtNode when it's
     // converted to USD
-    static std::string GetArnoldNodeName(const AtNode *node);
-    
+    static std::string getArnoldNodeName(const AtNode *node);
     bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
-    void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
+    
 
 protected:
-        
+    virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;        
+    void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
-
-    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported 
-
     
+    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported     
 };
 
 /**
@@ -89,6 +87,6 @@ private:
 // Helper macro for prim writers
 #define REGISTER_PRIM_WRITER(name)                                        \
     class name : public UsdArnoldPrimWriter {                             \
-    public:                                                               \
+    protected:                                                               \
         void write(const AtNode *node, UsdArnoldWriter &writer) override; \
     };

--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -42,7 +42,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
  **/
 void UsdArnoldWriteArnoldType::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what should be the name of this USD primitive
+    std::string nodeName = getArnoldNodeName(node); // what should be the name of this USD primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
 

--- a/translator/writer/write_arnold_type.h
+++ b/translator/writer/write_arnold_type.h
@@ -38,6 +38,7 @@ public:
         : UsdArnoldPrimWriter(), _entryName(entryName), _usdName(usdName), _entryTypeName(entryTypeName)
     {
     }
+protected:
     void write(const AtNode *node, UsdArnoldWriter &writer) override;
 
 private:

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -31,7 +31,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdGeomMesh mesh = UsdGeomMesh::Define(stage, SdfPath(nodeName));
@@ -67,7 +67,7 @@ void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteCurves::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdGeomBasisCurves curves = UsdGeomBasisCurves::Define(stage, SdfPath(nodeName));
@@ -103,7 +103,7 @@ void UsdArnoldWriteCurves::write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWritePoints::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdGeomPoints points = UsdGeomPoints::Define(stage, SdfPath(nodeName));

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -45,7 +45,7 @@ static void writeLightCommon(const AtNode *node, UsdLuxLight &light, UsdArnoldPr
 
 void UsdArnoldWriteDistantLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxDistantLight light = UsdLuxDistantLight::Define(stage, SdfPath(nodeName));
@@ -59,7 +59,7 @@ void UsdArnoldWriteDistantLight::write(const AtNode *node, UsdArnoldWriter &writ
 
 void UsdArnoldWriteDomeLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, SdfPath(nodeName));
@@ -100,7 +100,7 @@ void UsdArnoldWriteDomeLight::write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteDiskLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, SdfPath(nodeName));
@@ -115,7 +115,7 @@ void UsdArnoldWriteDiskLight::write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteSphereLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, SdfPath(nodeName));
@@ -139,7 +139,7 @@ void UsdArnoldWriteSphereLight::write(const AtNode *node, UsdArnoldWriter &write
 
 void UsdArnoldWriteRectLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxRectLight light = UsdLuxRectLight::Define(stage, SdfPath(nodeName));
@@ -199,7 +199,7 @@ void UsdArnoldWriteRectLight::write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteGeometryLight::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
     
     UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, SdfPath(nodeName));
@@ -213,7 +213,7 @@ void UsdArnoldWriteGeometryLight::write(const AtNode *node, UsdArnoldWriter &wri
     if (mesh)
     {
         writer.writePrimitive(mesh);
-        std::string meshName = GetArnoldNodeName(mesh);
+        std::string meshName = getArnoldNodeName(mesh);
         light.CreateGeometryRel().AddTarget(SdfPath(meshName));
     }
     writeArnoldParameters(node, writer, prim, "arnold");

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -39,7 +39,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 void UsdArnoldWriteShader::write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = getArnoldNodeName(node); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.getUsdStage();    // Get the USD stage defined in the writer
 
     // Create the primitive of type Shader (UsdShadeShader)

--- a/translator/writer/write_shader.h
+++ b/translator/writer/write_shader.h
@@ -39,6 +39,7 @@ public:
         : UsdArnoldPrimWriter(), _entryName(entryName), _usdShaderId(usdShaderId)
     {
     }
+protected:
     void write(const AtNode *node, UsdArnoldWriter &writer) override;
 
 private:

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -81,7 +81,7 @@ void UsdArnoldWriter::writePrimitive(const AtNode *node)
 
     UsdArnoldPrimWriter *primWriter = _registry->getPrimWriter(objType);
     if (primWriter) {
-        primWriter->write(node, *this); // write this primitive
+        primWriter->writeNode(node, *this);
     }
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This is an alternative solution than PR #142 in order to fix the issue #145 .

Every time we write a new node to usd, we ensure that the previous list of already exported attributes is cleared. This list is meant to avoid duplication of usd builtin parameters and arnold-namespaced parameters. But we don't need to keep a long list accumulating all the exported node. 

Since every new primitive-writer defines a function `write` and since we don't want to clear the list inside each of these functions, I'm making it so that the `UsdArnoldWriter` calls a function `primWriter->writeNode(node)` that will always clear the list before calling the virtual function `write`. To ensure that nobody calls directly `write` I'm making it protected.

In this PR I'm also removing the capital in `UsdArnoldPrimWriter::GetArnoldNodeName` that doesn't follow the guidelines.

**Issues fixed in this pull request**
Fixes #145
