### PR TITLE
Ensure motion range is written properly

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -224,7 +224,8 @@ public:
         _attr.Set(value);
     }
     template <typename T>
-    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values)
+    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values, 
+        float motionStart, float motionEnd)
     {
         if (values.empty())
             return;
@@ -232,12 +233,6 @@ public:
         if (values.size() == 1)
             _attr.Set(values[0]);
         else {
-            float motionStart = 0.f;
-            float motionEnd = 0.f;
-            if (_node && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(_node), "motion_start"))
-                motionStart = AiNodeGetFlt(_node, "motion_start");
-            if (_node && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(_node), "motion_end"))
-                motionEnd = AiNodeGetFlt(_node, "motion_end");
             
             if (motionStart >= motionEnd) {
                 // invalid motion start / end points, let's just write a single value
@@ -293,7 +288,8 @@ public:
         _attr.Set(value);
     }
     template <typename T>
-    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values)
+    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values, 
+        float motionStart, float motionEnd)
     {
         if (values.empty())
             return;
@@ -308,13 +304,6 @@ public:
         std::string usdParamName = (_scope.empty()) ? paramName : _scope + std::string(":") + paramName;
         _attr = _prim.CreateAttribute(TfToken(usdParamName), typeName, false);
 
-        float motionStart = 0.f;
-        float motionEnd = 1.f;
-        if (_node && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(_node), "motion_start"))
-            motionStart = AiNodeGetFlt(_node, "motion_start");
-        if (_node && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(_node), "motion_end"))
-            motionEnd = AiNodeGetFlt(_node, "motion_end");
-        
         if (motionStart >= motionEnd) {
             // invalid motion start / end points, let's just write a single value
             _attr.Set(values[0]);
@@ -445,7 +434,8 @@ public:
         }        
     }
     template <typename T>
-    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values)
+    void ProcessAttributeKeys(const SdfValueTypeName &typeName, const std::vector<T> &values, 
+        float motionStart, float motionEnd)
     {
         if (!values.empty())
             ProcessAttribute(typeName, values[0]);
@@ -484,6 +474,11 @@ void UsdArnoldPrimWriter::writeNode(const AtNode *node, UsdArnoldWriter &writer)
     // attributes and we clear it for the new node being written
     decltype(_exportedAttrs) prevExportedAttrs;
     prevExportedAttrs.swap(_exportedAttrs);
+
+    _motionStart = (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_start")) ?
+        AiNodeGetFlt(node, "motion_start") : writer.getShutterStart();
+    _motionEnd = (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_end")) ?
+        AiNodeGetFlt(node, "motion_end") : writer.getShutterEnd();            
 
     // Now call the virtual function write() defined for each primitive type
     write(node, writer); 
@@ -582,7 +577,8 @@ static inline std::string GetConnectedNode(UsdArnoldWriter &writer, AtNode *targ
  *                     or UsdArnoldPrimvarWriter (for arnold user data)
  **/
 template <typename T>
-static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer, T& attrWriter)
+static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer, 
+    UsdArnoldPrimWriter &primWriter, T& attrWriter)
 {
     int paramType = attrWriter.getParamType();
     const char* paramName = attrWriter.getParamName();
@@ -598,7 +594,9 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
             return false;
         }
         unsigned int numKeys = AiArrayGetNumKeys(array);
-        
+        float motionStart = primWriter.getMotionStart();
+        float motionEnd = primWriter.getMotionEnd();
+
         SdfValueTypeName usdTypeName;
         int index = 0;
         switch (arrayType) {
@@ -612,7 +610,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(unsigned char));
                     }
                         
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->UCharArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->UCharArray, vtMotionArray, 
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -625,7 +624,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(int));
                     }                        
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->IntArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->IntArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -638,7 +638,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(unsigned int));
                     }                        
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->UIntArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->UIntArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -652,7 +653,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(bool));
                     }                        
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->BoolArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->BoolArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -665,7 +667,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(float));
                     }                        
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->FloatArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->FloatArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -678,7 +681,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(GfVec3f));
                     }                        
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Color3fArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Color3fArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -691,7 +695,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(GfVec3f));
                     }
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Vector3fArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Vector3fArray, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -704,7 +709,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(GfVec4f));
                     }
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Color4fArray, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Color4fArray, vtMotionArray, 
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -717,7 +723,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                         vtArr.resize(numElements);
                         memcpy(&vtArr[0], &arrayMap[j*numElements], numElements * sizeof(GfVec2f));
                     }
