### PR TITLE
Load namespaced primvars

### DIFF
--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -345,9 +345,8 @@ void UsdArnoldPrimReader::ExportPrimvars(
         if ((name == "displayColor" || name == "displayOpacity") && !primvar.GetAttr().HasAuthoredValue())
             continue;
 
-        // if we find a namespacing in the primvar name we skip it.
-        // It's either an arnold attribute or it could be meant for another renderer
-        if (name.GetString().find(':') != std::string::npos)
+        // ignore primvars starting with arnold: as they will be loaded separately
+        if (name.GetString().find("arnold:") == 0)
             continue;
 
         TfToken arnoldName = name;


### PR DESCRIPTION
**Changes proposed in this pull request**
We load primvars from a usd primitive, even when they have a custom namespace.
Only primvars namespaced by `arnold:` are ignored because they're treated separately.

**Issues fixed in this pull request**
Fixes #382 
