### PR TITLE
Prevent crashes when writing USD files with upper-case extensions

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -264,8 +264,19 @@ scene_load
 //                 const AtParamValueMap* params, const AtMetadataStore* mds)
 scene_write
 {
+    std::string filenameStr(filename);
+
+    std::string extension = filenameStr.substr(filenameStr.find_last_of('.'));
+    if (extension == ".USD" || extension == ".USDA" || extension == ".USDC") {
+        std::transform(extension.begin(), extension.end(), extension.begin(),
+            [](unsigned char c){ return std::tolower(c, std::locale()); });
+        filenameStr = filenameStr.substr(0, filenameStr.find_last_of('.'));
+        filenameStr += extension;
+        AiMsgWarning("[usd] Filename extensions must be lower-case. Saving to %s", filenameStr.c_str());
+    }
+    
     // Create a new USD stage to write out the .usd file
-    UsdStageRefPtr stage = UsdStage::Open(SdfLayer::CreateNew(filename));
+    UsdStageRefPtr stage = UsdStage::Open(SdfLayer::CreateNew(filenameStr.c_str()));
 
     // Create a "writer" Translator that will handle the conversion
     UsdArnoldWriter* writer = new UsdArnoldWriter();

--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -155,6 +155,11 @@ procedural_viewport
 
     applyProceduralSearchPath(filename, universe);
 
+    if (!UsdStage::IsSupportedFile(filename)) {
+        AiMsgError("[usd] Filename not supported : %s", filename.c_str());
+        return false;
+    }
+
     // For now we always create a new reader for the viewport display, 
     // can we reuse the eventual existing one ?
     UsdArnoldReader *reader = new UsdArnoldReader();
@@ -240,6 +245,11 @@ AI_SCENE_FORMAT_EXPORT_METHODS(UsdSceneFormatMtd);
 // SceneLoad(AtUniverse* universe, const char* filename, const AtParamValueMap* params)
 scene_load
 {
+    if (!UsdStage::IsSupportedFile(filename)) {
+        AiMsgError("[usd] Filename not supported : %s", filename);
+        return false;
+    }
+
     // Create a reader with no procedural parent
     UsdArnoldReader *reader = new UsdArnoldReader();
     // set the arnold universe on which the scene will be converted
@@ -274,9 +284,18 @@ scene_write
         filenameStr += extension;
         AiMsgWarning("[usd] Filename extensions must be lower-case. Saving to %s", filenameStr.c_str());
     }
-    
+
+    if (!UsdStage::IsSupportedFile(filenameStr)) {
+        AiMsgError("[usd] Filename not supported : %s", filenameStr.c_str());
+        return false;
+    }
     // Create a new USD stage to write out the .usd file
     UsdStageRefPtr stage = UsdStage::Open(SdfLayer::CreateNew(filenameStr.c_str()));
+    
+    if (stage == nullptr) {
+        AiMsgError("[usd] Invalid USD Stage : %s", filenameStr.c_str());
+        return false;   
+    }
 
     // Create a "writer" Translator that will handle the conversion
     UsdArnoldWriter* writer = new UsdArnoldWriter();

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -165,6 +165,10 @@ void UsdArnoldReader::readStage(UsdStageRefPtr stage, const std::string &path)
 {
     // set the stage while we're reading
     _stage = stage;
+    if (stage == nullptr) {
+        AiMsgError("[usd] Impossible to read USD Stage %s", _filename.c_str());
+        return;
+    }
 
     if (_debug) {
         std::string txt("==== Initializing Usd Reader ");

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -166,7 +166,7 @@ void UsdArnoldReader::readStage(UsdStageRefPtr stage, const std::string &path)
     // set the stage while we're reading
     _stage = stage;
     if (stage == nullptr) {
-        AiMsgError("[usd] Impossible to read USD Stage %s", _filename.c_str());
+        AiMsgError("[usd] Unable to create USD stage from %s", _filename.c_str());
         return;
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
When trying to write to a USD file with upper-case extensions, we convert it to lower case to prevent the crashes
 
**Issues fixed in this pull request**
Fixes #288