-                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Float2Array, vtMotionArray);
+                    attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Float2Array, vtMotionArray,
+                        motionStart, motionEnd);
                     AiArrayUnmap(array);
                     break;
             }
@@ -747,7 +754,8 @@ static inline bool convertArnoldAttribute(const AtNode *node, UsdPrim &prim, Usd
                                 vtArr[i] = GfMatrix4d(matFlt);
                             }
                         }
-                        attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Matrix4dArray, vtMotionArray);
+                        attrWriter.ProcessAttributeKeys(SdfValueTypeNames->Matrix4dArray, vtMotionArray,
+                            motionStart, motionEnd);
                     }
                     AiArrayUnmap(array);
                     break;
@@ -901,7 +909,7 @@ void UsdArnoldPrimWriter::writeArnoldParameters(
 
         attrs.insert(paramName);
         UsdArnoldCustomParamWriter paramWriter(node, prim, paramEntry, scope);
-        convertArnoldAttribute(node, prim, writer, paramWriter);
+        convertArnoldAttribute(node, prim, writer, *this, paramWriter);
     }
     AiParamIteratorDestroy(paramIter);
 
@@ -913,7 +921,7 @@ void UsdArnoldPrimWriter::writeArnoldParameters(
         const char *paramName = AiUserParamGetName (paramEntry);
         attrs.insert(paramName);
         UsdArnoldPrimvarWriter paramWriter(node, prim, paramEntry);
-        convertArnoldAttribute(node, prim, writer, paramWriter);
+        convertArnoldAttribute(node, prim, writer, *this, paramWriter);
     }
     AiUserParamIteratorDestroy(iter);
 
