### PR TITLE
Ensure attributes of type "node" are converted by the writer

### DIFF
--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -174,7 +174,8 @@ void UsdArnoldPrimReader::readArnoldParameters(
                                 if (nodeName.empty()) {
                                     continue;
                                 }
-                                nodeName = std::string("/") + nodeName;
+                                if (nodeName[0] != '/')
+                                    nodeName = std::string("/") + nodeName;
                                 SdfPath targetPath(nodeName);
 
                                 UsdPrim targetPrim = reader.getStage()->GetPrimAtPath(targetPath);
@@ -272,7 +273,8 @@ void UsdArnoldPrimReader::readArnoldParameters(
                         case AI_TYPE_NODE:
                             std::string nodeName = vtValue.Get<std::string>();
                             if (!nodeName.empty()) {
-                                nodeName = std::string("/") + nodeName;
+                                if (nodeName[0] != '/')
+                                    nodeName = std::string("/") + nodeName;
                                 UsdPrim targetPrim = reader.getStage()->GetPrimAtPath(SdfPath(nodeName));
                                 // export this node
                                 if (targetPrim && targetPrim.IsActive()) {

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -147,7 +147,7 @@ const ParamConversionMap& _ParamConversionMap()
           return VtValue(targetName);
       },
       [](const AtNode* no, const char* na, const AtParamValue* pentry) -> bool {
-          return (AiNodeGetPtr(no, na) != nullptr);
+          return (AiNodeGetPtr(no, na) == nullptr);
       }}},
     {AI_TYPE_MATRIX,
      {SdfValueTypeNames->Matrix4d,


### PR DESCRIPTION
**Changes proposed in this pull request**
The USD writer was never saving AI_TYPE_NODE attributes. When exporting to usd, we check if the attribute values are equal to default or not, to decide if we want to author these attributes in the usd file.

The test for node attributes being default was incorrect, because of a typo. We were testing that the value was *not* null instead of testing that it's null.

While checking the code, I also realized that the reader always appends a "/" at the beginning of a  name, in the case of node attributes, which won't work if the node name already starts with "/".

**Issues fixed in this pull request**
Fixes #190 