### PR TITLE
Fix pixel format for render buffer conversion (#245)

### DIFF
--- a/render_delegate/render_buffer.h
+++ b/render_delegate/render_buffer.h
@@ -140,6 +140,7 @@ private:
     unsigned int _width;
     unsigned int _height;
     HdFormat _format;
+    unsigned int _pixelSize;
 
     std::vector<uint8_t> _buffer;
     std::atomic<int> _mappers;


### PR DESCRIPTION
Fix pixel format mismatch when copying to hyrda render buffers, and fix flash in screen and crash when creating render settings node on OSX.

The performance is slower after adding the render settings node due the per pixel copying.   It would preferable to use buffers in the render delegate that match the hydra buffers - see #8.