### PR TITLE
Improving render API usage.

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -215,7 +215,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
     if (*dirtyBits & HdLight::DirtyParams) {
         // We need to force dirtying the transform, because AiNodeReset resets the transformation.
         *dirtyBits |= HdLight::DirtyTransform;
-        param->End();
+        param->Interrupt();
         const auto id = GetId();
         const auto* nentry = AiNodeGetNodeEntry(_light);
         AiNodeReset(_light);
@@ -230,7 +230,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
     }
 
     if (*dirtyBits & HdLight::DirtyTransform) {
-        param->End();
+        param->Interrupt();
         HdArnoldSetTransform(_light, sceneDelegate, GetId());
     }
 

--- a/render_delegate/material.cpp
+++ b/render_delegate/material.cpp
@@ -345,7 +345,7 @@ void HdArnoldMaterial::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rende
     // Note, Katana 3.2 always dirties the resource, so we don't have to check
     // for dirtyParams or dirtySurfaceShader.
     if ((*dirtyBits & HdMaterial::DirtyResource) && !id.IsEmpty()) {
-        param->End();
+        param->Interrupt();
         auto value = sceneDelegate->GetMaterialResource(GetId());
         AtNode* surfaceEntry = nullptr;
         AtNode* displacementEntry = nullptr;

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -147,12 +147,12 @@ void HdArnoldMesh::Sync(
     if (_primvars.count(HdTokens->points) != 0) {
         _numberOfPositionKeys = 1;
     } else if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
-        param->End();
+        param->Interrupt();
         _numberOfPositionKeys = HdArnoldSetPositionFromPrimvar(_shape.GetShape(), id, delegate, str::vlist);
     }
 
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         const auto topology = GetMeshTopology(delegate);
         // We have to flip the orientation if it's left handed.
         const auto isLeftHanded = topology.GetOrientation() == PxOsdOpenSubdivTokens->leftHanded;
@@ -195,7 +195,7 @@ void HdArnoldMesh::Sync(
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         _UpdateVisibility(delegate, dirtyBits);
         _shape.SetVisibility(_sharedData.visible ? AI_RAY_ALL : uint8_t{0});
     }
@@ -208,7 +208,7 @@ void HdArnoldMesh::Sync(
 
     auto transformDirtied = false;
     if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         HdArnoldSetTransform(_shape.GetShape(), delegate, GetId());
         transformDirtied = true;
     }
@@ -275,14 +275,14 @@ void HdArnoldMesh::Sync(
             delegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, delegate->GetMaterialId(id)));
     };
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-        param->End();
+        param->Interrupt();
         arnoldMaterial = queryMaterial();
         assignMaterial(_IsVolume(), arnoldMaterial);
     }
 
     if (dirtyPrimvars) {
         HdArnoldGetPrimvars(delegate, id, *dirtyBits, _numberOfPositionKeys > 1, _primvars);
-        param->End();
+        param->Interrupt();
         const auto isVolume = _IsVolume();
         auto visibility = _shape.GetVisibility();
         for (const auto& primvar : _primvars) {

--- a/render_delegate/points.cpp
+++ b/render_delegate/points.cpp
@@ -69,12 +69,12 @@ void HdArnoldPoints::Sync(
     auto* param = reinterpret_cast<HdArnoldRenderParam*>(renderParam);
     const auto& id = GetId();
     if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
-        param->End();
+        param->Interrupt();
         HdArnoldSetPositionFromPrimvar(_shape.GetShape(), id, delegate, str::points);
         // HdPrman exports points like this, but this method does not support
         // motion blurred points.
     } else if (*dirtyBits & HdChangeTracker::DirtyPoints) {
-        param->End();
+        param->Interrupt();
         const auto pointsValue = delegate->Get(id, HdTokens->points);
         if (!pointsValue.IsEmpty() && pointsValue.IsHolding<VtVec3fArray>()) {
             const auto& points = pointsValue.UncheckedGet<VtVec3fArray>();
@@ -85,18 +85,18 @@ void HdArnoldPoints::Sync(
     }
 
     if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->widths)) {
-        param->End();
+        param->Interrupt();
         HdArnoldSetRadiusFromPrimvar(_shape.GetShape(), id, delegate);
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         _UpdateVisibility(delegate, dirtyBits);
         AiNodeSetByte(_shape.GetShape(), str::visibility, _sharedData.visible ? AI_RAY_ALL : uint8_t{0});
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-        param->End();
+        param->Interrupt();
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
             delegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, delegate->GetMaterialId(id)));
         if (material != nullptr) {
@@ -107,7 +107,7 @@ void HdArnoldPoints::Sync(
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        param->End();
+        param->Interrupt();
         for (const auto& primvar : delegate->GetPrimvarDescriptors(id, HdInterpolation::HdInterpolationConstant)) {
             HdArnoldSetConstantPrimvar(_shape.GetShape(), id, delegate, primvar);
         }

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -362,7 +362,7 @@ HdArnoldRenderDelegate::~HdArnoldRenderDelegate()
     if (_counterResourceRegistry.fetch_sub(1) == 1) {
         _resourceRegistry.reset();
     }
-    _renderParam->End();
+    _renderParam->Interrupt();
     hdArnoldUninstallNodes();
     AiUniverseDestroy(_universe);
     AiEnd();
@@ -437,7 +437,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& key, const VtValue
 
 void HdArnoldRenderDelegate::SetRenderSetting(const TfToken& key, const VtValue& value)
 {
-    _renderParam->End();
+    _renderParam->Interrupt();
     _SetRenderSetting(key, value);
 }
 
@@ -516,7 +516,7 @@ void HdArnoldRenderDelegate::DestroyInstancer(HdInstancer* instancer) { delete i
 
 HdRprim* HdArnoldRenderDelegate::CreateRprim(const TfToken& typeId, const SdfPath& rprimId, const SdfPath& instancerId)
 {
-    _renderParam->End();
+    _renderParam->Interrupt();
     if (typeId == HdPrimTypeTokens->mesh) {
         return new HdArnoldMesh(this, rprimId, instancerId);
     }
@@ -532,13 +532,13 @@ HdRprim* HdArnoldRenderDelegate::CreateRprim(const TfToken& typeId, const SdfPat
 
 void HdArnoldRenderDelegate::DestroyRprim(HdRprim* rPrim)
 {
-    _renderParam->End();
+    _renderParam->Interrupt();
     delete rPrim;
 }
 
 HdSprim* HdArnoldRenderDelegate::CreateSprim(const TfToken& typeId, const SdfPath& sprimId)
 {
-    _renderParam->End();
+    _renderParam->Interrupt();
     if (typeId == HdPrimTypeTokens->camera) {
         return new HdCamera(sprimId);
     }
@@ -613,7 +613,7 @@ HdSprim* HdArnoldRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
 
 void HdArnoldRenderDelegate::DestroySprim(HdSprim* sPrim)
 {
-    _renderParam->End();
+    _renderParam->Interrupt();
     delete sPrim;
 }
 

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -48,18 +48,6 @@ bool HdArnoldRenderParam::Render()
     return false;
 }
 
-void HdArnoldRenderParam::Restart()
-{
-    const auto status = AiRenderGetStatus();
-    if (status != AI_RENDER_STATUS_NOT_STARTED) {
-        if (status == AI_RENDER_STATUS_RENDERING) {
-            AiRenderInterrupt(AI_BLOCKING);
-        } else if (status == AI_RENDER_STATUS_FINISHED) {
-            AiRenderRestart();
-        }
-    }
-}
-
 void HdArnoldRenderParam::End()
 {
     const auto status = AiRenderGetStatus();

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -34,10 +34,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 bool HdArnoldRenderParam::Render()
 {
     const auto status = AiRenderGetStatus();
-    if (status == AI_RENDER_STATUS_NOT_STARTED) {
-        AiRenderBegin();
-        return false;
-    }
     if (status == AI_RENDER_STATUS_PAUSED) {
         AiRenderRestart();
         return false;
@@ -68,10 +64,7 @@ void HdArnoldRenderParam::End()
 {
     const auto status = AiRenderGetStatus();
     if (status != AI_RENDER_STATUS_NOT_STARTED) {
-        if (status == AI_RENDER_STATUS_RENDERING || status == AI_RENDER_STATUS_RESTARTING) {
-            AiRenderAbort(AI_BLOCKING);
-        }
-        AiRenderEnd();
+        AiRenderInterrupt(AI_BLOCKING);
     }
 }
 

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -48,7 +48,7 @@ bool HdArnoldRenderParam::Render()
     return false;
 }
 
-void HdArnoldRenderParam::End()
+void HdArnoldRenderParam::Interrupt()
 {
     const auto status = AiRenderGetStatus();
     if (status != AI_RENDER_STATUS_NOT_STARTED) {

--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -52,11 +52,11 @@ public:
     /// @return True if Arnold Core has finished converging.
     HDARNOLD_API
     bool Render();
-    /// Ends an ongoing render.
+    /// Interrupts an ongoing render.
     ///
-    /// Useful when any of the primitives want to make changes.
+    /// Useful when there is new data to display, or the render settings have changed.
     HDARNOLD_API
-    void End();
+    void Interrupt();
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -52,12 +52,6 @@ public:
     /// @return True if Arnold Core has finished converging.
     HDARNOLD_API
     bool Render();
-    /// Restarts rendering if it's already running or finished.
-    ///
-    /// Restarts rendering if the render is already running or finished. Useful
-    /// when the camera or the rendering resultion changes.
-    HDARNOLD_API
-    void Restart();
     /// Ends an ongoing render.
     ///
     /// Useful when any of the primitives want to make changes.

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -101,7 +101,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     if (projMtx != _projMtx || viewMtx != _viewMtx) {
         _projMtx = projMtx;
         _viewMtx = viewMtx;
-        renderParam->Restart();
+        renderParam->End();
         AiNodeSetMatrix(_camera, str::matrix, HdArnoldConvertMatrix(_viewMtx.GetInverse()));
         AiNodeSetMatrix(_driver, HdArnoldDriver::projMtx, HdArnoldConvertMatrix(_projMtx));
         AiNodeSetMatrix(_driver, HdArnoldDriver::viewMtx, HdArnoldConvertMatrix(_viewMtx));

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -98,12 +98,10 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
 
     const auto projMtx = renderPassState->GetProjectionMatrix();
     const auto viewMtx = renderPassState->GetWorldToViewMatrix();
-    auto restarted = false;
     if (projMtx != _projMtx || viewMtx != _viewMtx) {
         _projMtx = projMtx;
         _viewMtx = viewMtx;
         renderParam->Restart();
-        restarted = true;
         AiNodeSetMatrix(_camera, str::matrix, HdArnoldConvertMatrix(_viewMtx.GetInverse()));
         AiNodeSetMatrix(_driver, HdArnoldDriver::projMtx, HdArnoldConvertMatrix(_projMtx));
         AiNodeSetMatrix(_driver, HdArnoldDriver::viewMtx, HdArnoldConvertMatrix(_viewMtx));
@@ -115,9 +113,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     const auto height = static_cast<int>(vp[3]);
     const auto numPixels = static_cast<size_t>(width * height);
     if (width != _width || height != _height) {
-        if (!restarted) {
-            renderParam->Restart();
-        }
+        renderParam->End();
         hdArnoldEmptyBucketQueue([](const HdArnoldBucketData*) {});
         const auto oldNumPixels = static_cast<size_t>(_width * _height);
         _width = width;

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -101,7 +101,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     if (projMtx != _projMtx || viewMtx != _viewMtx) {
         _projMtx = projMtx;
         _viewMtx = viewMtx;
-        renderParam->End();
+        renderParam->Interrupt();
         AiNodeSetMatrix(_camera, str::matrix, HdArnoldConvertMatrix(_viewMtx.GetInverse()));
         AiNodeSetMatrix(_driver, HdArnoldDriver::projMtx, HdArnoldConvertMatrix(_projMtx));
         AiNodeSetMatrix(_driver, HdArnoldDriver::viewMtx, HdArnoldConvertMatrix(_viewMtx));
@@ -113,7 +113,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     const auto height = static_cast<int>(vp[3]);
     const auto numPixels = static_cast<size_t>(width * height);
     if (width != _width || height != _height) {
-        renderParam->End();
+        renderParam->Interrupt();
         hdArnoldEmptyBucketQueue([](const HdArnoldBucketData*) {});
         const auto oldNumPixels = static_cast<size_t>(_width * _height);
         _width = width;

--- a/render_delegate/shape.cpp
+++ b/render_delegate/shape.cpp
@@ -97,7 +97,7 @@ void HdArnoldShape::_SyncInstances(
 #endif
         return;
     }
-    param->End();
+    param->Interrupt();
     // We need to hide the source mesh.
     AiNodeSetByte(_shape, str::visibility, 0);
 #ifndef HDARNOLD_USE_INSTANCER
@@ -172,7 +172,7 @@ void HdArnoldShape::_UpdateInstanceVisibility(size_t count, HdArnoldRenderParam*
         return;
     }
     if (param != nullptr) {
-        param->End();
+        param->Interrupt();
     }
     AiNodeSetArray(_instancer, str::instance_visibility, AiArray(1, 1, AI_TYPE_BYTE, _visibility));
 #else
@@ -188,7 +188,7 @@ void HdArnoldShape::_UpdateInstanceVisibility(size_t count, HdArnoldRenderParam*
     }
     // If param is not nullptr, we have to stop the rendering process and signal that we have to changed something.
     if (param != nullptr) {
-        param->End();
+        param->Interrupt();
     }
     count = std::min(count, _instances.size());
     for (auto index = decltype(count){0}; index < count; index += 1) {

--- a/render_delegate/volume.cpp
+++ b/render_delegate/volume.cpp
@@ -190,13 +190,13 @@ void HdArnoldVolume::Sync(
     const auto& id = GetId();
     auto volumesChanged = false;
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         _CreateVolumes(id, delegate);
         volumesChanged = true;
     }
 
     if (volumesChanged || (*dirtyBits & HdChangeTracker::DirtyMaterialId)) {
-        param->End();
+        param->Interrupt();
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
             delegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, delegate->GetMaterialId(id)));
         auto* volumeShader = material != nullptr ? material->GetVolumeShader() : _delegate->GetFallbackVolumeShader();
@@ -205,19 +205,19 @@ void HdArnoldVolume::Sync(
 
     auto transformDirtied = false;
     if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         _ForEachVolume([&](HdArnoldShape* s) { HdArnoldSetTransform(s->GetShape(), delegate, GetId()); });
         transformDirtied = true;
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        param->End();
+        param->Interrupt();
         _UpdateVisibility(delegate, dirtyBits);
         _ForEachVolume([&](HdArnoldShape* s) { s->SetVisibility(_sharedData.visible ? AI_RAY_ALL : uint8_t{0}); });
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        param->End();
+        param->Interrupt();
         auto visibility = AI_RAY_ALL;
         if (!_volumes.empty()) {
             visibility = _volumes.front()->GetVisibility();


### PR DESCRIPTION
**Changes proposed in this pull request**
- Improving render API usage.
- Using `AiRenderInterrupt` instead of `AiRenderAbort`.
- Not using `AiRenderEnd` anymore.
- Removed `HdArnoldRenderParam::Restart`.
- Renamed `HdArnoldRenderParam::End` to `HdArnoldRenderParam::Interrupt` to better reflect what the function is doing.

**Issues fixed in this pull request**
Fixes #270

