### PR TITLE
Using the sub-network connected to a preview surface's displacement parameter when preview surface used as displacement

### DIFF
--- a/render_delegate/constant_strings.h
+++ b/render_delegate/constant_strings.h
@@ -139,6 +139,7 @@ ASTR(depth_pointer);
 ASTR(diffuseColor);
 ASTR(disk_light);
 ASTR(disp_map);
+ASTR(displacement);
 ASTR(distant_light);
 ASTR(emission);
 ASTR(emission_color);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Using the sub-network connected to a preview surface's displacement parameter when preview surface used as displacement.

**Issues fixed in this pull request**
Fixes #448 