### PR TITLE
Fix crash in the viewport functions #295

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -192,7 +192,7 @@ void UsdArnoldReader::readStage(UsdStageRefPtr stage, const std::string &path)
     // Note that the user might have set a mask on a custom registry.
     // We want to consider the intersection of the reader's mask, 
     // the existing registry mask, and the eventual procedural mask set above
-    _registry->setMask(_registry->getMask() & _mask & procMask);            
+    _registry->setMask(_registry->getMask() & _mask & procMask);
     
     // Register the prim readers now
     _registry->registerPrimitiveReaders();

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -192,7 +192,7 @@ void UsdArnoldReader::readStage(UsdStageRefPtr stage, const std::string &path)
     // Note that the user might have set a mask on a custom registry.
     // We want to consider the intersection of the reader's mask, 
     // the existing registry mask, and the eventual procedural mask set above
-    _registry->setMask(s_readerRegistry->getMask() & _mask & procMask);            
+    _registry->setMask(_registry->getMask() & _mask & procMask);            
     
     // Register the prim readers now
     _registry->registerPrimitiveReaders();


### PR DESCRIPTION
**Changes proposed in this pull request**
We were using `s_readerRegistry` which is null when called by the viewport API `procedural_viewport`.
We should simply be using `_registry` that is tested and set properly.

**Issues fixed in this pull request**
Fixes #295 
