### PR TITLE
Improve how ginstance attributes are written

### DIFF
--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -35,7 +35,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
  **/
 class UsdArnoldPrimWriter {
 public:
-    UsdArnoldPrimWriter() {}
+    UsdArnoldPrimWriter() : _motionStart(0.f), _motionEnd(0.f) {}
     virtual ~UsdArnoldPrimWriter() {}
     
     void writeNode(const AtNode *node, UsdArnoldWriter &writer);
@@ -61,13 +61,18 @@ public:
     static std::string getArnoldNodeName(const AtNode *node);
     bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
     
+    float getMotionStart() const {return _motionStart;}
+    float getMotionEnd() const {return _motionEnd;}
 
 protected:
     virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;        
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
     void writeMaterialBinding(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer, AtArray *shidxsArray = nullptr);
-    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported     
+    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported  
+
+    float _motionStart;
+    float _motionEnd;   
 };
 
 /**

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -35,7 +35,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
  **/
 class UsdArnoldPrimWriter {
 public:
-    UsdArnoldPrimWriter() : _motionStart(0.f), _motionEnd(0.f) {}
+    UsdArnoldPrimWriter() {}
     virtual ~UsdArnoldPrimWriter() {}
     
     void writeNode(const AtNode *node, UsdArnoldWriter &writer);
@@ -61,18 +61,13 @@ public:
     static std::string getArnoldNodeName(const AtNode *node);
     bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
     
-    float getMotionStart() const {return _motionStart;}
-    float getMotionEnd() const {return _motionEnd;}
 
 protected:
     virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;        
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
     void writeMaterialBinding(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer, AtArray *shidxsArray = nullptr);
-    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported  
-
-    float _motionStart;
-    float _motionEnd;   
+    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported     
 };
 
 /**

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -65,6 +65,10 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
     // Register the options node that needs a special treatment
     registerWriter("options", new UsdArnoldWriteOptions());
 
+    // Register a writer for ginstance, whose behaviour is a 
+    // bit special regarding default values
+    registerWriter("ginstance", new UsdArnoldWriteGinstance());
+
     // Iterate over all node types
     AtNodeEntryIterator *nodeEntryIter = AiUniverseGetNodeEntryIterator(AI_NODE_ALL);
     while (!AiNodeEntryIteratorFinished(nodeEntryIter)) {

--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -85,7 +85,6 @@ void UsdArnoldWriteGinstance::processInstanceAttribute(UsdPrim &prim, const AtNo
             attr.Set(AiNodeGetByte(node, attrName));
     }
     _exportedAttrs.insert(attrName);
-
 }
 
 void UsdArnoldWriteGinstance::write(const AtNode *node, UsdArnoldWriter &writer)
@@ -102,7 +101,6 @@ void UsdArnoldWriteGinstance::write(const AtNode *node, UsdArnoldWriter &writer)
     prim = stage->DefinePrim(objPath, TfToken(_usdName));
 
     AtNode *target = (AtNode *)AiNodeGetPtr(node, "node");
-
     if (target) {
         processInstanceAttribute(prim, node, target, "visibility", AI_TYPE_BYTE);
         processInstanceAttribute(prim, node, target, "sidedness", AI_TYPE_BYTE);
@@ -112,7 +110,5 @@ void UsdArnoldWriteGinstance::write(const AtNode *node, UsdArnoldWriter &writer)
         processInstanceAttribute(prim, node, target, "self_shadows", AI_TYPE_BOOLEAN);
     }
 
-
-    
     writeArnoldParameters(node, writer, prim, "");
 }

--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -55,3 +55,64 @@ void UsdArnoldWriteArnoldType::write(const AtNode *node, UsdArnoldWriter &writer
 
     writeArnoldParameters(node, writer, prim, "");
 }
+
+void UsdArnoldWriteGinstance::processInstanceAttribute(UsdPrim &prim, const AtNode *node, const AtNode *target, 
+        const char *attrName, int attrType)
+{
+    if (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(target), attrName) == nullptr)
+        return; // the attribute doesn't exist in the instanced node
+
+    // Now compare the values between the ginstance and the target node. If the value 
+    // is different we'll want to write it even though it's the default value
+    bool writeValue = false;
+    SdfValueTypeName usdType;
+    if (attrType == AI_TYPE_BOOLEAN) {
+        writeValue = (AiNodeGetBool(node, attrName) != AiNodeGetBool(target, attrName));
+        usdType = SdfValueTypeNames->Bool;
+    }
+    else if (attrType == AI_TYPE_BYTE) {
+        writeValue = (AiNodeGetByte(node, attrName) != AiNodeGetByte(target, attrName));
+        usdType = SdfValueTypeNames->UChar;
+    }
+    else 
+        return;
+
+    if (writeValue) {
+        UsdAttribute attr = prim.CreateAttribute(TfToken(attrName), usdType, false);
+        if (attrType == AI_TYPE_BOOLEAN)
+            attr.Set(AiNodeGetBool(node, attrName));
+        else if (attrType == AI_TYPE_BYTE)
+            attr.Set(AiNodeGetByte(node, attrName));
+    }
+    _exportedAttrs.insert(attrName);
+
+}
+
+void UsdArnoldWriteGinstance::write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = getArnoldNodeName(node); // what should be the name of this USD primitive
+    UsdStageRefPtr stage = writer.getUsdStage();    // get the current stage defined in the writer
+    SdfPath objPath(nodeName);
+
+    UsdPrim prim = stage->GetPrimAtPath(objPath);
+    if (prim && prim.IsActive()) {
+        // This primitive was already written, let's early out
+        return;
+    }
+    prim = stage->DefinePrim(objPath, TfToken(_usdName));
+
+    AtNode *target = (AtNode *)AiNodeGetPtr(node, "node");
+
+    if (target) {
+        processInstanceAttribute(prim, node, target, "visibility", AI_TYPE_BYTE);
+        processInstanceAttribute(prim, node, target, "sidedness", AI_TYPE_BYTE);
+        processInstanceAttribute(prim, node, target, "matte", AI_TYPE_BOOLEAN);
+        processInstanceAttribute(prim, node, target, "receive_shadows", AI_TYPE_BOOLEAN);
+        processInstanceAttribute(prim, node, target, "invert_normals", AI_TYPE_BOOLEAN);
+        processInstanceAttribute(prim, node, target, "self_shadows", AI_TYPE_BOOLEAN);
+    }
+
+
+    
+    writeArnoldParameters(node, writer, prim, "");
+}

--- a/translator/writer/write_arnold_type.h
+++ b/translator/writer/write_arnold_type.h
@@ -38,11 +38,33 @@ public:
         : UsdArnoldPrimWriter(), _entryName(entryName), _usdName(usdName), _entryTypeName(entryTypeName)
     {
     }
+    virtual ~UsdArnoldWriteArnoldType() {}
 protected:
     void write(const AtNode *node, UsdArnoldWriter &writer) override;
 
-private:
     std::string _entryName;
     std::string _usdName;
     std::string _entryTypeName;
+};
+
+/**  
+ *   Ginstance nodes require a special treatment, because of the behaviour of
+ *   default values. In general we can skip authoring an attribute if the value
+ *   is different from default, but that's not the case for instances. Here, 
+ *   we'll compare the value of the attribute with the corresponding value
+ *   for the instanced node. If it is different we will write it, even if the 
+ *   value is equal to default 
+ **/
+class UsdArnoldWriteGinstance : public UsdArnoldWriteArnoldType {
+public:
+    UsdArnoldWriteGinstance()
+        : UsdArnoldWriteArnoldType("ginstance", "ArnoldGinstance", "shape") {}
+
+    virtual ~UsdArnoldWriteGinstance() {}
+
+protected:
+    void write(const AtNode *node, UsdArnoldWriter &writer) override;
+
+    void processInstanceAttribute(UsdPrim &prim, const AtNode *node, const AtNode *target, 
+        						  const char *attrName, int attrType);
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
We register a new primitive writer for `ginstance` nodes.
It will do a special treatment for attributes `visiblity`, `sidedness`, `matte`, `receive_shadows`, `self_shadows`, `invert_normals`. Note that we don't consider `opaque` which is not used anymore.

For these attributes, we compare the value with the value from the instanced node. If the value is different, we author them. 

**Issues fixed in this pull request**
Fixes #362 
