### PR TITLE
Adding support for computed primvars

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ Python and Boost are optional if USD was build without Python support.
 | Name | Version | Optional |
 | --- | --- | --- |
 | Arnold | 5.4+ | |
-| USD | v19.01 - dev | |
+| USD | v19.05 - dev | |
 | Python | 2.7 |  x  |
 | Boost | 1.55 (Linux), 1.61 (Mac, Windows VS 2015), 1.65.1 (Windows VS 2017) or 1.66.0 (VFX platform) |  x  |
 | TBB | 4.4 Update 6 or 2018 (VFX platform) | |

--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -225,7 +225,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
             SetupTexture(sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile));
         }
         for (const auto& primvar : sceneDelegate->GetPrimvarDescriptors(id, HdInterpolation::HdInterpolationConstant)) {
-            ConvertPrimvarToBuiltinParameter(_light, id, sceneDelegate, primvar);
+            ConvertPrimvarToBuiltinParameter(_light, primvar.name, sceneDelegate->Get(id, primvar.name));
         }
     }
 

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -141,11 +141,8 @@ void HdArnoldMesh::Sync(
     auto* param = reinterpret_cast<HdArnoldRenderParam*>(renderParam);
     const auto& id = GetId();
 
-    const auto dirtyPrimvars = *dirtyBits & HdChangeTracker::DirtyPrimvar;
-
-    if (dirtyPrimvars) {
-        HdArnoldGetComputedPrimvars(delegate, id, *dirtyBits, _primvars);
-    }
+    const auto dirtyPrimvars = HdArnoldGetComputedPrimvars(delegate, id, *dirtyBits, _primvars) ||
+        (*dirtyBits & HdChangeTracker::DirtyPrimvar);
 
     if (_primvars.count(HdTokens->points) != 0) {
         _numberOfPositionKeys = 1;

--- a/render_delegate/mesh.h
+++ b/render_delegate/mesh.h
@@ -41,6 +41,7 @@
 #include "hdarnold.h"
 #include "render_delegate.h"
 #include "shape.h"
+#include "utils.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -99,8 +100,9 @@ protected:
     HDARNOLD_API
     bool _IsVolume() const;
 
-    HdArnoldShape _shape;     ///< Utility class for the mesh and instances.
-    VtIntArray _vertexCounts; ///< Vertex Counts array for reversing vertex and primvar polygon order.
+    HdArnoldShape _shape;             ///< Utility class for the mesh and instances.
+    HdArnoldPrimvarMap _primvars;     ///< Precomputed list of primvars.
+    VtIntArray _vertexCounts;         ///< Vertex Counts array for reversing vertex and primvar polygon order.
     size_t _numberOfPositionKeys = 1; ///< Number of vertex position keys for the mesh.
 };
 

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -31,6 +31,7 @@
 
 #include <pxr/imaging/hd/bprim.h>
 #include <pxr/imaging/hd/camera.h>
+#include <pxr/imaging/hd/extComputation.h>
 #include <pxr/imaging/hd/instancer.h>
 #include <pxr/imaging/hd/resourceRegistry.h>
 #include <pxr/imaging/hd/rprim.h>
@@ -151,6 +152,7 @@ inline const TfTokenVector& _SupportedSprimTypes()
                                  HdPrimTypeTokens->distantLight,  HdPrimTypeTokens->sphereLight,
                                  HdPrimTypeTokens->diskLight,     HdPrimTypeTokens->rectLight,
                                  HdPrimTypeTokens->cylinderLight, HdPrimTypeTokens->domeLight,
+                                 HdPrimTypeTokens->extComputation
                                  /*HdPrimTypeTokens->simpleLight*/};
     return r;
 }
