### PR TITLE
Enable parallel_node_init in the usd procedural

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -45,6 +45,10 @@ node_parameters
     AiMetaDataSetBool(nentry, AtString("object_path"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("frame"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("overrides"), AtString("_triggers_reload"), true);
+
+    // This type of procedural can be initialized in parallel
+    AiMetaDataSetBool(nentry, AtString(""), AtString("parallel_init"), true);
+
 }
 typedef std::vector<std::string> PathList;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR simply sets the metadata `parallel_init` in the usd procedural, to let arnold know that it can be initialized in parallel. By default, all the custom procedurals are initialized serially, one after each other, to avoid thread-safety issues that don't apply here.

Note that this commit is required to solve the hangs from #153 

**Issues fixed in this pull request**
Fixes #201 