### PR TITLE
Check which type is holding a vtValue before setting attributes 

### DIFF
--- a/testsuite/test_0009/data/sphere.usd
+++ b/testsuite/test_0009/data/sphere.usd
@@ -10,7 +10,7 @@ def SphereLight "distant"
  float exposure=3
  float intensity=15
  float radius = 5 
- bool treatAsPoint=true
+ int treatAsPoint=1
  float3 xformOp:translate= (0,0, 15)
  uniform token[] xformOpOrder = ["xformOp:translate"]
 }

--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -193,86 +193,94 @@ void UsdArnoldPrimReader::readArnoldParameters(
             // Simple parameters (not-an-array)
             switch (paramType) {
                 case AI_TYPE_BYTE:
-                    AiNodeSetByte(node, arnoldAttr.c_str(), vtValue.Get<unsigned char>());
+                    AiNodeSetByte(node, arnoldAttr.c_str(), vtValueGetByte(vtValue));
                     break;
                 case AI_TYPE_INT:
-                    AiNodeSetInt(node, arnoldAttr.c_str(), vtValue.Get<int>());
+                    AiNodeSetInt(node, arnoldAttr.c_str(), vtValueGetInt(vtValue));
                     break;
                 case AI_TYPE_UINT:
+                case AI_TYPE_USHORT:
                     AiNodeSetUInt(node, arnoldAttr.c_str(), vtValue.Get<unsigned int>());
                     break;
                 case AI_TYPE_BOOLEAN:
-                    AiNodeSetBool(node, arnoldAttr.c_str(), vtValue.Get<bool>());
+                    AiNodeSetBool(node, arnoldAttr.c_str(), vtValueGetBool(vtValue));
                     break;
                 case AI_TYPE_FLOAT:
-                    AiNodeSetFlt(node, arnoldAttr.c_str(), vtValue.Get<float>());
+                case AI_TYPE_HALF:
+                    AiNodeSetFlt(node, arnoldAttr.c_str(), vtValueGetFloat(vtValue));
                     break;
-                    {
-                        case AI_TYPE_VECTOR:
-                            GfVec3f vec = vtValue.Get<GfVec3f>();
-                            AiNodeSetVec(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2]);
-                            break;
+                {
+                case AI_TYPE_VECTOR:
+                    GfVec3f vec = vtValue.Get<GfVec3f>();
+                    AiNodeSetVec(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2]);
+                    break;
+                }
+                {
+                case AI_TYPE_RGB:
+                    GfVec3f vec = vtValue.Get<GfVec3f>();
+                    AiNodeSetRGB(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2]);
+                    break;
+                }
+                {
+                case AI_TYPE_RGBA:
+                    GfVec4f vec = vtValue.Get<GfVec4f>();
+                    AiNodeSetRGBA(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2], vec[3]);
+                    break;
+                }
+                {
+                case AI_TYPE_VECTOR2:
+                    GfVec2f vec = vtValue.Get<GfVec2f>();
+                    AiNodeSetVec2(node, arnoldAttr.c_str(), vec[0], vec[1]);
+                    break;
+                }
+                case AI_TYPE_ENUM:
+                    if (vtValue.IsHolding<int>()) {
+                        AiNodeSetInt(node, arnoldAttr.c_str(), vtValue.UncheckedGet<int>());
+                        break;
+                    } else if (vtValue.IsHolding<long>()) {
+                        AiNodeSetInt(node, arnoldAttr.c_str(), vtValue.UncheckedGet<long>());
+                        break;
+                    } 
+                {
+                case AI_TYPE_STRING:
+                    if (vtValue.IsHolding<std::string>()) {
+                        auto str = vtValue.UncheckedGet<std::string>();
+                        AiNodeSetStr(node, arnoldAttr.c_str(), str.c_str());
+                    } else if (vtValue.IsHolding<TfToken>()) {
+                        auto token = vtValue.UncheckedGet<TfToken>();
+                        AiNodeSetStr(node, arnoldAttr.c_str(), token.GetText());
+                    } else if (vtValue.IsHolding<SdfAssetPath>()) {
+                        auto assetPath = vtValue.UncheckedGet<SdfAssetPath>();
+                        auto path = assetPath.GetResolvedPath();
+                        if (path.empty()) {
+                            path = assetPath.GetAssetPath();
+                        }
+                        AiNodeSetStr(node, arnoldAttr.c_str(), path.c_str());
                     }
-                    {
-                        case AI_TYPE_RGB:
-                            GfVec3f vec = vtValue.Get<GfVec3f>();
-                            AiNodeSetRGB(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2]);
-                            break;
+                    break;
+                }
+                {
+                case AI_TYPE_MATRIX:
+                    GfMatrix4d usdMat = vtValue.Get<GfMatrix4d>();
+                    AtMatrix aiMat;
+                    const double *array = usdMat.GetArray();
+                    for (unsigned int i = 0; i < 4; ++i)
+                        for (unsigned int j = 0; j < 4; ++j)
+                            aiMat[i][j] = array[4 * i + j];
+                    AiNodeSetMatrix(node, arnoldAttr.c_str(), aiMat);
+                    break;
+                }
+                {
+                // node attributes are expected as strings
+                case AI_TYPE_NODE:
+                    std::string nodeName = vtValue.Get<std::string>();
+                    if (!nodeName.empty()) {
+                        if (nodeName[0] != '/')
+                            nodeName = std::string("/") + nodeName;
+                        context.addConnection(node, arnoldAttr, nodeName, UsdArnoldReaderContext::CONNECTION_PTR);
                     }
-                    {
-                        case AI_TYPE_RGBA:
-                            GfVec4f vec = vtValue.Get<GfVec4f>();
-                            AiNodeSetRGBA(node, arnoldAttr.c_str(), vec[0], vec[1], vec[2], vec[3]);
-                            break;
-                    }
-                    {
-                        case AI_TYPE_VECTOR2:
-                            GfVec2f vec = vtValue.Get<GfVec2f>();
-                            AiNodeSetVec2(node, arnoldAttr.c_str(), vec[0], vec[1]);
-                            break;
-                    }
-                    {
-                            // FIXME: ensure enum is working here
-                        case AI_TYPE_ENUM:
-                        case AI_TYPE_STRING:
-                            if (vtValue.IsHolding<std::string>()) {
-                                auto str = vtValue.UncheckedGet<std::string>();
-                                AiNodeSetStr(node, arnoldAttr.c_str(), str.c_str());
-                            } else if (vtValue.IsHolding<TfToken>()) {
-                                auto token = vtValue.UncheckedGet<TfToken>();
-                                AiNodeSetStr(node, arnoldAttr.c_str(), token.GetText());
-                            } else if (vtValue.IsHolding<SdfAssetPath>()) {
-                                auto assetPath = vtValue.UncheckedGet<SdfAssetPath>();
-                                auto path = assetPath.GetResolvedPath();
-                                if (path.empty()) {
-                                    path = assetPath.GetAssetPath();
-                                }
-                                AiNodeSetStr(node, arnoldAttr.c_str(), path.c_str());
-                            }
-                            break;
-                    }
-                    {
-                        case AI_TYPE_MATRIX:
-                            GfMatrix4d usdMat = vtValue.Get<GfMatrix4d>();
-                            AtMatrix aiMat;
-                            const double *array = usdMat.GetArray();
-                            for (unsigned int i = 0; i < 4; ++i)
-                                for (unsigned int j = 0; j < 4; ++j)
-                                    aiMat[i][j] = array[4 * i + j];
-                            AiNodeSetMatrix(node, arnoldAttr.c_str(), aiMat);
-                            break;
-                    }
-                    {
-                        // node attributes are expected as strings
-                        case AI_TYPE_NODE:
-                            std::string nodeName = vtValue.Get<std::string>();
-                            if (!nodeName.empty()) {
-                                if (nodeName[0] != '/')
-                                    nodeName = std::string("/") + nodeName;
-                                context.addConnection(node, arnoldAttr, nodeName, UsdArnoldReaderContext::CONNECTION_PTR);
-                            }
-                            break;
-                    }
+                    break;
+                }
                 default:
                     break;
             }

