### PR TITLE
Support motion blur in the scene format loader

### DIFF
--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -72,8 +72,8 @@ void exportMatrix(const UsdPrim &prim, AtNode *node, const TimeSettings &time, U
         GfInterval interval(time.start(), time.end(), false, false);
         std::vector<double> timeSamples;
         xformable.GetTimeSamplesInInterval(interval, &timeSamples);
-        size_t numKeys = AiMax(int(timeSamples.size()), (int)1);
-        numKeys += 2; // need to add the start end end keys (interval has open bounds)
+        // need to add the start end end keys (interval has open bounds)
+        size_t numKeys = timeSamples.size() + 2;
         AtArray *array = AiArrayAllocate(1, numKeys, AI_TYPE_MATRIX);
         float timeStep = float(interval.GetMax() - interval.GetMin()) / int(numKeys - 1);
         float timeVal = interval.GetMin();


### PR DESCRIPTION
**Changes proposed in this pull request**
When the reader is called without any parent procedural (thus from the scene format loader), we look for the render camera to get the shutter range. This will tell us how to load the USD data.

While doing the change, I noticed that before we were adding an additional useless time sample when the arnold data had only 2 motion keys (which is the default use case), so I've also fixed this 

**Issues fixed in this pull request**
Fixes #346 