### PR TITLE
Set _triggers_reload metadata on procedural attributes

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -39,11 +39,11 @@ node_parameters
     AiParameterArray("overrides", AiArray(0, 1, AI_TYPE_STRING));
 
     // Set metadata that triggers the re-generation of the procedural contents when this attribute
-    // is modified (see #176)    
+    // is modified (see #176)
     AiMetaDataSetBool(nentry, AtString("filename"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("object_path"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("frame"), AtString("_triggers_reload"), true);
-    AiMetaDataSetBool(nentry, AtString("overrides"), AtString("_triggers_reload"), true);    
+    AiMetaDataSetBool(nentry, AtString("overrides"), AtString("_triggers_reload"), true);
 }
 
 procedural_init

--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -37,6 +37,13 @@ node_parameters
     AiParameterBool("debug", false);
     AiParameterInt("threads", 1);
     AiParameterArray("overrides", AiArray(0, 1, AI_TYPE_STRING));
+
+    // Set metadata that triggers the re-generation of the procedural contents when this attribute
+    // is modified (see #176)    
+    AiMetaDataSetBool(nentry, AtString("filename"), AtString("_triggers_reload"), true);
+    AiMetaDataSetBool(nentry, AtString("object_path"), AtString("_triggers_reload"), true);
+    AiMetaDataSetBool(nentry, AtString("frame"), AtString("_triggers_reload"), true);
+    AiMetaDataSetBool(nentry, AtString("overrides"), AtString("_triggers_reload"), true);    
 }
 
 procedural_init


### PR DESCRIPTION
**Changes proposed in this pull request**
Set the metadata `_triggers_reload` in the procedural's attributes so that any change during IPR session clears the contents of the procedural so that they're re-generated at the next render. This is done similarly to what we have in the alembic procedural, and avoids handling this in each plugin.

In the future we'll want to be smarter, and update only what needs to be updated using the `procedural_update`  functions (see #168 ) , but for now we clear everything in order to have a correct render.

**Issues fixed in this pull request**
Fixes #176 