### PR TITLE
Fix warnings with UsdPreviewSurface in the procedural

### DIFF
--- a/translator/reader/read_shader.cpp
+++ b/translator/reader/read_shader.cpp
@@ -99,7 +99,7 @@ void UsdArnoldReadShader::read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AiNodeSetFlt(node, "specular_roughness", 0.5);
         exportParameter(shader, node, "roughness", "specular_roughness", context);
 
-        AiNodeSetFlt(node, " specular_IOR  ", 1.5);
+        AiNodeSetFlt(node, "specular_IOR", 1.5);
         exportParameter(shader, node, "ior", "specular_IOR", context);
 
         AiNodeSetFlt(node, "coat", 0.f);
@@ -108,7 +108,7 @@ void UsdArnoldReadShader::read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AiNodeSetFlt(node, "coat_roughness", 0.01f);
         exportParameter(shader, node, "clearcoatRoughness", "coat_roughness", context);
 
-        AiNodeSetFlt(node, "opacity", 1.f);
+        AiNodeSetRGB(node, "opacity", 1.f, 1.f, 1.f);
         exportParameter(shader, node, "opacity", "opacity", context);
 
         UsdShadeInput normalInput = shader.GetInput(TfToken("normal"));


### PR DESCRIPTION
**Changes proposed in this pull request**
There were some typos in the reader when loading a `UsdPreviewSurface`. Some empty spaces around the " specular_IOR " attribute name, and we were setting the opacity as a float instead of RGB.

**Issues fixed in this pull request**
Fixes #284 