### PR TITLE
Support motion keys in the USD writer

### DIFF
--- a/translator/reader/utils.h
+++ b/translator/reader/utils.h
@@ -169,8 +169,8 @@ size_t exportArray(UsdAttribute attr, AtNode* node, const char* attr_name, const
         GfInterval interval(time.start(), time.end(), false, false);
         std::vector<double> timeSamples;
         attr.GetTimeSamplesInInterval(interval, &timeSamples);
-        size_t numKeys = AiMax(int(timeSamples.size()), (int)1);
-        numKeys += 2; // need to add the start end end keys (interval has open bounds)
+        // need to add the start end end keys (interval has open bounds)
+        size_t numKeys = timeSamples.size() + 2;
 
         float timeStep = float(interval.GetMax() - interval.GetMin()) / int(numKeys - 1);
         float timeVal = interval.GetMin();


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR ensures that we're writing each of the motion keys from arnold array attributes, whether they're saved as USD builtin attributes (mesh matrix, vertices, etc...) or whether they're saved as arnold-specific attributes.

I also fixed another issue related to the amount of keys saved like in #347 , in another part of the reader code.

**Issues fixed in this pull request**
Fixes #334 