### PR TITLE
Add mask to the usd reader

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -250,6 +250,10 @@ scene_load
     // eventually check the input param map in case we have an entry for "frame"
     AiParamValueMapGetFlt(params, AtString("frame"), &frame);
     reader->setFrame(frame);
+
+    int mask = AI_NODE_ALL;
+    if (AiParamValueMapGetInt(params, AtString("mask"), &mask))
+        reader->setMask(mask);    
     
     // Read the USD file
     reader->read(filename, nullptr);

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -182,9 +182,18 @@ void UsdArnoldReader::readStage(UsdStageRefPtr stage, const std::string &path)
             s_readerRegistry = new UsdArnoldReaderRegistry(); // initialize the global registry
             s_readerRegistry->registerPrimitiveReaders();
         }
-
         _registry = s_readerRegistry;
     }
+    // If this is read through a procedural, we don't want to read 
+    // options, drivers, filters, etc...
+    int procMask = (_procParent) ? (AI_NODE_CAMERA | AI_NODE_LIGHT |
+                                    AI_NODE_SHAPE | AI_NODE_SHADER | 
+                                    AI_NODE_OPERATOR): AI_NODE_ALL;
+
+    // Note that the user might have set a mask on a custom registry.
+    // We want to consider the intersection of the reader's mask, 
+    // the existing registry mask, and the eventual procedural mask set above
+    s_readerRegistry->setMask(s_readerRegistry->getMask() & _mask & procMask);            
 
     UsdPrim rootPrim;
     UsdPrim *rootPrimPtr = nullptr;

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -39,6 +39,7 @@ public:
                         _convert(true),
                         _debug(false), 
                         _threadCount(1),
+                        _mask(AI_NODE_ALL),
                         _defaultShader(nullptr),
                         _overrides(nullptr),
                         _readerLock(nullptr),
@@ -61,6 +62,7 @@ public:
     void setDebug(bool b);
     void setThreadCount(unsigned int t);
     void setConvertPrimitives(bool b);
+    void setMask(int m) {_mask = m;}
 
     const UsdStageRefPtr &getStage() const { return _stage; }
     const std::vector<AtNode *> &getNodes() const { return _nodes; }
@@ -74,6 +76,7 @@ public:
     const std::string &getFilename() const {return _filename;}
     const AtArray *getOverrides() const {return _overrides;}
     unsigned int getThreadCount() const {return _threadCount;}
+    int getMask() const {return _mask;}
 
     static unsigned int RenderThread(void *data);
     static unsigned int ProcessConnectionsThread(void *data);
@@ -131,6 +134,8 @@ private:
     bool _convert;                      // do we want to convert the primitives attributes
     bool _debug;
     unsigned int _threadCount;
+    int _mask;             // mask based on the arnold flags (AI_NODE_SHADER, etc...) to control
+                           // what type of nodes are being read
     UsdStageRefPtr _stage; // current stage being read. Will be cleared once
                            // finished reading
     std::vector<AtNode *> _nodes;

--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -34,29 +34,34 @@ void UsdArnoldReaderRegistry::registerPrimitiveReaders()
     // builtin types
 
     // USD builtin Shapes
-    registerReader("Mesh", new UsdArnoldReadMesh());
-    registerReader("Curves", new UsdArnoldReadCurves());
-    registerReader("BasisCurves", new UsdArnoldReadCurves());
-    registerReader("Points", new UsdArnoldReadPoints());
-    registerReader("Cube", new UsdArnoldReadCube());
-    registerReader("Sphere", new UsdArnoldReadSphere());
-    registerReader("Cylinder", new UsdArnoldReadCylinder());
-    registerReader("Cone", new UsdArnoldReadCone());
-    registerReader("Capsule", new UsdArnoldReadCapsule());
-    registerReader("PointInstancer", new UsdArnoldReadPointInstancer());
-    registerReader("Nurbs", new UsdArnoldReadUnsupported("Nurbs"));
-    registerReader("Volume", new UsdArnoldReadVolume());
+    if (_mask & AI_NODE_SHAPE) {
+        registerReader("Mesh", new UsdArnoldReadMesh());
+        registerReader("Curves", new UsdArnoldReadCurves());
+        registerReader("BasisCurves", new UsdArnoldReadCurves());
+        registerReader("Points", new UsdArnoldReadPoints());
+        registerReader("Cube", new UsdArnoldReadCube());
+        registerReader("Sphere", new UsdArnoldReadSphere());
+        registerReader("Cylinder", new UsdArnoldReadCylinder());
+        registerReader("Cone", new UsdArnoldReadCone());
+        registerReader("Capsule", new UsdArnoldReadCapsule());
+        registerReader("PointInstancer", new UsdArnoldReadPointInstancer());
+        registerReader("Nurbs", new UsdArnoldReadUnsupported("Nurbs"));
+        registerReader("Volume", new UsdArnoldReadVolume());
+    }
 
     // USD builtin Lights