@@ -943,7 +951,7 @@ bool UsdArnoldPrimWriter::writeAttribute(const AtNode *node, const char *paramNa
         return false;
 
     UsdArnoldBuiltinParamWriter paramWriter(node, prim, paramEntry, attr);
-    convertArnoldAttribute(node, prim, writer, paramWriter);
+    convertArnoldAttribute(node, prim, writer, *this, paramWriter);
     _exportedAttrs.insert(std::string(paramName)); // remember that we've explicitely exported this arnold attribute
 
 
@@ -978,14 +986,10 @@ void UsdArnoldPrimWriter::writeMatrix(UsdGeomXformable &xformable, const AtNode 
     std::vector<double> xform;
     xform.reserve(16);
     // Get array of times based on motion_start / motion_end
-    float motion_start = (numKeys > 1 && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_start")) ?
-        AiNodeGetFlt(node, "motion_start") : 0.f;
-    float motion_end = (numKeys > 1 && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_end")) ?
-        AiNodeGetFlt(node, "motion_end") : 0.f;
 
     double m[4][4];
-    float timeDelta = (numKeys > 1) ? (motion_end - motion_start) / (int)(numKeys - 1) : 0.f;
-    float time = motion_start;
+    float timeDelta = (numKeys > 1) ? (_motionEnd - _motionStart) / (int)(numKeys - 1) : 0.f;
+    float time = _motionStart;
 
     for (unsigned int k = 0; k < numKeys; ++k) {
         AtMatrix &mtx = matrices[k];

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -35,7 +35,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
  **/
 class UsdArnoldPrimWriter {
 public:
-    UsdArnoldPrimWriter() {}
+    UsdArnoldPrimWriter() : _motionStart(0.f), _motionEnd(0.f) {}
     virtual ~UsdArnoldPrimWriter() {}
     
     void writeNode(const AtNode *node, UsdArnoldWriter &writer);
@@ -61,13 +61,18 @@ public:
     static std::string getArnoldNodeName(const AtNode *node);
     bool writeAttribute(const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
     
+    float getMotionStart() const {return _motionStart;}
+    float getMotionEnd() const {return _motionEnd;}
 
 protected:
     virtual void write(const AtNode *node, UsdArnoldWriter &writer) = 0;        
     void writeArnoldParameters(const AtNode *node, UsdArnoldWriter &writer, UsdPrim &prim, const std::string &scope="arnold");
     void writeMatrix(UsdGeomXformable &xform, const AtNode *node, UsdArnoldWriter &writer);
     void writeMaterialBinding(const AtNode *node, UsdPrim &prim, UsdArnoldWriter &writer, AtArray *shidxsArray = nullptr);
-    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported     
+    std::unordered_set<std::string> _exportedAttrs; // list of arnold attributes that were exported  
+
+    float _motionStart;
+    float _motionEnd;   
 };
 
 /**

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -108,13 +108,9 @@ void UsdArnoldWriteMesh::write(const AtNode *node, UsdArnoldWriter &writer)
         VtArray<GfVec3f> normalsValues(nlistNumElems);
         unsigned int nlistNumKeys = AiArrayGetNumKeys(nlist);
         AtVector *nlistArrayValues = static_cast<AtVector*>(AiArrayMap(nlist));
-        // Get array of times based on motion_start / motion_end
-        float motionStart = (nlistNumKeys > 1 && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_start")) ?
-            AiNodeGetFlt(node, "motion_start") : 0.f;
-        float motionEnd = (nlistNumKeys > 1 && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(node), "motion_end")) ?
-            AiNodeGetFlt(node, "motion_end") : 0.f;
-        float timeDelta = (nlistNumKeys > 1 && motionStart < motionEnd) ? (motionEnd - motionStart) / (int)(nlistNumKeys - 1) : 0.f;
-        float time = motionStart;
+
+        float timeDelta = (nlistNumKeys > 1 && _motionStart < _motionEnd) ? (_motionEnd - _motionStart) / (int)(nlistNumKeys - 1) : 0.f;
+        float time = _motionStart;
 
         for (unsigned int j = 0; j < nlistNumKeys; ++j, time+=timeDelta) {
             memcpy(normalsValues.data(), nlistArrayValues, nlistNumElems * sizeof(GfVec3f));

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -53,6 +53,13 @@ void UsdArnoldWriter::write(const AtUniverse *universe)
     // clear the list of nodes that were exported to usd
     _exportedNodes.clear(); 
 
+    AtNode *camera = AiUniverseGetCamera(universe);
+    if (camera)
+    {  
+        _shutterStart  = AiNodeGetFlt(camera, AtString("shutter_start"));
+        _shutterEnd  = AiNodeGetFlt(camera, AtString("shutter_end"));
+    }
+
     // Loop over the universe nodes, and write each of them
     AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, _mask);
     while (!AiNodeIteratorFinished(iter)) {

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -32,7 +32,8 @@ class UsdArnoldWriterRegistry;
 
 class UsdArnoldWriter {
 public:
-    UsdArnoldWriter() : _universe(NULL), _registry(NULL), _writeBuiltin(true), _mask(AI_NODE_ALL) {}
+    UsdArnoldWriter() : _universe(NULL), _registry(NULL), _writeBuiltin(true), 
+        _mask(AI_NODE_ALL), _shutterStart(0.f), _shutterEnd(0.f) {}
     ~UsdArnoldWriter() {}
 
     void write(const AtUniverse *universe);  // convert a given arnold universe
@@ -52,6 +53,9 @@ public:
     void setMask(int m) {_mask = m;}
     int getMask() const {return _mask;}
 
+    float getShutterStart() const {return _shutterStart;}
+    float getShutterEnd() const {return _shutterEnd;}
+
     bool isNodeExported(const AtString &name) { return _exportedNodes.count(name) == 1;}
 
 
@@ -63,5 +67,7 @@ private:
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
     int _mask;                          // Mask based on arnold flags (AI_NODE_SHADER, etc...),
                                         // determining what arnold nodes must be saved out
+    float _shutterStart;
+    float _shutterEnd;
     std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of looking for `motion_start`, `motion_end` every time we write an animated attribute, we now store this value at first when each primitive gets written. If the attribute isn't found, we default to the camera shutter start / end, which itself is stored in the main `UsdArnoldWriter` before the iteration starts.

When #157 is implemented, we can add a test for this use case, with an animated projection (using `uv_projection` and `matrix_interpolate`)

**Issues fixed in this pull request**
Fixes #368 
