### PR TITLE
Dirtying the Transform when Params are dirty for light updates.

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -213,6 +213,8 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
     TF_UNUSED(sceneDelegate);
     TF_UNUSED(dirtyBits);
     if (*dirtyBits & HdLight::DirtyParams) {
+        // We need to force dirtying the transform, because AiNodeReset resets the transformation.
+        *dirtyBits |= HdLight::DirtyTransform;
         param->End();
         const auto id = GetId();
         const auto* nentry = AiNodeGetNodeEntry(_light);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Dirtying the Transform when Params are dirty for light updates.

**Issues fixed in this pull request**
Fixes #243