### PR TITLE
Renaming the testsuite param "resave" by "resaved"

### DIFF
--- a/testsuite/test_0034/README
+++ b/testsuite/test_0034/README
@@ -3,4 +3,4 @@ Options shouldn't be loaded through procedurals
 author: sebastien ortega
 
 // Need to set these params to reproduce the problem. 
-PARAMS: {'resave':'ass', 'forceexpand': True}
+PARAMS: {'resaved':'ass', 'forceexpand': True}

--- a/testsuite/test_0051/README
+++ b/testsuite/test_0051/README
@@ -4,4 +4,4 @@ See #157
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0052/README
+++ b/testsuite/test_0052/README
@@ -4,4 +4,4 @@ See #248 #326
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0053/README
+++ b/testsuite/test_0053/README
@@ -4,4 +4,4 @@ See #367 #341
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0054/README
+++ b/testsuite/test_0054/README
@@ -2,4 +2,4 @@ Fisheye camera and background shader
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0055/README
+++ b/testsuite/test_0055/README
@@ -2,4 +2,4 @@ Orthographic Camera
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0056/README
+++ b/testsuite/test_0056/README
@@ -4,4 +4,4 @@ See #359
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0057/README
+++ b/testsuite/test_0057/README
@@ -2,4 +2,4 @@ Camera projection
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0058/README
+++ b/testsuite/test_0058/README
@@ -2,4 +2,4 @@ Shading trees with math shaders
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0059/README
+++ b/testsuite/test_0059/README
@@ -4,4 +4,4 @@ See #381
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0060/README
+++ b/testsuite/test_0060/README
@@ -2,4 +2,4 @@ Ramps with positions linked to shaders
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0061/README
+++ b/testsuite/test_0061/README
@@ -2,4 +2,4 @@ Instances with per-instance user data
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0062/README
+++ b/testsuite/test_0062/README
@@ -3,4 +3,4 @@ Shader Component linking
 See #352
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0063/README
+++ b/testsuite/test_0063/README
@@ -3,4 +3,4 @@ Motion blurred projections
 See #369
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0064/README
+++ b/testsuite/test_0064/README
@@ -4,4 +4,4 @@ See #348 #359 #369
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0065/README
+++ b/testsuite/test_0065/README
@@ -2,4 +2,4 @@ Light-linking
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0066/README
+++ b/testsuite/test_0066/README
@@ -2,4 +2,4 @@ Camera motion blur
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0067/README
+++ b/testsuite/test_0067/README
@@ -2,4 +2,4 @@ Auto-instanced .ass procedurals with different shaders
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0068/README
+++ b/testsuite/test_0068/README
@@ -2,4 +2,4 @@ Particles reading user attributes
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0069/README
+++ b/testsuite/test_0069/README
@@ -3,4 +3,4 @@ Geometry instances
 See #363 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0070/README
+++ b/testsuite/test_0070/README
@@ -3,4 +3,4 @@ See #287
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0071/README
+++ b/testsuite/test_0071/README
@@ -2,4 +2,4 @@ Polymesh tangent / bitangent
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0072/README
+++ b/testsuite/test_0072/README
@@ -2,4 +2,4 @@ Nurbs curves
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0073/README
+++ b/testsuite/test_0073/README
@@ -2,4 +2,4 @@ Hards and soft normals in polymeshes
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0074/README
+++ b/testsuite/test_0074/README
@@ -2,4 +2,4 @@ Utility shader id
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0075/README
+++ b/testsuite/test_0075/README
@@ -2,4 +2,4 @@ Photometric lights
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0076/README
+++ b/testsuite/test_0076/README
@@ -4,4 +4,4 @@ See #366
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0077/README
+++ b/testsuite/test_0077/README
@@ -2,4 +2,4 @@ Varying curve width
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0078/README
+++ b/testsuite/test_0078/README
@@ -2,4 +2,4 @@ User data colors
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0079/README
+++ b/testsuite/test_0079/README
@@ -2,4 +2,4 @@ Camera bokeh effect
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0080/README
+++ b/testsuite/test_0080/README
@@ -2,4 +2,4 @@ Diamond with dispersion and high refraction depth
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0081/README
+++ b/testsuite/test_0081/README
@@ -2,4 +2,4 @@ Vector displacement
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0082/README
+++ b/testsuite/test_0082/README
@@ -2,4 +2,4 @@ Animated shader parameters
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0083/README
+++ b/testsuite/test_0083/README
@@ -2,4 +2,4 @@ Blending different shaders
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0084/README
+++ b/testsuite/test_0084/README
@@ -2,4 +2,4 @@ Light Portals with skydome light
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0085/README
+++ b/testsuite/test_0085/README
@@ -2,4 +2,4 @@ Vertex colors and indexed data
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0086/README
+++ b/testsuite/test_0086/README
@@ -2,4 +2,4 @@ Motion blur on curves
 
 author: sebastien ortega
 
-PARAMS: {'resave':'usda'}
+PARAMS: {'resaved':'usda'}

--- a/tools/utils/regression_test.py
+++ b/tools/utils/regression_test.py
@@ -35,7 +35,7 @@ class Test:
                 reference_image     = '',
                 progressive         = False,
                 kick_params         = '',
-                resave              = None,
+                resaved             = None,
                 forceexpand         = False,
                 scene               = 'test.ass',
                 diff_hardfail       = 0.0157,  ## (4/256) oiiotool option --hardfail
@@ -56,7 +56,7 @@ class Test:
       self.reference_image = reference_image
       self.progressive = progressive
       self.kick_params = kick_params
-      self.resave = resave
+      self.resaved = resaved
       self.forceexpand = forceexpand
       self.scene = scene
       self.diff_hardfail = diff_hardfail
@@ -99,9 +99,10 @@ class Test:
          else:
             params.extend(self.kick_params)
 
-      if self.resave:
+      if self.resaved:
+         resaved_extension = self.resaved if isinstance(self.resaved, str) else 'ass'
          forceexpand = '-forceexpand' if self.forceexpand else ''
-         self.script = 'kick %s %s -resave test_resaved.%s\n' % (self.scene, forceexpand, self.resave) + ' '.join(['kick test_resaved.{}'.format(self.resave)] + params)
+         self.script = 'kick %s %s -resave test_resaved.%s\n' % (self.scene, forceexpand, resaved_extension) + ' '.join(['kick test_resaved.{}'.format(resaved_extension)] + params)
       else:
          self.script = ' '.join(['kick %s' % self.scene] + params)
 


### PR DESCRIPTION
**Changes proposed in this pull request**
Using again the keyword `resaved` , but we now check if it's a boolean or a string, before considering the extension for the resaved file

**Issues fixed in this pull request**
Fixes #402 
