### PR TITLE
Writer sets proper names for node attributes

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -143,7 +143,7 @@ const ParamConversionMap& _ParamConversionMap()
           std::string targetName;
           AtNode* target = (AtNode*)AiNodeGetPtr(no, na);
           if (target) {
-              targetName = AiNodeGetName(target);
+              targetName = UsdArnoldPrimWriter::getArnoldNodeName(target);
           }
           return VtValue(targetName);
       },
@@ -539,7 +539,7 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                     VtArray<std::string> vtArr(arraySize);
                     for (unsigned int i = 0; i < arraySize; ++i) {
                         AtNode* target = (AtNode*)AiArrayGetPtr(array, i);
-                        vtArr[i] = (target) ? AiNodeGetName(target) : "";
+                        vtArr[i] = (target) ? UsdArnoldPrimWriter::getArnoldNodeName(target) : "";
                     }
                     attrWriter.ProcessAttribute(SdfValueTypeNames->StringArray, vtArr);
             }

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -82,8 +82,12 @@ void UsdArnoldWriter::writePrimitive(const AtNode *node)
         return;
     }
 
+    // Check if this arnold node has already been exported, and early out if it was.
+    // Note that we're storing the name of the arnold node, which might be slightly 
+    // different from the USD prim name, since UsdArnoldPrimWriter::getArnoldNodeName 
+    // replaces some forbidden characters by underscores.
     if (isNodeExported(nodeName))
-        return; // this node has already been exported, nothing to do
+        return; 
 
     std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
 


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of using `AiNodeGetName` for node / node-array attributes, use `UsdArnoldPrimWriter::getArnoldNodeName` that does some formatting to sanitize the names

**Issues fixed in this pull request**
Fixes #208 