### PR TITLE
Resetting the aborted status when the scene changed.

### DIFF
--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -67,18 +67,17 @@ public:
     /// Interrupts an ongoing render.
     ///
     /// Useful when there is new data to display, or the render settings have changed.
+    ///
+    /// @param clearStatus Clears the internal failure status. Set it to false when no scene data changed, that could
+    ///  affect the aborted internal status.
     HDARNOLD_API
-    void Interrupt();
-
-    /// Clear aborted status of the render, so it can be resumed by calling Render again.
-    HDARNOLD_API
-    void ClearStatus();
+    void Interrupt(bool clearStatus = true);
 
 private:
     /// Indicate if render needs restarting, in case interrupt is called after rendering has finished.
     std::atomic<bool> _needsRestart;
     /// Indicate if rendering has been aborted at one point or another.
-    bool _aborted = false;
+    std::atomic<bool> _aborted;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -114,7 +114,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     if (projMtx != _projMtx || viewMtx != _viewMtx) {
         _projMtx = projMtx;
         _viewMtx = viewMtx;
-        renderParam->Interrupt();
+        renderParam->Interrupt(false);
         AiNodeSetMatrix(_camera, str::matrix, HdArnoldConvertMatrix(_viewMtx.GetInverse()));
         AiNodeSetMatrix(_driver, str::projMtx, HdArnoldConvertMatrix(_projMtx));
         AiNodeSetMatrix(_driver, str::viewMtx, HdArnoldConvertMatrix(_viewMtx));
@@ -125,7 +125,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     const auto width = static_cast<int>(vp[2]);
     const auto height = static_cast<int>(vp[3]);
     if (width != _width || height != _height) {
-        renderParam->Interrupt();
+        renderParam->Interrupt(false);
         _width = width;
         _height = height;
         auto* options = _delegate->GetOptions();
@@ -159,13 +159,13 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         // If USD has the newer compositor class, we can allocate float buffers for the color, otherwise we need to
         // stick to UNorm8.
         if (!_usingFallbackBuffers) {
-            renderParam->Interrupt();
+            renderParam->Interrupt(false);
             AiNodeSetArray(_delegate->GetOptions(), str::outputs, AiArrayCopy(_fallbackOutputs));
             _usingFallbackBuffers = true;
             AiNodeSetPtr(_driver, str::aov_pointer, &_fallbackBuffers);
         }
         if (_fallbackColor.GetWidth() != _width || _fallbackColor.GetHeight() != _height) {
-            renderParam->Interrupt();
+            renderParam->Interrupt(false);
 #ifdef USD_HAS_UPDATED_COMPOSITOR
             _fallbackColor.Allocate({_width, _height, 1}, HdFormatFloat32Vec4, false);
 #else


### PR DESCRIPTION
**Changes proposed in this pull request**
- Resetting the aborted status when the scene changed.

**Issues fixed in this pull request**
Fixes #430

**Additional context**
The render delegate stored an `aborted` flag, that stopped it from restarting renders when the render returned with an error. However, this `aborted` flag was never reset when there was a significant change to the scene (that could have fixed the previous issue). I introduced a new flag, `clearStatus` to `HdArnoldRenderParam::Interrupt`, with a default value of true. In most cases we want to clear the aborted flag, except when camera changes in the render pass, or the fallback buffers are used, because we know that these changes won't affect the status of renders.

One of the most obvious use cases was when the user enters an incorrect light path expression.
