### PR TITLE
Fix build issue regarding schemas on linux

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -95,6 +95,9 @@ def getParameterStr(paramType, paramValue = None, paramEntry = None):
             if strVal == 'auto':
                 strVal = 'metric_auto'
             
+            if strVal == 'linux':
+                strVal = 'os_linux'
+            
             valueStr = '"{}"'.format(strVal)
         optionsStr = '\n        allowedTokens = ['
 
@@ -106,6 +109,9 @@ def getParameterStr(paramType, paramValue = None, paramEntry = None):
 
             if t == 'auto':
                 t = "metric_auto"
+            
+            if t == 'linux':
+                t = "os_linux"
             
             if i > 0:
                 optionsStr += ','


### PR DESCRIPTION
**Changes proposed in this pull request**
Ensure we're not creating a token called `linux` (for attribute `string_replace.os` )

**Issues fixed in this pull request**
Fixes #219 
