### PR TITLE
Add a writer for toon shader

### DIFF
--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -68,6 +68,9 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
     // bit special regarding default values
     RegisterWriter("ginstance", new UsdArnoldWriteGinstance());
 
+    // Toon needs a special treatment for attributes "lights" and "rim_light" #374
+    RegisterWriter("toon", new UsdArnoldWriteToon());
+
     // Iterate over all node types
     AtNodeEntryIterator *nodeEntryIter = AiUniverseGetNodeEntryIterator(AI_NODE_ALL);
     while (!AiNodeEntryIteratorFinished(nodeEntryIter)) {

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -39,13 +39,82 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 void UsdArnoldWriteShader::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
-    UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    // Create the primitive of type Shader (UsdShadeShader)
-    UsdShadeShader shaderAPI = UsdShadeShader::Define(stage, SdfPath(nodeName));
-    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId)); // set the info:id parameter to the actual shader name
-
+    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), 
+                                          SdfPath(GetArnoldNodeName(node)));
+    // set the info:id parameter to the actual shader name
+    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId)); 
     UsdPrim prim = shaderAPI.GetPrim();
     _WriteArnoldParameters(node, writer, prim, "inputs");
+}
+
+static inline void SplitString(const std::string& input, std::vector<std::string> &result)
+{
+   std::string::size_type start = 0;
+   while (1)
+   {
+      // delimiters: semicolon and space
+      std::string::size_type semicolon = input.find(";", start);
+      std::string::size_type space = input.find(" ", start);
+      std::string::size_type end = std::min(semicolon, space);
+      bool notFound = (end == std::string::npos);
+      std::string::size_type width = (notFound ? input.length() : end) - start;
+      std::string name = input.substr(start, width);
+      if (!name.empty())
+         result.push_back(name);
+      if (notFound)
+         break;
+      start = end + 1;
+   }
+}
+
+
+void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), 
+                                          SdfPath(GetArnoldNodeName(node)));
+    // set the info:id parameter to the actual shader name
+    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId)); 
+    UsdPrim prim = shaderAPI.GetPrim();
+    _WriteArnoldParameters(node, writer, prim, "inputs");
+
+    const AtUniverse *universe = writer.GetUniverse();
+
+    // Now we need to modify the attribute "rim_light" that is a string
+    // pointing at a light name in the scene. Since we convert the node names
+    // when writing to usd, these strings aren't matching the usd light names
+    std::string rimLight = AiNodeGetStr(node, "rim_light");
+    AtNode *rimLightNode = rimLight.empty() ? nullptr : 
+                    AiNodeLookUpByName(universe, rimLight.c_str());
+    if (rimLightNode) {
+        std::string rimLightUsdName = GetArnoldNodeName(rimLightNode);
+        // At this point the attribute should already exist, as it 
+        // was created by _WriteArnoldParameters if not empty
+        UsdAttribute rimLightsAttr = prim.GetAttribute(TfToken("inputs:rim_light"));
+        if (rimLightsAttr)
+            rimLightsAttr.Set(VtValue(rimLightUsdName.c_str()));
+    }
+
+    // Same as above, the attribute "lights" is a string pointing at node names, 
+    // that need to be adapted. This attribute is more complicated than "rim_light"
+    // because the string can concatenate multiple light names, separated by semicolor
+    // or empty space. So we need to split each light name, convert them separately,
+    // and re-assemble them back in the usd attribute
+    std::string lights = AiNodeGetStr(node, "lights");
+    if (!lights.empty()) {
+        std::vector<std::string> splitStr;
+        SplitString(lights, splitStr);
+        lights.clear();
+        for (auto lightName : splitStr) {
+            AtNode *lightNode = AiNodeLookUpByName(universe, lightName.c_str());
+            if (lightNode == nullptr)
+                continue;
+            
+            if (!lights.empty())
+                lights += ";";
+            lights += GetArnoldNodeName(lightNode);
+        }
+        UsdAttribute lightsAttr = prim.GetAttribute(TfToken("inputs:lights"));
+        if (lightsAttr)
+            lightsAttr.Set(VtValue(lights.c_str()));
+    }
 }

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -82,7 +82,7 @@ void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
     // Now we need to modify the attribute "rim_light" that is a string
     // pointing at a light name in the scene. Since we convert the node names
     // when writing to usd, these strings aren't matching the usd light names
