### PR TITLE
Prevent crashes when writing nodes with empty names

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -501,7 +501,12 @@ std::string UsdArnoldPrimWriter::GetArnoldNodeName(const AtNode* node)
 {
     std::string name = AiNodeGetName(node);
     if (name.empty()) {
-        return name;
+        // Arnold can have nodes with empty names, but this is forbidden in USD.
+        // We're going to generate an arbitrary name for this node, with its node type
+        // and a naùe based on its pointer #380
+        std::stringstream ss;
+        ss << "unnamed/" << AiNodeEntryGetName(AiNodeGetNodeEntry(node)) <<"/p"<<node;
+        name = ss.str();
     }
 
     // We need to determine which parameters must be converted to underscores

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -87,21 +87,21 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
     if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr) {
         return;
     }
-
+    
     // Check if this arnold node has already been exported, and early out if it was.
     // Note that we're storing the name of the arnold node, which might be slightly
     // different from the USD prim name, since UsdArnoldPrimWriter::GetArnoldNodeName
     // replaces some forbidden characters by underscores.
-    if (IsNodeExported(nodeName))
+    if (!nodeName.empty() && IsNodeExported(nodeName))
         return;
 
-    std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
-
-    UsdArnoldPrimWriter *primWriter = _registry->GetPrimWriter(objType);
-    if (primWriter) {
+    if (!nodeName.empty())
         _exportedNodes.insert(nodeName); // remember that we already exported this node
+
+    std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
+    UsdArnoldPrimWriter *primWriter = _registry->GetPrimWriter(objType);
+    if (primWriter)
         primWriter->WriteNode(node, *this);
-    }
 }
 
 void UsdArnoldWriter::SetRegistry(UsdArnoldWriterRegistry *registry) { _registry = registry; }


### PR DESCRIPTION
**Changes proposed in this pull request**
When writing to usd an arnold node with an empty name, we give it an arbitrary name to prevent the crashes.

Here we put them under a group "unnamed" and another with the node type. Then the final name will be based on the AtNode pointer. So for example, a standard_surface shader without any name will be named in usd as `unnamed/standard_surface/p000001734935B0F0`.
Note that the pointer string must be prefixed with "p" otherwise USD will complain if it starts with the digit.

Also, for the explanation, the actual crash was in fact caused by `_exportedNodes.insert(nodeName) where we try to insert an empty string in an unordered_set. Asking usd to create a node with an empty name caused a usd error but didn't crash. 

**Issues fixed in this pull request**
Fixes #380 
