### PR TITLE
Check for long long type in _CheckForBoolValue (#398)

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -283,6 +283,8 @@ void _CheckForBoolValue(const VtValue& value, F&& f)
         f(value.UncheckedGet<int>() != 0);
     } else if (value.IsHolding<long>()) {
         f(value.UncheckedGet<long>() != 0);
+    } else if (value.IsHolding<long long>()) {
+        f(value.UncheckedGet<long long>() != 0);
     }
 }
 

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -295,6 +295,8 @@ void _CheckForIntValue(const VtValue& value, F&& f)
         f(value.UncheckedGet<int>());
     } else if (value.IsHolding<long>()) {
         f(static_cast<int>(value.UncheckedGet<long>()));
+    } else if (value.IsHolding<long long>()) {
+        f(static_cast<int>(value.UncheckedGet<long long>()));
     }
 }
 


### PR DESCRIPTION
Fixes #398, since windows is receiving the boolean value as long long

