### PR TITLE
Support UsdGeomCamera in the translator

### DIFF
--- a/translator/CMakeLists.txt
+++ b/translator/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRC
         reader/read_geometry.cpp
         reader/read_light.cpp
         reader/read_shader.cpp
+        reader/read_camera.cpp
         reader/reader.cpp
         reader/registry.cpp
         reader/utils.cpp
@@ -15,6 +16,7 @@ set(SRC
         writer/write_light.cpp
         writer/write_options.cpp
         writer/write_shader.cpp
+        writer/write_camera.cpp
         writer/writer.cpp)
 
 set(HDR
@@ -23,6 +25,7 @@ set(HDR
         reader/read_geometry.h
         reader/read_light.h
         reader/read_shader.h
+        reader/read_camera.h
         reader/reader.h
         reader/registry.h
         reader/utils.h
@@ -36,6 +39,7 @@ set(HDR
         writer/write_light.h
         writer/write_options.h
         writer/write_shader.h
+        writer/write_camera.h
         writer/writer.h)
 
 add_library(translator STATIC ${SRC})

--- a/translator/CMakeLists.txt
+++ b/translator/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(SRC
         reader/prim_reader.cpp
         reader/read_arnold_type.cpp
+        reader/read_camera.cpp
         reader/read_geometry.cpp
         reader/read_light.cpp
         reader/read_shader.cpp
-        reader/read_camera.cpp
         reader/reader.cpp
         reader/registry.cpp
         reader/utils.cpp
@@ -12,20 +12,20 @@ set(SRC
         writer/prim_writer.cpp
         writer/registry.cpp
         writer/write_arnold_type.cpp
+        writer/write_camera.cpp
         writer/write_geometry.cpp
         writer/write_light.cpp
         writer/write_options.cpp
         writer/write_shader.cpp
-        writer/write_camera.cpp
         writer/writer.cpp)
 
 set(HDR
         reader/prim_reader.h
         reader/read_arnold_type.h
+        reader/read_camera.h
         reader/read_geometry.h
         reader/read_light.h
         reader/read_shader.h
-        reader/read_camera.h
         reader/reader.h
         reader/registry.h
         reader/utils.h
@@ -35,11 +35,11 @@ set(HDR
         writer/prim_writer.h
         writer/registry.h
         writer/write_arnold_type.h
+        writer/write_camera.h
         writer/write_geometry.h
         writer/write_light.h
         writer/write_options.h
         writer/write_shader.h
-        writer/write_camera.h
         writer/writer.h)
 
 add_library(translator STATIC ${SRC})

--- a/translator/reader/read_camera.cpp
+++ b/translator/reader/read_camera.cpp
@@ -1,0 +1,79 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "read_shader.h"
+
+#include <ai.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <pxr/usd/usdGeom/camera.h>
+#include <pxr/base/gf/camera.h>
+
+#include "registry.h"
+#include "utils.h"
+#include "read_camera.h"
+//-*************************************************************************
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void UsdArnoldReadCamera::Read(const UsdPrim &prim, UsdArnoldReaderContext &context)
+{
+    const TimeSettings &time = context.GetTimeSettings();
+    UsdGeomCamera cam(prim);
+
+    TfToken projection;
+    cam.GetProjectionAttr().Get(&projection);
+
+    bool persp = false;
+    std::string camType;
+    if (projection == UsdGeomTokens->perspective) {
+        persp = true;
+        camType = "persp_camera";
+    } else if (projection == UsdGeomTokens->orthographic) {
+        camType = "ortho_camera";
+    } else
+        return;
+
+    AtNode *node = context.CreateArnoldNode(camType.c_str(), prim.GetPath().GetText());
+    ExportMatrix(prim, node, time, context);
+
+    if (persp) {
+        // GfCamera has the utility functions to get the field of view,
+        // so we don't need to duplicate the code here
+        GfCamera gfCamera = cam.GetCamera(time.frame);
+        float fov = gfCamera.GetFieldOfView(GfCamera::FOVHorizontal);
+        AiNodeSetFlt(node, "fov", fov);
+
+        VtValue focusDistanceValue;
+        if (cam.CreateFocusDistanceAttr().Get(&focusDistanceValue))
+            AiNodeSetFlt(node, "focus_distance", VtValueGetFloat(focusDistanceValue));
+    }
+    GfVec2f clippingRange;
+    cam.CreateClippingRangeAttr().Get(&clippingRange);
+    AiNodeSetFlt(node, "near_clip", clippingRange[0]);
+    AiNodeSetFlt(node, "far_clip", clippingRange[1]);
+    
+    VtValue shutterOpenValue;
+    if (cam.GetShutterOpenAttr().Get(&shutterOpenValue))
+        AiNodeSetFlt(node, "shutter_start", VtValueGetFloat(shutterOpenValue));
+
+    VtValue shutterCloseValue;
+    if (cam.GetShutterCloseAttr().Get(&shutterCloseValue))
+        AiNodeSetFlt(node, "shutter_end", VtValueGetFloat(shutterCloseValue));
+    
+    _ReadArnoldParameters(prim, context, node, time, "primvars:arnold");
+    ExportPrimvars(prim, node, time, context);
+}

--- a/translator/reader/read_camera.cpp
+++ b/translator/reader/read_camera.cpp
@@ -19,12 +19,12 @@
 #include <string>
 #include <vector>
 
-#include <pxr/usd/usdGeom/camera.h>
 #include <pxr/base/gf/camera.h>
+#include <pxr/usd/usdGeom/camera.h>
 
+#include "read_camera.h"
 #include "registry.h"
 #include "utils.h"
-#include "read_camera.h"
 //-*************************************************************************
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -44,8 +44,9 @@ void UsdArnoldReadCamera::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         camType = "persp_camera";
     } else if (projection == UsdGeomTokens->orthographic) {
         camType = "ortho_camera";
-    } else
+    } else {
         return;
+    }
 
     AtNode *node = context.CreateArnoldNode(camType.c_str(), prim.GetPath().GetText());
     ExportMatrix(prim, node, time, context);
@@ -58,22 +59,25 @@ void UsdArnoldReadCamera::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AiNodeSetFlt(node, "fov", fov);
 
         VtValue focusDistanceValue;
-        if (cam.CreateFocusDistanceAttr().Get(&focusDistanceValue))
+        if (cam.CreateFocusDistanceAttr().Get(&focusDistanceValue)) {
             AiNodeSetFlt(node, "focus_distance", VtValueGetFloat(focusDistanceValue));
+        }
     }
     GfVec2f clippingRange;
     cam.CreateClippingRangeAttr().Get(&clippingRange);
     AiNodeSetFlt(node, "near_clip", clippingRange[0]);
     AiNodeSetFlt(node, "far_clip", clippingRange[1]);
-    
+
     VtValue shutterOpenValue;
-    if (cam.GetShutterOpenAttr().Get(&shutterOpenValue))
+    if (cam.GetShutterOpenAttr().Get(&shutterOpenValue)) {
         AiNodeSetFlt(node, "shutter_start", VtValueGetFloat(shutterOpenValue));
+    }
 
     VtValue shutterCloseValue;
-    if (cam.GetShutterCloseAttr().Get(&shutterCloseValue))
+    if (cam.GetShutterCloseAttr().Get(&shutterCloseValue)) {
         AiNodeSetFlt(node, "shutter_end", VtValueGetFloat(shutterCloseValue));
-    
+    }
+
     _ReadArnoldParameters(prim, context, node, time, "primvars:arnold");
     ExportPrimvars(prim, node, time, context);
 }