--- a/translator/reader/prim_reader.h
+++ b/translator/reader/prim_reader.h
@@ -37,9 +37,50 @@ public:
 
     virtual void read(const UsdPrim &prim, UsdArnoldReaderContext &context) = 0;
 
+    static inline bool vtValueGetBool(const VtValue& value)
+    {
+        if (value.IsHolding<bool>())
+            return value.UncheckedGet<bool>();
+        if (value.IsHolding<int>())
+            return value.UncheckedGet<int>() != 0;
+        if (value.IsHolding<long>())
+            return value.UncheckedGet<long>() != 0;
+
+        return value.Get<bool>();
+    }
+    static inline float vtValueGetFloat(const VtValue& value)
+    {
+        if (value.IsHolding<float>())
+            return value.UncheckedGet<float>();
+        if (value.IsHolding<double>())
+            return static_cast<float>(value.UncheckedGet<double>());
+        
+        return value.Get<float>();
+    }
+    static inline unsigned char vtValueGetByte(const VtValue& value)
+    {
+        if (value.IsHolding<int>())
+            return static_cast<unsigned char>(value.UncheckedGet<int>());
+        if (value.IsHolding<long>())
+            return static_cast<unsigned char>(value.UncheckedGet<long>());
+        if (value.IsHolding<unsigned char>())
+            return value.UncheckedGet<unsigned char>();
+            
+        return value.Get<unsigned char>();
+    }
+    static inline int vtValueGetInt(const VtValue& value)
+    {
+        if (value.IsHolding<int>())
+            return value.UncheckedGet<int>();
+        if (value.IsHolding<long>())
+            return static_cast<int>(value.UncheckedGet<long>());
+
+        return value.Get<int>();
+    }
 protected:
     void readArnoldParameters(
         const UsdPrim &prim, UsdArnoldReaderContext &context, AtNode *node, const TimeSettings &time, const std::string &scope = "arnold");
