### PR TITLE
Temporarily disable test_0040

### DIFF
--- a/testsuite/groups
+++ b/testsuite/groups
@@ -41,7 +41,7 @@ darwin:
 #######################
 
 # Tests in this group will never be executed (you can use it to temporarily disable some tests and/or groups)
-ignore: test_0011 
+ignore: test_0011 test_0040
 
 ############################
 # USER-DEFINED TEST GROUPS #


### PR DESCRIPTION
**Changes proposed in this pull request**
This  commit is related to #26 , 
we're temporarily disabling the test running `arnold_to_usd` test_0040, because it should only be executed when `BUILD_USD_WRITER=True`.