### PR TITLE
HdArnoldRenderBuffer : Fixed uninitialized _mutex variable.

### DIFF
--- a/render_delegate/render_buffer.cpp
+++ b/render_delegate/render_buffer.cpp
@@ -193,7 +193,7 @@ WriteBucketFunctionMap writeBucketFunctions{
 
 } // namespace
 
-HdArnoldRenderBuffer::HdArnoldRenderBuffer(const SdfPath& id) : HdRenderBuffer(id)
+HdArnoldRenderBuffer::HdArnoldRenderBuffer(const SdfPath& id) : HdRenderBuffer(id), _mutex()
 {
     _hasUpdates.store(false, std::memory_order_release);
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Constructor initalize _mutex variable.

**Issues fixed in this pull request**
When quickly switching between AOVs using UsdImagingGLEngine SetRendererAOV(), I was tripping the debugger on a lock_guard using a "_mutex" member variable that seemingly was unitialized. The following attempt at a fix seems to resolve the issue.