+
 };
 
 class UsdArnoldReadUnsupported : public UsdArnoldPrimReader {

--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -94,7 +94,7 @@ void UsdArnoldReadMesh::read(const UsdPrim &prim, UsdArnoldReaderContext &contex
 
     VtValue sidedness;
     if (mesh.GetDoubleSidedAttr().Get(&sidedness))
-        AiNodeSetByte(node, "sidedness", sidedness.Get<bool>() ? AI_RAY_ALL : 0);
+        AiNodeSetByte(node, "sidedness", vtValueGetBool(sidedness) ? AI_RAY_ALL : 0);
 
     TfToken subdiv;
     mesh.GetSubdivisionSchemeAttr().Get(&subdiv);
@@ -210,7 +210,7 @@ void UsdArnoldReadCube::read(const UsdPrim &prim, UsdArnoldReaderContext &contex
 
     VtValue size_attr;
     if (cube.GetSizeAttr().Get(&size_attr)) {
-        float size_value = (float)size_attr.Get<double>();
+        float size_value = vtValueGetFloat(size_attr);
         AiNodeSetVec(node, "min", -size_value / 2.f, -size_value / 2.f, -size_value / 2.f);
         AiNodeSetVec(node, "max", size_value / 2.f, size_value / 2.f, size_value / 2.f);
     }
@@ -231,7 +231,7 @@ void UsdArnoldReadSphere::read(const UsdPrim &prim, UsdArnoldReaderContext &cont
 
     VtValue radius_attr;
     if (sphere.GetRadiusAttr().Get(&radius_attr))
-        AiNodeSetFlt(node, "radius", (float)radius_attr.Get<double>());
+        AiNodeSetFlt(node, "radius", vtValueGetFloat(radius_attr));
 
     exportMatrix(prim, node, time, context);
     exportPrimvars(prim, node, time);
@@ -247,12 +247,12 @@ void exportCylindricalShape(const UsdPrim &prim, AtNode *node, const char *radiu
 
     VtValue radius_attr;
     if (geom.GetRadiusAttr().Get(&radius_attr))
-        AiNodeSetFlt(node, radius_name, (float)radius_attr.Get<double>());
+        AiNodeSetFlt(node, radius_name, UsdArnoldPrimReader::vtValueGetFloat(radius_attr));
 
     float height = 1.f;
     VtValue height_attr;
     if (geom.GetHeightAttr().Get(&height_attr))
-        height = (float)height_attr.Get<double>();
+        height = UsdArnoldPrimReader::vtValueGetFloat(height_attr);
 
     height /= 2.f;
 

--- a/translator/reader/read_light.cpp
+++ b/translator/reader/read_light.cpp
@@ -46,11 +46,11 @@ static void exportLightCommon(const UsdLuxLight &light, AtNode *node)
 
     VtValue diffuse_attr;
     if (light.GetDiffuseAttr().Get(&diffuse_attr)) {
-        AiNodeSetFlt(node, "diffuse", diffuse_attr.Get<float>());
+        AiNodeSetFlt(node, "diffuse", UsdArnoldPrimReader::vtValueGetFloat(diffuse_attr));
     }
     VtValue specular_attr;
     if (light.GetSpecularAttr().Get(&specular_attr)) {
-        AiNodeSetFlt(node, "specular", specular_attr.Get<float>());
+        AiNodeSetFlt(node, "specular", UsdArnoldPrimReader::vtValueGetFloat(specular_attr));
     }
 
     /*
@@ -69,7 +69,7 @@ void UsdArnoldReadDistantLight::read(const UsdPrim &prim, UsdArnoldReaderContext
     float angle = 0.52f;
     VtValue angle_attr;
     if (light.GetAngleAttr().Get(&angle_attr)) {
-        AiNodeSetFlt(node, "angle", angle_attr.Get<float>());
+        AiNodeSetFlt(node, "angle", vtValueGetFloat(angle_attr));
     }
 
     const TimeSettings &time = context.getTimeSettings();
@@ -104,12 +104,13 @@ void UsdArnoldReadDomeLight::read(const UsdPrim &prim, UsdArnoldReaderContext &c
 
             // now we need to export the intensity and exposure manually,
             // because we have overridden the color
-            float intensity = 1.f;
-            light.GetIntensityAttr().Get(&intensity);
-            AiNodeSetFlt(node, "intensity", intensity);
-            float exposure = 0.f;
-            light.GetExposureAttr().Get(&exposure);
-            AiNodeSetFlt(node, "exposure", exposure);
+            
+            VtValue intensity_attr;
+            if (light.GetIntensityAttr().Get(&intensity_attr))
+                AiNodeSetFlt(node, "intensity", vtValueGetFloat(intensity_attr));
+            VtValue exposure_attr;
+            if (light.GetExposureAttr().Get(&exposure_attr))
+                AiNodeSetFlt(node, "exposure", vtValueGetFloat(exposure_attr));
         }
     }
     TfToken format;
@@ -140,12 +141,12 @@ void UsdArnoldReadDiskLight::read(const UsdPrim &prim, UsdArnoldReaderContext &c
 
     VtValue radius_attr;
     if (light.GetRadiusAttr().Get(&radius_attr)) {
-        AiNodeSetFlt(node, "radius", radius_attr.Get<float>());
+        AiNodeSetFlt(node, "radius", vtValueGetFloat(radius_attr));
     }
 
     VtValue normalize_attr;
     if (light.GetNormalizeAttr().Get(&normalize_attr)) {
-        AiNodeSetBool(node, "normalize", normalize_attr.Get<bool>());
+        AiNodeSetBool(node, "normalize", vtValueGetBool(normalize_attr));
     }
 
     exportMatrix(prim, node, time, context);
@@ -161,15 +162,19 @@ void UsdArnoldReadSphereLight::read(const UsdPrim &prim, UsdArnoldReaderContext 
     exportLightCommon(light, node);
 
     bool treatAsPoint = false;
-    if (light.GetTreatAsPointAttr().Get(&treatAsPoint) && (!treatAsPoint)) {
-        VtValue radiusAttr;
-        if (light.GetRadiusAttr().Get(&radiusAttr)) {
-            AiNodeSetFlt(node, "radius", radiusAttr.Get<float>());
-        }
+    VtValue treatAsPointAttr;
+    if (light.GetTreatAsPointAttr().Get(&treatAsPointAttr)) {
+        treatAsPoint = vtValueGetBool(treatAsPointAttr);
+        if (!treatAsPoint) {
+            VtValue radiusAttr;
+            if (light.GetRadiusAttr().Get(&radiusAttr)) {
+                AiNodeSetFlt(node, "radius", vtValueGetFloat(radiusAttr));
+            }
 
-        VtValue normalizeAttr;
-        if (light.GetNormalizeAttr().Get(&normalizeAttr)) {
-            AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
+            VtValue normalizeAttr;
+            if (light.GetNormalizeAttr().Get(&normalizeAttr)) {
+                AiNodeSetBool(node, "normalize", vtValueGetBool(normalizeAttr));
+            }
         }
     }
 
@@ -190,9 +195,12 @@ void UsdArnoldReadRectLight::read(const UsdPrim &prim, UsdArnoldReaderContext &c
 
     float width = 1.f;
     float height = 1.f;
+    VtValue widthAttr, heightAttr;
 
-    light.GetWidthAttr().Get(&width);
-    light.GetHeightAttr().Get(&height);
+    if (light.GetWidthAttr().Get(&widthAttr))
+        width = vtValueGetFloat(widthAttr);
+    if (light.GetHeightAttr().Get(&heightAttr))
+        height = vtValueGetFloat(heightAttr);
 
     width /= 2.f;
     height /= 2.f;
@@ -219,18 +227,18 @@ void UsdArnoldReadRectLight::read(const UsdPrim &prim, UsdArnoldReaderContext &c
 
             // now we need to export the intensity and exposure manually,
             // because we have overridden the color
-            float intensity = 1.f;
-            light.GetIntensityAttr().Get(&intensity);
-            AiNodeSetFlt(node, "intensity", intensity);
-            float exposure = 0.f;
-            light.GetExposureAttr().Get(&exposure);
-            AiNodeSetFlt(node, "exposure", exposure);
+            VtValue intensityAttr;
+            if (light.GetIntensityAttr().Get(&intensityAttr))
+                AiNodeSetFlt(node, "intensity", vtValueGetFloat(intensityAttr));
+            VtValue exposureAttr;
+            if (light.GetExposureAttr().Get(&exposureAttr))
+                AiNodeSetFlt(node, "exposure", vtValueGetFloat(exposureAttr));
         }
     }
 
     VtValue normalizeAttr;
     if (light.GetNormalizeAttr().Get(&normalizeAttr)) {
-        AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
+        AiNodeSetBool(node, "normalize", vtValueGetBool(normalizeAttr));
     }
 
     exportMatrix(prim, node, time, context);
@@ -273,7 +281,7 @@ void UsdArnoldReadGeometryLight::read(const UsdPrim &prim, UsdArnoldReaderContex
 
         VtValue normalizeAttr;
         if (light.GetNormalizeAttr().Get(&normalizeAttr)) {
-            AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
+            AiNodeSetBool(node, "normalize", vtValueGetBool(normalizeAttr));
         }
 
         exportMatrix(prim, node, time, context);


### PR DESCRIPTION
**Changes proposed in this pull request**
We used to set `vtValues` by assuming they had the exact type that is expected. But the render delegate code is testing which value type an attribute is holding before setting it. For example an integer attribute can either be defined as `int` or as `long`, etc...

For the issue reported in #238 , boolean attributes can sometimes be defined as an `int` so we're also treating this use case.

I changed `test_0009` to have a boolean attribute expressed as an integer. With the proposed commit it passes successfully.

**Issues fixed in this pull request**
Fixes #238 
