### PR TITLE
Fix tbb linkage when using a custom `USD_LIB_PREFIX`

### DIFF
--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -171,10 +171,10 @@ if env['USD_BUILD_MODE'] == 'shared_libs':
         'usdShade',
         'vt',
         'usdLux',
-        'tbb',
     ]
 
     usd_deps, usd_sources = link_usd_libraries(myenv, usd_libs)
+    usd_deps.append('tbb')
     source_files = source_files + usd_sources
     wrapper_source_files = wrapper_source_files + usd_sources
 else:


### PR DESCRIPTION
Fixes linkage against `tbb` when building against shared, non-monolithic USD libs using a custom `USD_LIB_PREFIX`.

Currently, if a custom prefix is passed, the `tbb` link flag gets modified as well.