--- a/translator/reader/read_camera.h
+++ b/translator/reader/read_camera.h
@@ -1,0 +1,29 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ai_nodes.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "prim_reader.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// Register readers for the USD builtin lights
+REGISTER_PRIM_READER(UsdArnoldReadCamera);

--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -281,9 +281,9 @@ void UsdArnoldReadCube::Read(const UsdPrim &prim, UsdArnoldReaderContext &contex
 
     UsdGeomCube cube(prim);
 
-    VtValue size_attr;
-    if (cube.GetSizeAttr().Get(&size_attr)) {
-        float sizeValue = VtValueGetFloat(size_attr);
+    VtValue sizeAttr;
+    if (cube.GetSizeAttr().Get(&sizeAttr)) {
+        float sizeValue = VtValueGetFloat(sizeAttr);
         AiNodeSetVec(node, "min", -sizeValue / 2.f, -sizeValue / 2.f, -sizeValue / 2.f);
         AiNodeSetVec(node, "max", sizeValue / 2.f, sizeValue / 2.f, sizeValue / 2.f);
     }

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -229,18 +229,20 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
                     UsdPrim cameraPrim = _stage->GetPrimAtPath(SdfPath(cameraName.c_str()));
                     if (cameraPrim) {
                         UsdGeomCamera cam(cameraPrim);
-                    
+
                         bool motionBlur = false;
                         float shutterStart = 0.f;
                         float shutterEnd = 0.f;
 
                         if (cam) {
                             VtValue shutterOpenValue;
-                            if (cam.GetShutterOpenAttr().Get(&shutterOpenValue))
+                            if (cam.GetShutterOpenAttr().Get(&shutterOpenValue)) {
                                 shutterStart = VtValueGetFloat(shutterOpenValue);
+                            }
                             VtValue shutterCloseValue;
-                            if (cam.GetShutterCloseAttr().Get(&shutterCloseValue))
+                            if (cam.GetShutterCloseAttr().Get(&shutterCloseValue)) {
                                 shutterEnd = VtValueGetFloat(shutterCloseValue);
+                            }
                         }
 
                         _time.motionBlur = (shutterEnd > shutterStart);

--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -23,6 +23,7 @@
 #include "read_geometry.h"
 #include "read_light.h"
 #include "read_shader.h"
+#include "read_camera.h"
 #include "utils.h"
 //-*************************************************************************
 
@@ -59,6 +60,10 @@ void UsdArnoldReaderRegistry::RegisterPrimitiveReaders()
         RegisterReader("SphereLight", new UsdArnoldReadSphereLight());
         RegisterReader("RectLight", new UsdArnoldReadRectLight());
         RegisterReader("GeometryLight", new UsdArnoldReadGeometryLight());
+    }
+
+    if (_mask & AI_NODE_CAMERA) {
+        RegisterReader("Camera", new UsdArnoldReadCamera());
     }
 
     // USD Shaders (builtin, or custom ones, including arnold)

--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -20,10 +20,10 @@
 #include <vector>
 
 #include "read_arnold_type.h"
+#include "read_camera.h"
 #include "read_geometry.h"
 #include "read_light.h"
 #include "read_shader.h"
-#include "read_camera.h"
 #include "utils.h"
 //-*************************************************************************
 

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -508,7 +508,7 @@ std::string UsdArnoldPrimWriter::GetArnoldNodeName(const AtNode* node)
         // We're going to generate an arbitrary name for this node, with its node type
         // and a naùe based on its pointer #380
         std::stringstream ss;
-        ss << "unnamed/" << AiNodeEntryGetName(AiNodeGetNodeEntry(node)) <<"/p"<<node;
+        ss << "unnamed/" << AiNodeEntryGetName(AiNodeGetNodeEntry(node)) << "/p" << node;
         name = ss.str();
     }
 

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -25,6 +25,7 @@
 #include "write_light.h"
 #include "write_options.h"
 #include "write_shader.h"
+#include "write_camera.h"
 
 //-*************************************************************************
 
@@ -48,6 +49,11 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
         RegisterWriter("point_light", new UsdArnoldWriteSphereLight());
         RegisterWriter("quad_light", new UsdArnoldWriteRectLight());
         RegisterWriter("mesh_light", new UsdArnoldWriteGeometryLight());
+
+        RegisterWriter("persp_camera", 
+            new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_PERSPECTIVE));
+        RegisterWriter("ortho_camera", 
+            new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_ORTHOGRAPHIC));
     }
 
     // Now let's iterate over all the arnold classes known at this point

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -21,11 +21,11 @@
 #include <vector>
 #include "../utils/utils.h"
 #include "write_arnold_type.h"