-    registerReader("DistantLight", new UsdArnoldReadDistantLight());
-    registerReader("DomeLight", new UsdArnoldReadDomeLight());
-    registerReader("DiskLight", new UsdArnoldReadDiskLight());
-    registerReader("SphereLight", new UsdArnoldReadSphereLight());
-    registerReader("RectLight", new UsdArnoldReadRectLight());
-    registerReader("GeometryLight", new UsdArnoldReadGeometryLight());
+    if (_mask & AI_NODE_LIGHT) {
+        registerReader("DistantLight", new UsdArnoldReadDistantLight());
+        registerReader("DomeLight", new UsdArnoldReadDomeLight());
+        registerReader("DiskLight", new UsdArnoldReadDiskLight());
+        registerReader("SphereLight", new UsdArnoldReadSphereLight());
+        registerReader("RectLight", new UsdArnoldReadRectLight());
+        registerReader("GeometryLight", new UsdArnoldReadGeometryLight());
+    }
 
     // USD Shaders (builtin, or custom ones, including arnold)
-    registerReader("Shader", new UsdArnoldReadShader());
+    if (_mask & AI_NODE_SHADER)
+        registerReader("Shader", new UsdArnoldReadShader());
 
     // Now let's iterate over all the arnold classes known at this point
     bool universeCreated = false;
@@ -78,6 +83,9 @@ void UsdArnoldReaderRegistry::registerPrimitiveReaders()
 
         // Do we need different behaviour depending on the entry type name ?
         std::string entryTypeName = AiNodeEntryGetTypeName(nodeEntry);
+        int nodeEntryType = AiNodeEntryGetType(nodeEntry);
+        if (!(nodeEntryType & _mask)) // This node type isn't meant to be read
+            continue;
 
         // FIXME: should we switch to camel case for usd node types ?
         std::string usdName = makeCamelCase(entryName);

--- a/translator/reader/registry.h
+++ b/translator/reader/registry.h
@@ -34,7 +34,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 class UsdArnoldReaderRegistry {
 public:
-    UsdArnoldReaderRegistry() {}
+    UsdArnoldReaderRegistry() :_mask(AI_NODE_ALL) {}
     virtual ~UsdArnoldReaderRegistry();
 
     virtual void registerPrimitiveReaders();
@@ -42,6 +42,8 @@ public:
     // If an existing one was previously registed for this same type, it will be
     // deleted and overridden
     void registerReader(const std::string &primName, UsdArnoldPrimReader *primReader);
+    void setMask(int m) {_mask = m;}
+    int getMask() const {return _mask;}
 
     UsdArnoldPrimReader *getPrimReader(const std::string &primName)
     {
@@ -53,6 +55,9 @@ public:
         return it->second;
     }
 
+protected:
+    int _mask; // Mask based on arnold flags (AI_NODE_SHADER, etc...) 
+               // to filter out the nodes being loaded
 private:
     std::unordered_map<std::string, UsdArnoldPrimReader *> _readersMap;
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
We're adding a parameter `mask` to the reader in order to filter the type of nodes that are exported from usd to arnold. We use this mask to prevent options, filters, drivers, etc... to be created when loading a usd file through a procedural. This way we're consistent with .ass procedurals 

This is an enhancement since we provide a new feature, but it's also a bugfix because the current behaviour is causing crashes in the arnold plugins.

**Issues fixed in this pull request**
Fixes #276 
