### PR TITLE
Translate the options node properly

### DIFF
--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -139,7 +139,7 @@ void UsdArnoldPrimReader::readArnoldParameters(
                             // FIXME: ensure enum is working here
                         case AI_TYPE_ENUM:
                         case AI_TYPE_STRING:
-                            exportArray<std::string, std::string>(attr, node, arnoldAttr.c_str(), time);
+                            exportStringArray(attr, node, arnoldAttr.c_str(), time);
                             break;
                     }
                     {

--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -139,7 +139,7 @@ void UsdArnoldPrimReader::readArnoldParameters(
                             // FIXME: ensure enum is working here
                         case AI_TYPE_ENUM:
                         case AI_TYPE_STRING:
-                            exportArray<TfToken, TfToken>(attr, node, arnoldAttr.c_str(), time);
+                            exportArray<std::string, std::string>(attr, node, arnoldAttr.c_str(), time);
                             break;
                     }
                     {

--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -453,3 +453,41 @@ void exportParameter(
     }
 }
 
+size_t exportStringArray(UsdAttribute attr, AtNode* node, const char* attr_name, const TimeSettings& time)
+{
+    // Strings can be represented in USD as std::string, TfToken or SdfAssetPath.
+    // We'll try to get the input attribute value as each of these types
+    VtArray<std::string> arrayStr;
+    VtArray<TfToken> arrayToken;
+    VtArray<SdfAssetPath> arrayPath;
+    AtArray *outArray = nullptr;
+
+    if (attr.Get(&arrayStr, time.frame)) {
+        size_t size = arrayStr.size();
+        if (size > 0) {
+            outArray = AiArrayAllocate(size, 1, AI_TYPE_STRING);
+            for (size_t i = 0; i < size; ++i) 
+                AiArraySetStr(outArray, i, AtString(arrayStr[i].c_str()));
+        } 
+    } else if (attr.Get(&arrayToken, time.frame)) {
+        size_t size = arrayToken.size();
+        if (size > 0) {
+            outArray = AiArrayAllocate(size, 1, AI_TYPE_STRING);
+            for (size_t i = 0; i < size; ++i) 
+                AiArraySetStr(outArray, i, AtString(arrayToken[i].GetText()));
+            
+        } 
+    } else if (attr.Get(&arrayPath, time.frame)) {
+        size_t size = arrayPath.size();
+        if (size > 0) {
+            outArray = AiArrayAllocate(size, 1, AI_TYPE_STRING);
+            for (size_t i = 0; i < size; ++i) 
+                AiArraySetStr(outArray, i, AtString(arrayPath[i].GetResolvedPath().c_str()));
+            
+        }
+    }
+    if (outArray)
+        AiNodeSetArray(node, attr_name, outArray);
+    else
+        AiNodeResetParameter(node, attr_name);
+}

--- a/translator/reader/utils.h
+++ b/translator/reader/utils.h
@@ -75,6 +75,11 @@ void MeshOrientation::orientFaceIndexAttribute(T& attr)
  */
 void exportMatrix(const UsdPrim& prim, AtNode* node, const TimeSettings& time, UsdArnoldReaderContext &context);
 
+/** Export String arrays, and handle the conversion from std::string / TfToken to AtString.
+ */
+size_t exportStringArray(UsdAttribute attr, AtNode* node, const char* attr_name, const TimeSettings& time);
+
+
 /** Convert a USD array attribute (type U), to an Arnold array (type A).
  *  When both types are identical, we can simply their pointer to create the
  *array. Otherwise we need to copy the data first
@@ -128,6 +133,10 @@ size_t exportArray(UsdAttribute attr, AtNode* node, const char* attr_name, const
             same_data = true;
     }
 
+    // Call a dedicated function for string conversions
+    if (attr_type == AI_TYPE_STRING)
+        return exportStringArray(attr, node, attr_name, time);
+
     bool animated = time.motion_blur && attr.ValueMightBeTimeVarying();
 
     if (!animated) {
@@ -138,15 +147,7 @@ size_t exportArray(UsdAttribute attr, AtNode* node, const char* attr_name, const
 
         size_t size = array.size();
         if (size > 0) {
-            if  (std::is_same<U, std::string>::value && same_data) {
-                // special case for strings, because AtString is a bit special
-                AtArray *strArray = AiArrayAllocate(size, 1, AI_TYPE_STRING);
-                for (size_t i = 0; i < size; ++i) {
-                    std::string  *strVal = (std::string*)&array[i];
-                    AiArraySetStr(strArray, i, AtString(strVal->c_str()));
-                }
-                AiNodeSetArray(node, attr_name, strArray);
-            } else if (same_data) {
+            if (same_data) {
                 // The USD data representation is the same as the Arnold one, we don't
                 // need to convert the data
                 AiNodeSetArray(node, attr_name, AiArrayConvert(size, 1, attr_type, array.cdata()));

--- a/translator/reader/utils.h
+++ b/translator/reader/utils.h
@@ -138,11 +138,19 @@ size_t exportArray(UsdAttribute attr, AtNode* node, const char* attr_name, const
 
         size_t size = array.size();
         if (size > 0) {
-            // The USD data representation is the same as the Arnold one, we don't
-            // need to convert the data
-            if (same_data)
+            if  (std::is_same<U, std::string>::value && same_data) {
+                // special case for strings, because AtString is a bit special
+                AtArray *strArray = AiArrayAllocate(size, 1, AI_TYPE_STRING);
+                for (size_t i = 0; i < size; ++i) {
+                    std::string  *strVal = (std::string*)&array[i];
+                    AiArraySetStr(strArray, i, AtString(strVal->c_str()));
+                }
+                AiNodeSetArray(node, attr_name, strArray);
+            } else if (same_data) {
+                // The USD data representation is the same as the Arnold one, we don't
+                // need to convert the data
                 AiNodeSetArray(node, attr_name, AiArrayConvert(size, 1, attr_type, array.cdata()));
-            else {
+            } else {
                 // Different data representation between USD and Arnold, we need to
                 // copy the vector. Note that we could instead allocate the AtArray
                 // and set the elements one by one, but I'm assuming it's faster

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -20,6 +20,7 @@
 #include "write_shader.h"
 #include "write_light.h"
 #include "write_geometry.h"
+#include "write_options.h"
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -60,6 +61,9 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
         universeCreated = true;
         // FIXME: should we call AiLoadPlugins here ?
     }
+
+    // Register the options node that needs a special treatment
+    registerWriter("options", new UsdArnoldWriteOptions());
 
     // Iterate over all node types
     AtNodeEntryIterator *nodeEntryIter = AiUniverseGetNodeEntryIterator(AI_NODE_ALL);

--- a/translator/writer/write_options.cpp
+++ b/translator/writer/write_options.cpp
@@ -1,0 +1,80 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "write_options.h"
+
+#include <ai.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/usdShade/input.h>
+#include <pxr/usd/usdShade/material.h>
+#include <pxr/usd/usdShade/shader.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <iostream>
+
+#include "registry.h"
+
+//-*************************************************************************
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+/**
+ *  Export Arnold options node. This will be exported in a very similar way than
+ *  other UsdArnoldWriteType nodes, except that it needs a special treatment for
+ *  the outputs attribute
+ **/
+
+void UsdArnoldWriteOptions::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    UsdStageRefPtr stage = writer.getUsdStage();
+    UsdPrim prim = stage->DefinePrim(SdfPath("/options"), TfToken("ArnoldOptions"));
+
+    // We need a special treatment for the outputs array
+    AtArray *outputs = AiNodeGetArray(node, "outputs");
+    unsigned int numOutputs = (outputs) ? AiArrayGetNumElements(outputs) : 0;
+    if (numOutputs > 0) {
+        UsdAttribute outputsAttr = prim.CreateAttribute(TfToken("outputs"), SdfValueTypeNames->StringArray, false);
+        VtArray<std::string> vtArray(numOutputs);
+        for (unsigned int i = 0; i < numOutputs; ++i) {
+            AtString output = AiArrayGetStr(outputs, i);
+            std::string outputStr(output.c_str());
+            // split the array with empty space, replace driver names
+            std::string outStr;
+            std::istringstream f(outputStr);
+            std::string s; 
+            AtNode *outputsNode = nullptr;
+            int ind = 0;
+            while (std::getline(f, s, ' ')) {
+                if(ind > 1 && (outputsNode = AiNodeLookUpByName(s.c_str()))) {
+                    // convert the name
+                    s = getArnoldNodeName(outputsNode);
+                }
+                if (ind > 0)
+                    outStr += " ";
+                outStr += s;
+                ind++;
+            }
+            vtArray[i] = outStr.c_str();
+        }
+        outputsAttr.Set(vtArray);
+    }
+
+    _exportedAttrs.insert("outputs");
+    writeArnoldParameters(node, writer, prim, "");
+}

--- a/translator/writer/write_options.h
+++ b/translator/writer/write_options.h
@@ -1,0 +1,28 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ai_nodes.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "prim_writer.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+REGISTER_PRIM_WRITER(UsdArnoldWriteOptions);


### PR DESCRIPTION
**Changes proposed in this pull request**
The problem is twofold :
 1 - in the USD writer, we need a special treatment to translate `options.outputs` to USD. The problem is that the usd primitive names are different from the arnold node names, and `options.outputs` is a string array that contains the name of driver and filter nodes. Therefore we need to modify this strings so that the node names correspond to the usd ones
 2 - In the USD reader, the string array attributes weren't translated properly. Given how the code was written, we were trying to read a string array attribute as a TfToken array, which fails. Plus, later on we were trying to do a memcopy of `TfToken` to `AtString` which obviously cannot work. So we need to do a special treatment for string array attributes (like we already do for string attributes) and do the conversion from string to AtString

Once we can do tests for the scene format that kick usd files (#157 ), they will automatically test this use case

**Issues fixed in this pull request**
Fixes #320 