+#include "write_camera.h"
 #include "write_geometry.h"
 #include "write_light.h"
 #include "write_options.h"
 #include "write_shader.h"
-#include "write_camera.h"
 
 //-*************************************************************************
 
@@ -50,10 +50,8 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
         RegisterWriter("quad_light", new UsdArnoldWriteRectLight());
         RegisterWriter("mesh_light", new UsdArnoldWriteGeometryLight());
 
-        RegisterWriter("persp_camera", 
-            new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_PERSPECTIVE));
-        RegisterWriter("ortho_camera", 
-            new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_ORTHOGRAPHIC));
+        RegisterWriter("persp_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_PERSPECTIVE));
+        RegisterWriter("ortho_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_ORTHOGRAPHIC));
     }
 
     // Now let's iterate over all the arnold classes known at this point

--- a/translator/writer/write_camera.cpp
+++ b/translator/writer/write_camera.cpp
@@ -1,0 +1,93 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "write_camera.h"
+
+#include <ai.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/usdGeom/camera.h>
+#include <pxr/base/gf/camera.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "registry.h"
+
+//-*************************************************************************
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
+{
+    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
+
+    UsdGeomCamera cam = UsdGeomCamera::Define(stage, SdfPath(nodeName));
+    UsdPrim prim = cam.GetPrim();
+    
+    TfToken projection;
+    bool persp = false; 
+    if (_type == CAMERA_PERSPECTIVE) {
+        persp = true;
+        projection = TfToken("perspective");
+    }
+    else if (_type == CAMERA_ORTHOGRAPHIC)
+        projection = TfToken("orthographic");
+    else {
+        AiMsgError("[usd] Invalid camera type %s", nodeName.c_str());
+        return; // invalid camera type
+    }
+    cam.CreateProjectionAttr().Set(projection);
+
+    if (persp) {
+        AtNode *options = AiUniverseGetOptions(writer.GetUniverse());
+
+        float fov = AiNodeGetFlt(node, "fov");
+        float horizontalAperature = tan(fov * AI_DTOR * 0.5f);
+        horizontalAperature *= (2.f * 50.f * GfCamera::FOCAL_LENGTH_UNIT);
+        horizontalAperature /= GfCamera::APERTURE_UNIT;
+
+        cam.CreateHorizontalApertureAttr().Set(horizontalAperature);
+        float verticalAperture = horizontalAperature;
+        
+        // Use the options image resolution to determine the vertical aperture
+        if (options) 
+            verticalAperture *= (float)AiNodeGetInt(options, "yres") / (float)AiNodeGetInt(options, "xres");
+
+        cam.CreateVerticalApertureAttr().Set(verticalAperture);
+        // Note that we're not adding "fov" to the list of exported attrs, because we still
+        // want it to be set as an arnold-specific attribute. This way, when it's read from usd, 
+        // we can get the exact same value without any difference caused by the back and forth conversions
+
+        cam.CreateFocusDistanceAttr().Set(AiNodeGetFlt(node, "focus_distance"));
+        _exportedAttrs.insert("focus_distance");
+    }
+
+    // To be written in both perspective and orthographic cameras: 
+    GfVec2f clippingRange = GfVec2f(AiNodeGetFlt(node, "near_clip"), AiNodeGetFlt(node, "far_clip"));
+    cam.CreateClippingRangeAttr().Set(clippingRange);
+    _exportedAttrs.insert("near_clip");
+    _exportedAttrs.insert("far_clip");
+
+    cam.CreateShutterOpenAttr().Set(double(AiNodeGetFlt(node, "shutter_start")));
+    cam.CreateShutterCloseAttr().Set(double(AiNodeGetFlt(node, "shutter_end")));
+    
+    _exportedAttrs.insert("shutter_start");
+    _exportedAttrs.insert("shutter_end");
+
+    _WriteMatrix(cam, node, writer);
+    _WriteArnoldParameters(node, writer, prim, "primvars:arnold");
+}

--- a/translator/writer/write_camera.cpp
+++ b/translator/writer/write_camera.cpp
@@ -15,9 +15,9 @@
 
 #include <ai.h>
 
+#include <pxr/base/gf/camera.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/usd/usdGeom/camera.h>
-#include <pxr/base/gf/camera.h>
 
 #include <cstdio>
 #include <cstring>
@@ -37,16 +37,15 @@ void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
 
     UsdGeomCamera cam = UsdGeomCamera::Define(stage, SdfPath(nodeName));
     UsdPrim prim = cam.GetPrim();
-    
+
     TfToken projection;
-    bool persp = false; 
+    bool persp = false;
     if (_type == CAMERA_PERSPECTIVE) {
         persp = true;
         projection = TfToken("perspective");
-    }
-    else if (_type == CAMERA_ORTHOGRAPHIC)
+    } else if (_type == CAMERA_ORTHOGRAPHIC) {
         projection = TfToken("orthographic");
-    else {
+    } else {
         AiMsgError("[usd] Invalid camera type %s", nodeName.c_str());
         return; // invalid camera type
     }
@@ -62,21 +61,22 @@ void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
 
         cam.CreateHorizontalApertureAttr().Set(horizontalAperature);
         float verticalAperture = horizontalAperature;
-        
+
         // Use the options image resolution to determine the vertical aperture
-        if (options) 
+        if (options) {
             verticalAperture *= (float)AiNodeGetInt(options, "yres") / (float)AiNodeGetInt(options, "xres");
+        }
 
         cam.CreateVerticalApertureAttr().Set(verticalAperture);
         // Note that we're not adding "fov" to the list of exported attrs, because we still
-        // want it to be set as an arnold-specific attribute. This way, when it's read from usd, 
+        // want it to be set as an arnold-specific attribute. This way, when it's read from usd,
         // we can get the exact same value without any difference caused by the back and forth conversions
 
         cam.CreateFocusDistanceAttr().Set(AiNodeGetFlt(node, "focus_distance"));
         _exportedAttrs.insert("focus_distance");
     }
 
