### PR TITLE
Limiting symbol export of procedural on Linux and OSX

### DIFF
--- a/procedural/CMakeLists.txt
+++ b/procedural/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(SRC
         main.cpp)
 
+if (LINUX)
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/plugin.map -Wl,--exclude-libs=ALL")
+endif ()
+
 add_library(usd_proc SHARED ${SRC})
 target_link_libraries(usd_proc PRIVATE translator)
 target_include_directories(usd_proc PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../translator/reader")
@@ -13,6 +17,17 @@ endif ()
 
 if (APPLE OR LINUX)
     target_link_libraries(usd_proc PRIVATE dl)
+endif ()
+
+# Hiding exported symbols
+if (LINUX)
+    target_compile_options(usd_proc PRIVATE -fvisibility=hidden)
+elseif(APPLE)
+    if (${ARNOLD_VERSION} VERSION_GREATER_EQUAL "6.0.3.0")
+        string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Xlinker -S -Xlinker -x -Xlinker -exported_symbols_list -Xlinker ${CMAKE_CURRENT_SOURCE_DIR}/macos_export_list")
+    else ()
+        string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Xlinker -S -Xlinker -x -Xlinker -exported_symbols_list -Xlinker ${CMAKE_CURRENT_SOURCE_DIR}/macos_export_list_no_scene")
+    endif ()
 endif ()
 
 install(TARGETS usd_proc

--- a/procedural/SConscript
+++ b/procedural/SConscript
@@ -104,6 +104,18 @@ myenv.Append(LIBS = usd_deps)
 if myenv['USD_HAS_PYTHON_SUPPORT']:
     myenv.Append(LIBS = [myenv['PYTHON_LIB_NAME'], myenv['BOOST_LIB_NAME'] % 'python'])
 
+if system.IS_LINUX:
+    plugin_map = os.path.join(src_proc_dir, 'plugin.map')
+    myenv.Append(LINKFLAGS = [ '-Wl,--version-script={}'.format(plugin_map) ])
+    myenv.Append(LINKFLAGS = [ '-Wl,--exclude-libs=ALL' ])
+    myenv.Append(CXXFLAGS = [ '-fvisibility=hidden' ])
+elif system.IS_DARWIN:
+    if myenv['ARNOLD_HAS_SCENE_FORMAT_API']:
+        export_list = os.path.join(src_proc_dir, 'macos_export_list')
+    else:
+        export_list = os.path.join(src_proc_dir, 'macos_export_list_no_scene')
+    myenv.Append(LINKFLAGS = Split('-Xlinker -S -Xlinker -x -Xlinker -exported_symbols_list -Xlinker {} '.format(export_list)))
+
 # Build shared library for the Alembic procedural
 USD = myenv.SharedLibrary('usd_proc', source_files, SHLIBPREFIX='')
 Return('USD')

--- a/procedural/macos_export_list
+++ b/procedural/macos_export_list
@@ -1,0 +1,2 @@
+_NodeLoader
+_SceneFormatLoader

--- a/procedural/macos_export_list_no_scene
+++ b/procedural/macos_export_list_no_scene
@@ -1,0 +1,1 @@
+_NodeLoader

--- a/procedural/plugin.map
+++ b/procedural/plugin.map
@@ -1,0 +1,8 @@
+{
+global:
+    extern "C" {
+        NodeLoader;
+        SceneFormatLoader;
+    };
+local: *;
+};


### PR DESCRIPTION
**Changes proposed in this pull request**
- Limiting symbol export of procedural on Linux and OSX.

**Issues fixed in this pull request**
Fixes #409
