### PR TITLE
Reader checks existing node's parent before skipping its creation

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -377,7 +377,7 @@ void UsdArnoldReader::setUniverse(AtUniverse *universe)
 
 AtNode *UsdArnoldReader::createArnoldNode(const char *type, const char *name, bool *existed)
 {
-    AtNode *node = lookupNode(name); 
+    AtNode *node = lookupNode(name);
     if (existed) {
         *existed = (node != NULL);
     }

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -377,7 +377,7 @@ void UsdArnoldReader::setUniverse(AtUniverse *universe)
 
 AtNode *UsdArnoldReader::createArnoldNode(const char *type, const char *name, bool *existed)
 {
-    AtNode *node = AiNodeLookUpByName(_universe, name, _procParent);
+    AtNode *node = lookupNode(name); 
     if (existed) {
         *existed = (node != NULL);
     }

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -77,6 +77,22 @@ public:
     static unsigned int RenderThread(void *data);
 
     AtNode *getDefaultShader();
+    AtNode *lookupNode(const char *name) {
+        AtNode *node = AiNodeLookUpByName(_universe, name, _procParent);
+        // We don't want to take into account nodes that were created by a parent procedural 
+        // (see #172). It happens that calling AiNodeGetParent on a child node that was just
+        // created by this procedural returns nullptr. I guess we'll get a correct result only
+        // after the procedural initialization is finished. The best test we can do now is to 
+        // ignore the node returned by AiNodeLookupByName if it has a non-null parent that
+        // is different from the current procedural parent
+        if (node) {
+            AtNode *parent = AiNodeGetParent(node);
+            if (parent != nullptr && parent != _procParent)
+                node = nullptr;
+        }
+        return node;
+    }
+
 
 private:
     const AtNode *_procParent;          // the created nodes are children of a procedural parent

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -79,10 +79,10 @@ public:
     AtNode *getDefaultShader();
     AtNode *lookupNode(const char *name) {
         AtNode *node = AiNodeLookUpByName(_universe, name, _procParent);
-        // We don't want to take into account nodes that were created by a parent procedural 
+        // We don't want to take into account nodes that were created by a parent procedural
         // (see #172). It happens that calling AiNodeGetParent on a child node that was just
         // created by this procedural returns nullptr. I guess we'll get a correct result only
-        // after the procedural initialization is finished. The best test we can do now is to 
+        // after the procedural initialization is finished. The best test we can do now is to
         // ignore the node returned by AiNodeLookupByName if it has a non-null parent that
         // is different from the current procedural parent
         if (node) {


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR is needed to support point instancer properly in #153 
Before creating a node, we check if it already exists by calling `AiNodeLookUpbyName`. If it exists, we skip its creation as it's already there. But this arnold function can actually return us a node with the same name in the scope of a parent procedural. So if the usd procedural is created by another procedural and the parent has a node with the same name, there will be a confusion between both and some nodes won't be generated.

Note that when #179 is pushed we'll no longer need this test in `UsdArnoldPrimReader::createArnoldNode` as we won't need to check if a node already exists anymore, before creating it.

Also, there are still some places in the core where we still call `AiNodeLookUpByName`, for example when settings links to other nodes in the scene. This is fine, because nodes are first looked up in the current procedural scope, then eventually in its parent scope, etc... so there shouldn't be any case where we setup the wrong connection. 

**Issues fixed in this pull request**
Fixes #172 