-    // To be written in both perspective and orthographic cameras: 
+    // To be written in both perspective and orthographic cameras:
     GfVec2f clippingRange = GfVec2f(AiNodeGetFlt(node, "near_clip"), AiNodeGetFlt(node, "far_clip"));
     cam.CreateClippingRangeAttr().Set(clippingRange);
     _exportedAttrs.insert("near_clip");
@@ -84,7 +84,7 @@ void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
 
     cam.CreateShutterOpenAttr().Set(double(AiNodeGetFlt(node, "shutter_start")));
     cam.CreateShutterCloseAttr().Set(double(AiNodeGetFlt(node, "shutter_end")));
-    
+
     _exportedAttrs.insert("shutter_start");
     _exportedAttrs.insert("shutter_end");
 

--- a/translator/writer/write_camera.h
+++ b/translator/writer/write_camera.h
@@ -1,0 +1,44 @@
+// Copyright 2019 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ai_nodes.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "prim_writer.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+class UsdArnoldWriteCamera : public UsdArnoldPrimWriter {
+
+public:
+    enum CameraType {
+        CAMERA_PERSPECTIVE = 0,
+        CAMERA_ORTHOGRAPHIC = 1
+    };
+
+    UsdArnoldWriteCamera(UsdArnoldWriteCamera::CameraType t = CAMERA_PERSPECTIVE)
+        : UsdArnoldPrimWriter(), _type(t) {}
+
+    void Write(const AtNode *node, UsdArnoldWriter &writer) override;
+
+private:
+    CameraType _type;
+};
+

