### PR TITLE
Always write polymesh.subdiv_iterations

### DIFF
--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -136,6 +136,10 @@ void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
     else
         mesh.GetSubdivisionSchemeAttr().Set(UsdGeomTokens->none);
 
+    // always write subdiv iterations even if it's set to default
+    prim.CreateAttribute(TfToken("primvars:arnold:subdiv_iterations"), 
+        SdfValueTypeNames->UChar, false).Set(AiNodeGetByte(node, "subdiv_iterations"));
+        
     // We're setting double sided to true if the sidedness is non-null.
     // Note that if it's not 255 (default), it will be set as a primvar
     // in writeArnoldParameters, and this primvar will have priority over


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we're ensuring that we always write `polymesh.subdiv_iterations` when writing a usd file.
Usually, an attribute gets written if and only if the value is different from the default (for arnold), but this no longer works if the default in USD is different from the default in arnold.

This will need a test in #157 

**Issues fixed in this pull request**
Fixes #349 
