### PR TITLE
Not unlocking the render buffer in Unmap when the buffer is empty.

### DIFF
--- a/render_delegate/render_buffer.cpp
+++ b/render_delegate/render_buffer.cpp
@@ -233,7 +233,12 @@ uint8_t* HdArnoldRenderBuffer::Map()
     return _buffer.data();
 }
 
-void HdArnoldRenderBuffer::Unmap() { _mutex.unlock(); }
+void HdArnoldRenderBuffer::Unmap()
+{
+    if (!_buffer.empty()) {
+        _mutex.unlock();
+    }
+}
 
 bool HdArnoldRenderBuffer::IsMapped() const { return false; }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Not unlocking the render buffer in Unmap when the buffer is empty.

**Issues fixed in this pull request**
Fixes #394

**Additional context**
This was a different behavior between Houdini and Usdview I believe. In Hydra and usdview, when `HdRenderBuffer::Map` returns a nullptr, `HdRenderBuffer::Unmap` is not used. Our implementation relied on this behavior, even though this was not hinted at in the HdRenderBuffer base class. In Houdini, this lead to calling `HdRenderBuffer::Unmap` on empty buffers, calling `std::mutex::unlock` on non-locked mutexes. This is an undefined behavior in the standard (`The mutex must be locked by the current thread of execution, otherwise, the behavior is undefined.`), but it was not causing an issue on non-windows systems.
