### PR TITLE
Remove arnold:global: prefix (#302)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -259,7 +259,7 @@ if env['COMPILER'] in ['gcc', 'clang']:
     if env['WARN_LEVEL'] == 'none':
         env.Append(CCFLAGS = Split('-w'))
     else:
-        env.Append(CCFLAGS = Split('-Wall -Wsign-compare'))
+        env.Append(CCFLAGS = Split('-Wall -Wsign-compare -Wno-deprecated-register -Wno-undefined-var-template -Wno-unused-local-typedef'))
         if env['WARN_LEVEL'] == 'strict':
             env.Append(CCFLAGS = Split('-Werror'))
 

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -296,9 +296,9 @@ void _CheckForIntValue(const VtValue& value, F&& f)
     }
 }
 
-inline TfToken _RemoveArnoldGlobalPrefix(const TfToken& key)
+void _RemoveArnoldGlobalPrefix(const TfToken& key, TfToken& key_new)
 {
-    return TfStringStartsWith(key, _tokens->arnoldGlobal) ? TfToken{key.GetText() + _tokens->arnoldGlobal.size()} : key;
+    key_new = TfStringStartsWith(key, _tokens->arnoldGlobal) ? TfToken{key.GetText() + _tokens->arnoldGlobal.size()} : key;
 }
 
 } // namespace
@@ -386,7 +386,8 @@ const TfTokenVector& HdArnoldRenderDelegate::GetSupportedBprimTypes() const { re
 
 void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValue& _value)
 {
-    const auto key = _RemoveArnoldGlobalPrefix(_key);
+    TfToken key;
+    _RemoveArnoldGlobalPrefix(_key, key);
 
     // Currently usdview can return double for floats, so until it's fixed
     // we have to convert doubles to float.
@@ -451,7 +452,8 @@ void HdArnoldRenderDelegate::SetRenderSetting(const TfToken& key, const VtValue&
 
 VtValue HdArnoldRenderDelegate::GetRenderSetting(const TfToken& _key) const
 {
-    const auto key = _RemoveArnoldGlobalPrefix(_key);
+    TfToken key;
+    _RemoveArnoldGlobalPrefix(_key, key);
 
     if (key == str::t_enable_gpu_rendering) {
         return VtValue(AiNodeGetStr(_options, str::render_device) == str::GPU);

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -91,7 +91,7 @@ public:
     /// @param key Name of the Render Setting to get.
     /// @return Value of the Render Setting.
     HDARNOLD_API
-    VtValue GetRenderSetting(const TfToken& key) const override;
+    VtValue GetRenderSetting(const TfToken& _key) const override;
     /// Gets the list of Render Setting descriptors.
     ///
     /// @return std::vector holding HdRenderSettingDescriptor for all the
@@ -240,7 +240,7 @@ private:
     HdArnoldRenderDelegate(const HdArnoldRenderDelegate&) = delete;
     HdArnoldRenderDelegate& operator=(const HdArnoldRenderDelegate&) = delete;
 
-    void _SetRenderSetting(const TfToken& key, const VtValue& value);
+    void _SetRenderSetting(const TfToken& _key, const VtValue& value);
 
     /// Mutex for the shared Resource Registry.
     static std::mutex _mutexResourceRegistry;

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -198,7 +198,7 @@ public:
     ///
     /// @return Name of the preferred material network.
     HDARNOLD_API
-    TfToken GetMaterialNetworkSelector() const;
+    TfToken GetMaterialNetworkSelector() const override;
     /// Suffixes Node names with the Render Delegate's paths.
     ///
     /// @param name Name of the Node.

--- a/render_delegate/render_pass.h
+++ b/render_delegate/render_pass.h
@@ -65,7 +65,7 @@ public:
     /// Returns true if the render has converged.
     ///
     /// @return True if the render has converged.
-    bool IsConverged() const { return _isConverged; }
+    bool IsConverged() const override { return _isConverged; }
 
 protected:
     /// Executing the Render Pass.


### PR DESCRIPTION
Remove arnold:global: prefix (see #302) due to namespacing of render settings parameters.