### PR TITLE
Add needed include for scene format plugins

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -191,6 +191,7 @@ node_loader
  *  and kick directly USD files
  **/
 #if AI_VERSION_ARCH_NUM >= 6 && AI_VERSION_MINOR_NUM >= 2
+#include <ai_scene_format.h>
 
 AI_SCENE_FORMAT_EXPORT_METHODS(UsdSceneFormatMtd);
 #include "writer.h"


### PR DESCRIPTION
**Changes proposed in this pull request**
Add the include that is needed to build scene format plugins as an experimental/unexposed API
This relates to #173 but doesn't fully address this issue, since we also need to change the version check by another test