-    std::string rimLight = AiNodeGetStr(node, "rim_light");
+    AtString rimLight = AiNodeGetStr(node, "rim_light");
     AtNode *rimLightNode = rimLight.empty() ? nullptr : 
                     AiNodeLookUpByName(universe, rimLight.c_str());
     if (rimLightNode) {
@@ -99,8 +99,9 @@ void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
     // because the string can concatenate multiple light names, separated by semicolor
     // or empty space. So we need to split each light name, convert them separately,
     // and re-assemble them back in the usd attribute
-    std::string lights = AiNodeGetStr(node, "lights");
-    if (!lights.empty()) {
+    AtString lightsStr = AiNodeGetStr(node, "lights");
+    if (!lightsStr.empty()) {
+        std::string lights(lightsStr.c_str());
         std::vector<std::string> splitStr;
         SplitString(lights, splitStr);
         lights.clear();

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -37,43 +37,43 @@ PXR_NAMESPACE_USING_DIRECTIVE
  *"info:id" attribute. Input parameter are saved in the "input:" namespace.
  **/
 
+namespace {
+
+inline void SplitString(const std::string &input, std::vector<std::string> &result)
+{
+    std::string::size_type start = 0;
+    while (true) {
+        // delimiters: semicolon and space
+        std::string::size_type semicolon = input.find(";", start);
+        std::string::size_type space = input.find(" ", start);
+        std::string::size_type end = std::min(semicolon, space);
+        bool notFound = (end == std::string::npos);
+        std::string::size_type width = (notFound ? input.length() : end) - start;
+        std::string name = input.substr(start, width);
+        if (!name.empty())
+            result.push_back(name);
+        if (notFound)
+            break;
+        start = end + 1;
+    }
+}
+
+}
+
 void UsdArnoldWriteShader::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), 
-                                          SdfPath(GetArnoldNodeName(node)));
+    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), SdfPath(GetArnoldNodeName(node)));
     // set the info:id parameter to the actual shader name
-    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId)); 
+    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId));
     UsdPrim prim = shaderAPI.GetPrim();
     _WriteArnoldParameters(node, writer, prim, "inputs");
 }
 
-static inline void SplitString(const std::string& input, std::vector<std::string> &result)
-{
-   std::string::size_type start = 0;
-   while (1)
-   {
-      // delimiters: semicolon and space
-      std::string::size_type semicolon = input.find(";", start);
-      std::string::size_type space = input.find(" ", start);
-      std::string::size_type end = std::min(semicolon, space);
-      bool notFound = (end == std::string::npos);
-      std::string::size_type width = (notFound ? input.length() : end) - start;
-      std::string name = input.substr(start, width);
-      if (!name.empty())
-         result.push_back(name);
-      if (notFound)
-         break;
-      start = end + 1;
-   }
-}
-
-
 void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), 
-                                          SdfPath(GetArnoldNodeName(node)));
+    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), SdfPath(GetArnoldNodeName(node)));
     // set the info:id parameter to the actual shader name
-    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId)); 
+    shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId));
     UsdPrim prim = shaderAPI.GetPrim();
     _WriteArnoldParameters(node, writer, prim, "inputs");
 
@@ -83,18 +83,17 @@ void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
     // pointing at a light name in the scene. Since we convert the node names
     // when writing to usd, these strings aren't matching the usd light names
     AtString rimLight = AiNodeGetStr(node, "rim_light");
-    AtNode *rimLightNode = rimLight.empty() ? nullptr : 
-                    AiNodeLookUpByName(universe, rimLight.c_str());
+    AtNode *rimLightNode = rimLight.empty() ? nullptr : AiNodeLookUpByName(universe, rimLight.c_str());
     if (rimLightNode) {
         std::string rimLightUsdName = GetArnoldNodeName(rimLightNode);
-        // At this point the attribute should already exist, as it 
+        // At this point the attribute should already exist, as it
         // was created by _WriteArnoldParameters if not empty
         UsdAttribute rimLightsAttr = prim.GetAttribute(TfToken("inputs:rim_light"));
         if (rimLightsAttr)
             rimLightsAttr.Set(VtValue(rimLightUsdName.c_str()));
     }
 
-    // Same as above, the attribute "lights" is a string pointing at node names, 
+    // Same as above, the attribute "lights" is a string pointing at node names,
     // that need to be adapted. This attribute is more complicated than "rim_light"
     // because the string can concatenate multiple light names, separated by semicolor
     // or empty space. So we need to split each light name, convert them separately,
@@ -109,7 +108,7 @@ void UsdArnoldWriteToon::Write(const AtNode *node, UsdArnoldWriter &writer)
             AtNode *lightNode = AiNodeLookUpByName(universe, lightName.c_str());
             if (lightNode == nullptr)
                 continue;
-            
+
             if (!lights.empty())
                 lights += ";";
             lights += GetArnoldNodeName(lightNode);

--- a/translator/writer/write_shader.h
+++ b/translator/writer/write_shader.h
@@ -42,7 +42,17 @@ public:
 
     void Write(const AtNode *node, UsdArnoldWriter &writer) override;
 
-private:
+protected:
     std::string _entryName;   // node entry name for this node
     std::string _usdShaderId; // name (id) of this shader in USD-land
 };
+
+class UsdArnoldWriteToon : public UsdArnoldWriteShader {
+public:
+    UsdArnoldWriteToon() : UsdArnoldWriteShader("toon", "arnold:toon")
+    {
+    }
+
+    void Write(const AtNode *node, UsdArnoldWriter &writer) override;
+};
+


### PR DESCRIPTION
**Changes proposed in this pull request**
We're adding a writer for toon shader. In addition to the regular shader export, it will do modify the attributes `rim_light` and `lights` so that these strings match the nodes names in the usd scene.
The attribute `lights` is slightly more complicated, as there can be multiple light names concatenated.
MtoA's test 273 is a good candidate when #157 will be implemented

**Issues fixed in this pull request**
Fixes #374 
