### PR TITLE
Export material bindings in the writer

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -21,14 +21,13 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 #include <pxr/usd/usdShade/material.h>
+#include <pxr/usd/usdShade/materialBindingAPI.h>
 #include <pxr/usd/usdShade/shader.h>
 
 #include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
-
-#include <pxr/usd/usdShade/materialBindingAPI.h>
 
 //-*************************************************************************
 
@@ -363,14 +362,14 @@ void UsdArnoldPrimWriter::writeNode(const AtNode *node, UsdArnoldWriter &writer)
 {
     // we're exporting a new node, so we store the previous list of exported 
     // attributes and we clear it for the new node being written
-    std::unordered_set<std::string> prevExportedAttrs = _exportedAttrs;
-    _exportedAttrs.clear();
+    decltype(_exportedAttrs) prevExportedAttrs;
+    prevExportedAttrs.swap(_exportedAttrs);
 
     // Now call the virtual function write() defined for each primitive type
     write(node, writer); 
 
     // restore the previous list (likely empty, unless there have been recursive creation of nodes)
-    _exportedAttrs = prevExportedAttrs;
+    _exportedAttrs.swap(prevExportedAttrs);
 }
 /**
  *    Get the USD node name for this Arnold node. We need to replace the
@@ -662,18 +661,28 @@ void UsdArnoldPrimWriter::writeMatrix(UsdGeomXformable &xformable, const AtNode 
 
 void UsdArnoldPrimWriter::writeMaterialBinding(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer)
 {
+    _exportedAttrs.insert("shader");
     AtNode *shader = (AtNode*) AiNodeGetPtr(node, "shader");
 
     static const AtString polymesh_str("polymesh");
     AtNode *displacement = (AiNodeIs(node, polymesh_str)) ?
         (AtNode*) AiNodeGetPtr(node, "disp_map"): nullptr;
 
-    if (shader == nullptr && displacement == nullptr)
-        return; // nothing to export
-
+    
     std::string shaderName = (shader) ? UsdArnoldPrimWriter::getArnoldNodeName(shader) : "";
     std::string dispName = (displacement) ? UsdArnoldPrimWriter::getArnoldNodeName(displacement) : "";
-    
+
+    // Special case : by default when no shader is assigned, the shader that is returned
+    // is the arnold default shader "ai_default_reflection_shader". Since it's an implicit node that
+    // isn't exported to arnold, we don't want to consider it
+    if (shaderName == "/ai_default_reflection_shader") {
+        shader = nullptr;
+        shaderName = "";
+    }
+ 
+    if (shader == nullptr && displacement == nullptr)
+        return; // nothing to export
+   
     // The material node doesn't exist in Arnold, but is required in USD, 
     // let's create one based on the name of the shader plus the name of 
     // the eventual displacement. This way we'll have a unique material in USD
@@ -681,11 +690,8 @@ void UsdArnoldPrimWriter::writeMaterialBinding(const AtNode *node, UsdPrim &prim
     // for every geometry.
     std::string materialName = "/materials";
     materialName += shaderName;
-
-    if (displacement) {
-        materialName += "_disp_";
-        materialName += dispName;
-    }
+    materialName += dispName;
+    
     // Note that if the material was already created, Define will just return
     // the existing one
     UsdShadeMaterial mat = UsdShadeMaterial::Define(writer.getUsdStage(), SdfPath(materialName));
@@ -698,15 +704,18 @@ void UsdArnoldPrimWriter::writeMaterialBinding(const AtNode *node, UsdPrim &prim
     if (shader) {
         writer.writePrimitive(shader); // ensure the shader exists in the USD stage    
         UsdShadeOutput surfaceOutput = mat.CreateSurfaceOutput(arnoldContext);
-        std::string surfaceTargetName = shaderName + std::string(".outputs:surface");
-        surfaceOutput.ConnectToSource(SdfPath(surfaceTargetName));
+        if (writer.getUsdStage()->GetPrimAtPath(SdfPath(shaderName))) {
+            std::string surfaceTargetName = shaderName + std::string(".outputs:surface");
+            surfaceOutput.ConnectToSource(SdfPath(surfaceTargetName));
+        }
     }
 
     if (displacement) {
         writer.writePrimitive(displacement); // ensure the displacement shader exists in USD
         UsdShadeOutput dispOutput = mat.CreateDisplacementOutput(arnoldContext);
-        std::string dispTargetName = shaderName + std::string(".outputs:displacement");
-        dispOutput.ConnectToSource(SdfPath(dispTargetName));
+        if (writer.getUsdStage()->GetPrimAtPath(SdfPath(dispName))) {
+            std::string dispTargetName = dispName + std::string(".outputs:displacement");
+            dispOutput.ConnectToSource(SdfPath(dispTargetName));
+        }
     }
-    _exportedAttrs.insert("shader");
 }

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -66,7 +66,7 @@ protected:
     virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;        
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
-    
+    void writeMaterialBinding(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer);
     std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported     
 };
 

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -61,7 +61,7 @@ void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
     }
 
     writeAttribute(node, "vlist", prim, mesh.GetPointsAttr(), writer);    
-    // TODO : export material binding
+    writeMaterialBinding(node, prim, writer);
     writeArnoldParameters(node, writer, prim, "primvars:arnold");
 }
 
@@ -96,7 +96,7 @@ void UsdArnoldWriteCurves::write(const AtNode *node, UsdArnoldWriter &writer)
     writeAttribute(node, "points", prim, curves.GetPointsAttr(), writer);    
     writeAttribute(node, "num_points", prim, curves.GetCurveVertexCountsAttr(), writer);    
     writeAttribute(node, "radius", prim, curves.GetWidthsAttr(), writer);    
-    // TODO : export material binding
+    writeMaterialBinding(node, prim, writer);
     writeArnoldParameters(node, writer, prim, "primvars:arnold");
 }
 
@@ -113,6 +113,6 @@ void UsdArnoldWritePoints::write(const AtNode *node, UsdArnoldWriter &writer)
 
     writeAttribute(node, "points", prim, points.GetPointsAttr(), writer);    
     writeAttribute(node, "radius", prim, points.GetWidthsAttr(), writer);    
-    // TODO : export material binding
+    writeMaterialBinding(node, prim, writer);
     writeArnoldParameters(node, writer, prim, "primvars:arnold");
 }

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -72,21 +72,24 @@ void UsdArnoldWriter::writePrimitive(const AtNode *node)
         return;
     }
 
-    std::string objName = AiNodeGetName(node);
+    AtString nodeName = AtString(AiNodeGetName(node));
+
+    static const AtString rootStr("root");
+    static const AtString ai_default_reflection_shaderStr("ai_default_reflection_shader");
 
     // some Arnold nodes shouldn't be saved
-    if (objName == "root" || objName == "ai_default_reflection_shader") {
+    if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr) {
         return;
     }
 
-    if (isNodeExported(objName))
+    if (isNodeExported(nodeName))
         return; // this node has already been exported, nothing to do
 
     std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
 
     UsdArnoldPrimWriter *primWriter = _registry->getPrimWriter(objType);
     if (primWriter) {
-        _exportedNodes.insert(objName); // remember that we already exported this node
+        _exportedNodes.insert(nodeName); // remember that we already exported this node
         primWriter->writeNode(node, *this);
     }
 }

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -50,6 +50,8 @@ void UsdArnoldWriter::write(const AtUniverse *universe)
         }
         _registry = s_writerRegistry;
     }
+    // clear the list of nodes that were exported to usd
+    _exportedNodes.clear(); 
 
     // Loop over the universe nodes, and write each of them
     AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, AI_NODE_ALL);
@@ -77,10 +79,14 @@ void UsdArnoldWriter::writePrimitive(const AtNode *node)
         return;
     }
 
+    if (isNodeExported(objName))
+        return; // this node has already been exported, nothing to do
+
     std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
 
     UsdArnoldPrimWriter *primWriter = _registry->getPrimWriter(objType);
     if (primWriter) {
+        _exportedNodes.insert(objName); // remember that we already exported this node
         primWriter->writeNode(node, *this);
     }
 }

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -58,5 +58,5 @@ private:
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
-    std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported     
+    std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported
 };

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -49,6 +49,8 @@ public:
     void setWriteBuiltin(bool b) { _writeBuiltin = b;}
     bool getWriteBuiltin() const { return _writeBuiltin;}
 
+    bool isNodeExported(const std::string &name) { return _exportedNodes.find(name) != _exportedNodes.end();}
+
 
 private:
     const AtUniverse *_universe;        // Arnold universe to be converted
@@ -56,4 +58,5 @@ private:
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
+    std::unordered_set<std::string> _exportedNodes; // list of arnold attributes that were exported     
 };

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -49,7 +49,7 @@ public:
     void setWriteBuiltin(bool b) { _writeBuiltin = b;}
     bool getWriteBuiltin() const { return _writeBuiltin;}
 
-    bool isNodeExported(const std::string &name) { return _exportedNodes.find(name) != _exportedNodes.end();}
+    bool isNodeExported(const AtString &name) { return _exportedNodes.count(name) == 1;}
 
 
 private:
@@ -58,5 +58,5 @@ private:
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
-    std::unordered_set<std::string> _exportedNodes; // list of arnold attributes that were exported     
+    std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported     
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
The usd writer now exports arnold shader assignments by connecting a `UsdShadeMaterial` primitive, on which both the surface shader and displacement are linked.

Since the material node doesn't exist in the arnold scene, we need to give it a unique name. Here I'm appending both the name of the surface shader and the eventual displacement, so that every combination surface + displacement is unique, and so that we share the same material between geometries.

While doing it, I saw that we were sometimes doing the export of a node multiple times uselessly (in case of shader links or node connections), so I've enforced it here. The list of exported attributes was also cleared by mistake when setting connections, this is now fixed.

I am not handling the geometry subset assignments yet. We can add the logic to this current PR if it's not too complicated to translate.

**Issues fixed in this pull request**
Fixes #163 
