### PR TITLE
Support textured mesh lights

### DIFF
--- a/translator/reader/read_light.cpp
+++ b/translator/reader/read_light.cpp
@@ -325,6 +325,8 @@ void UsdArnoldReadGeometryLight::read(const UsdPrim &prim, UsdArnoldReaderContex
         if (light.GetNormalizeAttr().Get(&normalizeAttr)) {
             AiNodeSetBool(node, "normalize", vtValueGetBool(normalizeAttr));
         }
+        // Special case, the attribute "color" can be linked to some shader
+        exportLightColorLinks(light, node, context);
 
         exportMatrix(prim, node, time, context);
         readArnoldParameters(prim, context, node, time, "primvars:arnold");


### PR DESCRIPTION
**Changes proposed in this pull request**
We just need mesh lights reader to call the function that was introduced in #340 for skydome and quad lights.

I have a test scene ready, but it requires the scene format testsuite first. Loading mesh lights through a procedural doesn't seem to work in arnold, so I cannot test it with the procedural

**Issues fixed in this pull request**
Fixes #365 