--- a/translator/writer/write_camera.h
+++ b/translator/writer/write_camera.h
@@ -26,19 +26,13 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 class UsdArnoldWriteCamera : public UsdArnoldPrimWriter {
-
 public:
-    enum CameraType {
-        CAMERA_PERSPECTIVE = 0,
-        CAMERA_ORTHOGRAPHIC = 1
-    };
+    enum CameraType { CAMERA_PERSPECTIVE = 0, CAMERA_ORTHOGRAPHIC = 1 };
 
-    UsdArnoldWriteCamera(UsdArnoldWriteCamera::CameraType t = CAMERA_PERSPECTIVE)
-        : UsdArnoldPrimWriter(), _type(t) {}
+    UsdArnoldWriteCamera(UsdArnoldWriteCamera::CameraType t = CAMERA_PERSPECTIVE) : UsdArnoldPrimWriter(), _type(t) {}
 
     void Write(const AtNode *node, UsdArnoldWriter &writer) override;
 
 private:
     CameraType _type;
 };
-

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -58,7 +58,7 @@ inline void SplitString(const std::string &input, std::vector<std::string> &resu
     }
 }
 
-}
+} // namespace
 
 void UsdArnoldWriteShader::Write(const AtNode *node, UsdArnoldWriter &writer)
 {

--- a/translator/writer/write_shader.h
+++ b/translator/writer/write_shader.h
@@ -49,10 +49,7 @@ protected:
 
 class UsdArnoldWriteToon : public UsdArnoldWriteShader {
 public:
-    UsdArnoldWriteToon() : UsdArnoldWriteShader("toon", "arnold:toon")
-    {
-    }
+    UsdArnoldWriteToon() : UsdArnoldWriteShader("toon", "arnold:toon") {}
 
     void Write(const AtNode *node, UsdArnoldWriter &writer) override;
 };
-

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -87,7 +87,7 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
     if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr) {
         return;
     }
-    
+
     // Check if this arnold node has already been exported, and early out if it was.
     // Note that we're storing the name of the arnold node, which might be slightly
     // different from the USD prim name, since UsdArnoldPrimWriter::GetArnoldNodeName


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of writing arnold cameras as `ArnoldPerspCamera`, `ArnoldOrthoCamera` schemas, we now write them as `UsdGeomCamera` primitives.

Since there are some formulas when converting arnold's `fov` to USD horizontal and vertical aperture + focal length, I'm writing both the usd native parameters, and also the arnold one as an arnold primvar `primvars:arnold:fov`. 

Same in the reader : we first read the usd builtin attributes, but if a primvar is present, then its value will be used.

This will require a test when #157 is done, as we can't really test this through a procedural

**Issues fixed in this pull request**
Fixes #345 