@@ -188,7 +190,8 @@ const SupportedRenderSettings& _GetSupportedRenderSettings()
     static const SupportedRenderSettings data{
         // Global settings to control rendering
         {str::t_enable_progressive_render, {"Enable Progressive Render", config.enable_progressive_render}},
-        {str::t_progressive_min_AA_samples, {"Progressive Render Minimum AA Samples", config.progressive_min_AA_samples}},
+        {str::t_progressive_min_AA_samples,
+         {"Progressive Render Minimum AA Samples", config.progressive_min_AA_samples}},
         {str::t_enable_adaptive_sampling, {"Enable Adaptive Sampling", config.enable_adaptive_sampling}},
 #ifndef __APPLE__
         {str::t_enable_gpu_rendering, {"Enable GPU Rendering", config.enable_gpu_rendering}},
@@ -353,6 +356,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate()
     AiNodeSetStr(_fallbackShader, "shade_mode", "ambocc");
     AiNodeSetStr(_fallbackShader, "color_mode", "color");
     auto* userDataReader = AiNode(_universe, "user_data_rgb");
+    AiNodeSetStr(userDataReader, str::name, TfStringPrintf("fallbackShader_userDataReader_%p", userDataReader).c_str());
     AiNodeSetStr(userDataReader, "attribute", "displayColor");
     AiNodeSetRGB(userDataReader, "default", 1.0f, 1.0f, 1.0f);
     AiNodeLink(userDataReader, "color", _fallbackShader);
@@ -396,7 +400,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& key, const VtValue
     auto value = _value.IsHolding<double>() ? VtValue(static_cast<float>(_value.UncheckedGet<double>())) : _value;
     // Certain applications might pass boolean values via ints or longs.
     if (key == str::t_enable_gpu_rendering) {
-        _CheckForBoolValue(value, [&] (const bool b) {
+        _CheckForBoolValue(value, [&](const bool b) {
             AiNodeSetStr(_options, str::render_device, b ? str::GPU : str::CPU);
             AiDeviceAutoSelect();
         });
@@ -578,6 +582,9 @@ HdSprim* HdArnoldRenderDelegate::CreateSprim(const TfToken& typeId, const SdfPat
         // return HdArnoldLight::CreateSimpleLight(this, sprimId);
         return nullptr;
     }
+    if (typeId == HdPrimTypeTokens->extComputation) {
+        return new HdExtComputation(sprimId);
+    }
     TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     return nullptr;
 }
@@ -611,6 +618,9 @@ HdSprim* HdArnoldRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
     if (typeId == HdPrimTypeTokens->simpleLight) {
         // return HdArnoldLight::CreateSimpleLight(this, SdfPath::EmptyPath());
         return nullptr;
+    }
+    if (typeId == HdPrimTypeTokens->extComputation) {
+        return new HdExtComputation(SdfPath::EmptyPath());
     }
     TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     return nullptr;

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -732,7 +732,7 @@ AtArray* HdArnoldGenerateIdxs(unsigned int numIdxs, const VtIntArray* vertexCoun
     return array;
 }
 
-void HdArnoldGetComputedPrimvars(
+bool HdArnoldGetComputedPrimvars(
     HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, HdArnoldPrimvarMap& primvars)
 {
     // First we are querying which primvars need to be computed, and storing them in a list to rely on
@@ -749,18 +749,21 @@ void HdArnoldGetComputedPrimvars(
 
     // Early exit.
     if (dirtyPrimvars.empty()) {
-        return;
+        return false;
     }
 
+    auto changed = false;
     auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues(dirtyPrimvars, delegate);
     for (const auto& primvar : dirtyPrimvars) {
         const auto itComputed = valueStore.find(primvar.name);
         if (itComputed == valueStore.end()) {
             continue;
         }
-
+        changed = true;
         _HdArnoldInsertPrimvar(primvars, primvar.name, primvar.role, primvar.interpolation, itComputed->second);
     }
+
+    return changed;
 }
 
 void HdArnoldGetPrimvars(

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -265,7 +265,8 @@ using HdArnoldPrimvarMap = std::unordered_map<TfToken, HdArnoldPrimvar, TfToken:
 /// @param id Path to the Hyra Primitive.
 /// @param dirtyBits Dirty bits of what has changed for the current sync.
 /// @param primvars Output variable to store the computed primvars.
-void HdArnoldGetComputedPrimvars(
+/// @return Returns true if anything computed False otherwise.
+bool HdArnoldGetComputedPrimvars(
     HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, HdArnoldPrimvarMap& primvars);
 
 /// Get the non-computed primvars and ignoring the points primvar. If multiple position keys are used, the function

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -95,15 +95,32 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
 /// instead of setting it on the node.
 ///
 /// @param node Pointer to an Arnold node.
-/// @param id Path to the Primitive.
 /// @param delegate Pointer to the Scene Delegate.
-/// @param primvarDesc Primvar Descriptor for the Primvar to be set.
+/// @param name Name of the primvar.
+/// @param value Value of the primvar.
 /// @param visibility Pointer to the output visibility parameter.
 /// @return Returns true if the conversion was successful.
 HDARNOLD_API
 bool ConvertPrimvarToBuiltinParameter(
-    AtNode* node, const SdfPath& id, HdSceneDelegate* delegate, const HdPrimvarDescriptor& primvarDesc,
-    uint8_t* visibility = nullptr);
+    AtNode* node, const TfToken& name, const VtValue& value, uint8_t* visibility = nullptr);
+/// Sets a Constant scope Primvar on an Arnold node from a Hydra Primitive.
+///
+/// There is some additional type remapping done to deal with various third
+/// party apps:
+/// bool -> bool / int / long
+/// int -> int / long
+/// float -> float / double
+///
+/// The function also calls ConvertPrimvarToBuiltinParameter.
+///
+/// @param node Pointer to an Arnold Node.
+/// @param name Name of the primvar.
+/// @param role Role of the primvar.
+/// @param value Value of the primvar.
+/// @param visibility Pointer to the output visibility parameter.
+HDARNOLD_API
+void HdArnoldSetConstantPrimvar(
+    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value, uint8_t* visibility = nullptr);
 /// Sets a Constant scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// There is some additional type remapping done to deal with various third
@@ -117,7 +134,7 @@ bool ConvertPrimvarToBuiltinParameter(
 /// @param node Pointer to an Arnold Node.
 /// @param id Path to the Primitive.
 /// @param delegate Pointer to the Scene Delegate.
-/// @param primvarDesch Primvar Descriptor for the Primvar to be set.
+/// @param primvarDesc Description of the primvar.
 /// @param visibility Pointer to the output visibility parameter.
 HDARNOLD_API
 void HdArnoldSetConstantPrimvar(
@@ -125,23 +142,35 @@ void HdArnoldSetConstantPrimvar(
     uint8_t* visibility = nullptr);
 /// Sets a Uniform scope Primvar on an Arnold node from a Hydra Primitive.
 ///
-/// If the parameter is named arnold:xyz (so it exist in the form of
-/// primvars:arnold:xyz), the function checks if a normal parameter exist with
-/// the same name as removing the arnold: prefix.
+/// @param node Pointer to an Arnold Node.
+/// @param name Name of the primvar.
+/// @param role Role of the primvar.
+/// @param value Value of the primvar.
+HDARNOLD_API
+void HdArnoldSetUniformPrimvar(AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value);
+/// Sets a Uniform scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// @param node Pointer to an Arnold Node.
 /// @param id Path to the Primitive.
 /// @param delegate Pointer to the Scene Delegate.
-/// @param primvarDesch Primvar Descriptor for the Primvar to be set.
+/// @param primvarDesc Primvar Descriptor for the Primvar to be set.
 HDARNOLD_API
 void HdArnoldSetUniformPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* delegate, const HdPrimvarDescriptor& primvarDesc);
 /// Sets a Vertex scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// @param node Pointer to an Arnold Node.
+/// @param name Name of the primvar.
+/// @param role Role of the primvar.
+/// @param value Value of the primvar.
+HDARNOLD_API
+void HdArnoldSetVertexPrimvar(AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value);
+/// Sets a Vertex scope Primvar on an Arnold node from a Hydra Primitive.
+///
+/// @param node Pointer to an Arnold Node.
 /// @param id Path to the Primitive.
 /// @param delegate Pointer to the Scene Delegate.
-/// @param primvarDesch Primvar Descriptor for the Primvar to be set.
+/// @param primvarDesc Primvar Descriptor for the Primvar to be set.
 HDARNOLD_API
 void HdArnoldSetVertexPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* delegate, const HdPrimvarDescriptor& primvarDesc);
@@ -151,10 +180,24 @@ void HdArnoldSetVertexPrimvar(
 /// stored in the primvar.
 ///
 /// @param node Pointer to an Arnold Node.
+/// @param name Name of the primvar.
+/// @param role Role of the primvar.
+/// @param value Value of the primvar.
+/// @param vertexCounts Pointer to the VtIntArray holding the face vertex counts for the mesh.
+HDARNOLD_API
+void HdArnoldSetFaceVaryingPrimvar(
+    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value,
+    const VtIntArray* vertexCounts = nullptr);
+/// Sets a Face-Varying scope Primvar on an Arnold node from a Hydra Primitive. If @p vertexCounts is not a nullptr
+/// and it is not empty, it is used to reverse the order of the generated face vertex indices, to support
+/// left handed topologies. The total sum of the @p vertexCounts array is expected to be the same as the number values
+/// stored in the primvar.
+///
+/// @param node Pointer to an Arnold Node.
 /// @param id Path to the Primitive.
 /// @param delegate Pointer to the Scene Delegate.
+/// @param primvarDesc Primvar Descriptor for the Primvar to be set.
 /// @param vertexCounts Pointer to the VtIntArray holding the face vertex counts for the mesh.
-/// @param primvarDesch Primvar Descriptor for the Primvar to be set.
 HDARNOLD_API
 void HdArnoldSetFaceVaryingPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* delegate, const HdPrimvarDescriptor& primvarDesc,
@@ -169,6 +212,12 @@ void HdArnoldSetFaceVaryingPrimvar(
 HDARNOLD_API
 size_t HdArnoldSetPositionFromPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* delegate, const AtString& paramName);
+/// Sets positions attribute on an Arnold shape from a VtValue holding VtVec3fArray.
+///
+/// @param node Pointer to an Arnold node.
+/// @param paramName Name of the positions parameter on the Arnold node.
+/// @param value Value holding a VtVec3fArray.
+void HdArnoldSetPositionFromValue(AtNode* node, const AtString& paramName, const VtValue& value);
 /// Sets radius attribute on an Arnold shape from a float primvar.
 ///
 /// This function looks for a widths primvar, which will be multiplied by 0.5
@@ -189,5 +238,46 @@ void HdArnoldSetRadiusFromPrimvar(AtNode* node, const SdfPath& id, HdSceneDelega
 /// @return An AtArray with the generated indices of @param numIdxs length.
 HDARNOLD_API
 AtArray* HdArnoldGenerateIdxs(unsigned int numIdxs, const VtIntArray* vertexCounts = nullptr);
+
+/// Struct storing the cached primvars.
+struct HdArnoldPrimvar {
+    VtValue value;                 ///< Copy-On-Write Value of the primvar.
+    TfToken role;                  ///< Role of the primvar.
+    HdInterpolation interpolation; ///< Type of interpolation used for the value.
+    bool dirtied;                  ///< If the primvar has been dirtied.;
+
+    ///< Constructor for creating the primvar description.
+    ///
+    /// @param _value Value to be stored for the primvar.
+    /// @param _interpolation Interpolation type for the primvar.
+    HdArnoldPrimvar(const VtValue& _value, const TfToken& _role, HdInterpolation _interpolation)
+        : value(_value), role(_role), interpolation(_interpolation), dirtied(true)
+    {
+    }
+};
+
+/// Storing precomputed primvars.
+using HdArnoldPrimvarMap = std::unordered_map<TfToken, HdArnoldPrimvar, TfToken::HashFunctor>;
+
+/// Get the computed primvars using HdExtComputation.
+///
+/// @param delegate Pointer to the Hydra Scene Delegate.
+/// @param id Path to the Hyra Primitive.
+/// @param dirtyBits Dirty bits of what has changed for the current sync.
+/// @param primvars Output variable to store the computed primvars.
+void HdArnoldGetComputedPrimvars(
+    HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, HdArnoldPrimvarMap& primvars);
+
+/// Get the non-computed primvars and ignoring the points primvar. If multiple position keys are used, the function
+/// does not query the value of the normals.
+///
+/// @param delegate Pointer to the Hydra Scene Delegate.
+/// @param id Path to the Hyra Primitive.
+/// @param dirtyBits Dirty bits of what has changed for the current sync.
+/// @param multiplePositionKeys If the points primvar has multiple position keys.
+/// @param primvars Output variable to store the primvars.
+void HdArnoldGetPrimvars(
+    HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, bool multiplePositionKeys,
+    HdArnoldPrimvarMap& primvars);
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding support for computed primvars

**Issues fixed in this pull request**
Fixes #265 

**Additional context**
I raised the minimum required USD version to 19.05 since some of the ext computation utils are named differently in previous versions. Katana 3.2 uses 19.05 and Houdini ships 19.11, so it's reasonable to bump up the version requirement.
