### PR TITLE
Add mask parameter to the usd writer 

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -257,7 +257,8 @@ scene_load
     return true;
 }
 
-// bool SceneWrite(AtUniverse* universe, const char* filename, const AtParamValueMap* params, const AtMetadataStore* mds)
+// bool SceneWrite(AtUniverse* universe, const char* filename, 
+//                 const AtParamValueMap* params, const AtMetadataStore* mds)
 scene_write
 {
     // Create a new USD stage to write out the .usd file
@@ -266,8 +267,16 @@ scene_write
     // Create a "writer" Translator that will handle the conversion
     UsdArnoldWriter* writer = new UsdArnoldWriter();
     writer->setUsdStage(stage);    // give it the output stage
+
+    // Check if a mask has been set through the params map
+    int mask = AI_NODE_ALL;
+    static const AtString maskStr("mask");
+    if (AiParamValueMapGetInt(params, maskStr, &mask))
+        writer->setMask(mask); // only write out this type or arnold nodes
+    
     writer->write(universe);       // convert this universe please
     stage->GetRootLayer()->Save(); // Ask USD to save out the file
+        
     delete writer;
     return true;
 }

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -54,7 +54,7 @@ void UsdArnoldWriter::write(const AtUniverse *universe)
     _exportedNodes.clear(); 
 
     // Loop over the universe nodes, and write each of them
-    AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, AI_NODE_ALL);
+    AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, _mask);
     while (!AiNodeIteratorFinished(iter)) {
         writePrimitive(AiNodeIteratorGetNext(iter));
     }

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -32,7 +32,7 @@ class UsdArnoldWriterRegistry;
 
 class UsdArnoldWriter {
 public:
-    UsdArnoldWriter() : _universe(NULL), _registry(NULL), _writeBuiltin(true) {}
+    UsdArnoldWriter() : _universe(NULL), _registry(NULL), _writeBuiltin(true), _mask(AI_NODE_ALL) {}
     ~UsdArnoldWriter() {}
 
     void write(const AtUniverse *universe);  // convert a given arnold universe
@@ -49,6 +49,9 @@ public:
     void setWriteBuiltin(bool b) { _writeBuiltin = b;}
     bool getWriteBuiltin() const { return _writeBuiltin;}
 
+    void setMask(int m) {_mask = m;}
+    int getMask() const {return _mask;}
+
     bool isNodeExported(const AtString &name) { return _exportedNodes.count(name) == 1;}
 
 
@@ -58,5 +61,7 @@ private:
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
+    int _mask;                          // Mask based on arnold flags (AI_NODE_SHADER, etc...),
+                                        // determining what arnold nodes must be saved out
     std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
Adding a parameter "mask" on the USD writer. It will determine over which type of arnold nodes we loop when converting the scene to usd.

The scene format writer function looks for a parameter `mask` from the `AtParamValue` argument, and eventually sets it in the writer before running the conversion

**Issues fixed in this pull request**
Fixes #274