### PR TITLE
Adding usdSkel as a link time dependency when using a shared USD build

### DIFF
--- a/procedural/SConscript
+++ b/procedural/SConscript
@@ -90,6 +90,7 @@ else:  # shared libs
         'usdLux',
         'gf',
         'usdVol',
+        'usdSkel',
     ]
 
     usd_libs, usd_sources = link_usd_libraries(myenv, usd_libs)

--- a/tools/utils/dependencies.py
+++ b/tools/utils/dependencies.py
@@ -122,6 +122,7 @@ def translator(env, sources):
             'usdLux',
             'gf',
             'usdVol',
+            'usdSkel',
         ]
 
         usd_deps = ['tbb']

--- a/translator/CMakeLists.txt
+++ b/translator/CMakeLists.txt
@@ -80,7 +80,7 @@ else ()
     if (USD_MONOLITHIC_BUILD)
         target_link_libraries(translator INTERFACE usd_ms)
     else ()
-        target_link_libraries(translator INTERFACE gf sdf tf usd ar usdGeom usdShade vt usdLux usdVol)
+        target_link_libraries(translator INTERFACE gf sdf tf usd ar usdGeom usdShade vt usdLux usdVol usdSkel)
     endif ()
 endif ()
 

--- a/translator/SConscript
+++ b/translator/SConscript
@@ -51,6 +51,7 @@ elif myenv['USD_BUILD_MODE'] == 'shared_libs':
         'vt',
         'usdLux',
         'usdVol',
+        'usdSkel',
     ]
 
     usd_libs, usd_sources = link_usd_libraries(myenv, usd_libs)


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding usdSkel as a link time dependency when using a shared USD build.

**Issues fixed in this pull request**
#329

**Additional context**
This was missing from pull request #419 and I didn't test building against a shared usd build
