### PR TITLE
Disable the kitchen scene test again

### DIFF
--- a/testsuite/groups
+++ b/testsuite/groups
@@ -41,7 +41,7 @@ darwin:
 #######################
 
 # Tests in this group will never be executed (you can use it to temporarily disable some tests and/or groups)
-ignore: test_0011
+ignore: test_0011 test_0016
 
 ############################
 # USER-DEFINED TEST GROUPS #


### PR DESCRIPTION
**Changes proposed in this pull request**
Related to #196  , with the Arnold CI we noticed that the kitchen scene in `test_0016` was also giving random results with a single thread. I thought the issues only happened in parallel translation, but it was just more frequent.

We need to disable this test until the issue is properly solved