### PR TITLE
Extend viewport representation of nested procedurals

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -697,15 +697,37 @@ void UsdArnoldReadVolume::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
 void UsdArnoldReadProcViewport::Read(const UsdPrim &prim, UsdArnoldReaderContext &context)
 {
     AtUniverse *universe = context.GetReader()->GetUniverse();
+    const TimeSettings &time = context.GetTimeSettings();
+
+    // Get the filename of this ass/usd/abc procedural
     UsdAttribute attr = prim.GetAttribute(TfToken("filename"));
-    if (attr) {
-        VtValue value;
-        if (attr.Get(&value)) {
-            std::string filename = VtValueGetString(value);
-            AtParamValueMap *params = AiParamValueMap();
-            AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_SHAPE);
-            AiSceneLoad(universe, filename.c_str(), params);
-            AiParamValueMapDestroy(params);
-        }
-    }
+    if (!attr)
+        return;
+
+    VtValue value;
+    if (!attr.Get(&value))
+        return;
+
+    std::string filename = VtValueGetString(value);
+
+    // create a temporary universe to create a dummy procedural
+    AtUniverse* tmpUniverse = AiUniverse();
+
+    // copy the procedural search path string from the input universe
+    AiNodeSetStr(AiUniverseGetOptions(tmpUniverse), "procedural_searchpath", 
+        AiNodeGetStr(AiUniverseGetOptions(universe), "procedural_searchpath"));
+
+    // Create a procedural with the given filename
+    AtNode *proc = AiNode(tmpUniverse, _procName.c_str(), "viewport_proc");
+    AiNodeSetStr(proc, "filename", filename.c_str());
+    // ensure we read all the parameters from the procedural
+    _ReadArnoldParameters(prim, context, proc, time, "");
+    ReadPrimvars(prim, proc, time, context);
+
+    AtParamValueMap* params = AiParamValueMap();
+    AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_SHAPE);
+    AiProceduralViewport(proc, universe, _mode, params);
+    AiParamValueMapDestroy(params);
+
+    AiUniverseDestroy(tmpUniverse);
 }

--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -701,20 +701,23 @@ void UsdArnoldReadProcViewport::Read(const UsdPrim &prim, UsdArnoldReaderContext
 
     // Get the filename of this ass/usd/abc procedural
     UsdAttribute attr = prim.GetAttribute(TfToken("filename"));
-    if (!attr)
+    if (!attr) {
         return;
+    }
 
     VtValue value;
-    if (!attr.Get(&value))
+    if (!attr.Get(&value)) {
         return;
+    }
 
     std::string filename = VtValueGetString(value);
 
     // create a temporary universe to create a dummy procedural
-    AtUniverse* tmpUniverse = AiUniverse();
+    AtUniverse *tmpUniverse = AiUniverse();
 
     // copy the procedural search path string from the input universe
-    AiNodeSetStr(AiUniverseGetOptions(tmpUniverse), "procedural_searchpath", 
+    AiNodeSetStr(
+        AiUniverseGetOptions(tmpUniverse), "procedural_searchpath",
         AiNodeGetStr(AiUniverseGetOptions(universe), "procedural_searchpath"));
 
     // Create a procedural with the given filename
@@ -724,7 +727,7 @@ void UsdArnoldReadProcViewport::Read(const UsdPrim &prim, UsdArnoldReaderContext
     _ReadArnoldParameters(prim, context, proc, time, "");
     ReadPrimvars(prim, proc, time, context);
 
-    AtParamValueMap* params = AiParamValueMap();
+    AtParamValueMap *params = AiParamValueMap();
     AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_SHAPE);
     AiProceduralViewport(proc, universe, _mode, params);
     AiParamValueMapDestroy(params);

--- a/translator/reader/read_geometry.h
+++ b/translator/reader/read_geometry.h
@@ -43,8 +43,10 @@ REGISTER_PRIM_READER(UsdArnoldReadVolume, AI_NODE_SHAPE);
 
 class UsdArnoldReadProcViewport : public UsdArnoldPrimReader {
 public:
-    UsdArnoldReadProcViewport(const std::string &procName, AtProcViewportMode mode) : UsdArnoldPrimReader(AI_NODE_SHAPE), 
-    _procName(procName), _mode(mode) {}
+    UsdArnoldReadProcViewport(const std::string &procName, AtProcViewportMode mode)
+        : UsdArnoldPrimReader(AI_NODE_SHAPE), _procName(procName), _mode(mode)
+    {
+    }
     void Read(const UsdPrim &prim, UsdArnoldReaderContext &context) override;
 
 private:

--- a/translator/reader/read_geometry.h
+++ b/translator/reader/read_geometry.h
@@ -40,4 +40,14 @@ REGISTER_PRIM_READER(UsdArnoldReadGenericPolygons, AI_NODE_SHAPE);
 REGISTER_PRIM_READER(UsdArnoldReadGenericPoints, AI_NODE_SHAPE);
 REGISTER_PRIM_READER(UsdArnoldReadPointInstancer, AI_NODE_SHAPE);
 REGISTER_PRIM_READER(UsdArnoldReadVolume, AI_NODE_SHAPE);
-REGISTER_PRIM_READER(UsdArnoldReadProcViewport, AI_NODE_SHAPE);
+
+class UsdArnoldReadProcViewport : public UsdArnoldPrimReader {
+public:
+    UsdArnoldReadProcViewport(const std::string &procName, AtProcViewportMode mode) : UsdArnoldPrimReader(AI_NODE_SHAPE), 
+    _procName(procName), _mode(mode) {}
+    void Read(const UsdPrim &prim, UsdArnoldReaderContext &context) override;
+
+private:
+    std::string _procName;
+    AtProcViewportMode _mode;
+};

--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -151,8 +151,8 @@ void UsdArnoldViewportReaderRegistry::RegisterPrimitiveReaders()
 
     // For procedurals that can be read a scene format (ass, abc, usd),
     // we use a prim reader that will load the scene in this universe
-    RegisterReader("ArnoldProcedural", new UsdArnoldReadProcViewport());
-    RegisterReader("ArnoldUsd", new UsdArnoldReadProcViewport());
-    RegisterReader("ArnoldAlembic", new UsdArnoldReadProcViewport());
+    RegisterReader("ArnoldProcedural", new UsdArnoldReadProcViewport("procedural", _mode));
+    RegisterReader("ArnoldUsd", new UsdArnoldReadProcViewport("usd", _mode));
+    RegisterReader("ArnoldAlembic", new UsdArnoldReadProcViewport("alembic", _mode));
 }
 #endif


### PR DESCRIPTION
**Changes proposed in this pull request**
This ticket improves the work done in #424 and now allows for recursive nested procedurals.
Now we create a procedural in a temporary universe, and we call `AiProceduralViewport` in this procedural, so that it populates the desired universe. If another usd procedural is found, the same will happen recursively, and so on....

**Issues fixed in this pull request**
Fixes #435 
