### PR TITLE
Using single element arrays to set parameters

### DIFF
--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -38,6 +38,8 @@
 #include "constant_strings.h"
 #include "hdarnold.h"
 
+#include <type_traits>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 // clang-format off
@@ -74,6 +76,50 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 
 namespace {
 
+auto nodeSetByteFromInt = [](AtNode* node, const AtString paramName, int v) {
+    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
+};
+auto nodeSetByteFromUChar = [](AtNode* node, const AtString paramName, unsigned char v) {
+    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
+};
+auto nodeSetByteFromLong = [](AtNode* node, const AtString paramName, long v) {
+    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
+};
+auto nodeSetIntFromLong = [](AtNode* node, const AtString paramName, long v) {
+    AiNodeSetInt(node, paramName, static_cast<int>(v));
+};
+auto nodeSetStrFromToken = [](AtNode* node, const AtString paramName, TfToken v) {
+    AiNodeSetStr(node, paramName, v.GetText());
+};
+auto nodeSetStrFromStdStr = [](AtNode* node, const AtString paramName, const std::string& v) {
+    AiNodeSetStr(node, paramName, v.c_str());
+};
+auto nodeSetBoolFromInt = [](AtNode* node, const AtString paramName, int v) { AiNodeSetBool(node, paramName, v != 0); };
+auto nodeSetBoolFromLong = [](AtNode* node, const AtString paramName, long v) {
+    AiNodeSetBool(node, paramName, v != 0);
+};
+auto nodeSetFltFromHalf = [](AtNode* node, const AtString paramName, GfHalf v) {
+    AiNodeSetFlt(node, paramName, static_cast<float>(v));
+};
+auto nodeSetFltFromDouble = [](AtNode* node, const AtString paramName, double v) {
+    AiNodeSetFlt(node, paramName, static_cast<float>(v));
+};
+auto nodeSetRGBFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
+    AiNodeSetRGB(node, paramName, v[0], v[1], v[2]);
+};
+auto nodeSetRGBAFromVec4 = [](AtNode* node, const AtString paramName, const GfVec4f& v) {
+    AiNodeSetRGBA(node, paramName, v[0], v[1], v[2], v[3]);
+};
+auto nodeSetVecFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
+    AiNodeSetVec(node, paramName, v[0], v[1], v[2]);
+};
+auto nodeSetVec2FromVec2 = [](AtNode* node, const AtString paramName, const GfVec2f& v) {
+    AiNodeSetVec2(node, paramName, v[0], v[1]);
+};
+auto nodeSetStrFromAssetPath = [](AtNode* node, const AtString paramName, const SdfAssetPath& v) {
+    AiNodeSetStr(node, paramName, v.GetResolvedPath().empty() ? v.GetAssetPath().c_str() : v.GetResolvedPath().c_str());
+};
+
 const std::array<HdInterpolation, HdInterpolationCount> interpolations{
     HdInterpolationConstant, HdInterpolationUniform,     HdInterpolationVarying,
     HdInterpolationVertex,   HdInterpolationFaceVarying, HdInterpolationInstance,
@@ -100,15 +146,56 @@ inline uint32_t _ConvertArray(AtNode* node, const AtString& name, uint8_t arnold
 }
 
 template <typename T>
+AtArray* _ArrayConvert(const VtArray<T>& v, uint8_t arnoldType)
+{
+    return AiArrayConvert(v.size(), 1, arnoldType, v.data());
+}
+
+template <>
+AtArray* _ArrayConvert<std::string>(const VtArray<std::string>& v, uint8_t arnoldType)
+{
+    // TODO(pal): Implement.
+    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
+}
+
+template <>
+AtArray* _ArrayConvert<TfToken>(const VtArray<TfToken>& v, uint8_t arnoldType)
+{
+    // TODO(pal): Implement.
+    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
+}
+
+template <>
+AtArray* _ArrayConvert<SdfAssetPath>(const VtArray<SdfAssetPath>& v, uint8_t arnoldType)
+{
+    // TODO(pal): Implement.
+    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
+}
+
+template <typename T>
 inline uint32_t _DeclareAndConvertArray(
     AtNode* node, const TfToken& name, const TfToken& scope, const TfToken& type, uint8_t arnoldType,
-    const VtValue& value)
+    const VtValue& value, bool isConstant, void (*f)(AtNode*, const AtString, T))
 {
+    // We are removing const and reference from the type. When using std::string or SdfAssetPath, we want
+    // to use a function pointer with const& type, because we'll be providing our own lambda to do the conversion, and
+    // we don't want to copy complex types. For other cases, Arnold functions are receiving types by their value. We
+    // can't use a template to automatically deduct the type of the functions, because the AiNodeSet functions have
+    // overrides for both const char* and AtString in their second parameter, so we are forcing the deduction using
+    // the function pointer.
+    using CT = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+    const auto& v = value.UncheckedGet<VtArray<CT>>();
+    if (isConstant && v.size() == 1) {
+        if (!_Declare(node, name, _tokens->constant, type)) {
+            return 0;
+        }
+        f(node, AtString{name.GetText()}, v[0]);
+        return 1;
+    }
     if (!_Declare(node, name, scope, type)) {
         return 0;
     }
-    const auto& v = value.UncheckedGet<T>();
-    auto* arr = AiArrayConvert(v.size(), 1, arnoldType, v.data());
+    auto* arr = _ArrayConvert<CT>(v, arnoldType);
     AiNodeSetArray(node, name.GetText(), arr);
     return AiArrayGetNumElements(arr);
 }
@@ -116,30 +203,49 @@ inline uint32_t _DeclareAndConvertArray(
 // This is useful for uniform, vertex and face-varying. We need to know the size
 // to generate the indices for faceVarying data.
 inline uint32_t _DeclareAndAssignFromArray(
-    AtNode* node, const TfToken& name, const TfToken& scope, const VtValue& value, bool isColor = false)
+    AtNode* node, const TfToken& name, const TfToken& scope, const VtValue& value, bool isColor,
+    bool isConstant = false)
 {
     if (value.IsHolding<VtBoolArray>()) {
-        return _DeclareAndConvertArray<VtBoolArray>(node, name, scope, _tokens->BOOL, AI_TYPE_BOOLEAN, value);
+        return _DeclareAndConvertArray<bool>(
+            node, name, scope, _tokens->BOOL, AI_TYPE_BOOLEAN, value, isConstant, AiNodeSetBool);
     } else if (value.IsHolding<VtUCharArray>()) {
-        return _DeclareAndConvertArray<VtUCharArray>(node, name, scope, _tokens->BYTE, AI_TYPE_BYTE, value);
+        return _DeclareAndConvertArray<VtUCharArray::value_type>(
+            node, name, scope, _tokens->BYTE, AI_TYPE_BYTE, value, isConstant, AiNodeSetByte);
     } else if (value.IsHolding<VtUIntArray>()) {
-        return _DeclareAndConvertArray<VtUIntArray>(node, name, scope, _tokens->UINT, AI_TYPE_UINT, value);
+        return _DeclareAndConvertArray<unsigned int>(
+            node, name, scope, _tokens->UINT, AI_TYPE_UINT, value, isConstant, AiNodeSetUInt);
     } else if (value.IsHolding<VtIntArray>()) {
-        return _DeclareAndConvertArray<VtIntArray>(node, name, scope, _tokens->INT, AI_TYPE_INT, value);
+        return _DeclareAndConvertArray<int>(
+            node, name, scope, _tokens->INT, AI_TYPE_INT, value, isConstant, AiNodeSetInt);
     } else if (value.IsHolding<VtFloatArray>()) {
-        return _DeclareAndConvertArray<VtFloatArray>(node, name, scope, _tokens->FLOAT, AI_TYPE_FLOAT, value);
+        return _DeclareAndConvertArray<float>(
+            node, name, scope, _tokens->FLOAT, AI_TYPE_FLOAT, value, isConstant, AiNodeSetFlt);
     } else if (value.IsHolding<VtDoubleArray>()) {
         // TODO
     } else if (value.IsHolding<VtVec2fArray>()) {
-        return _DeclareAndConvertArray<VtVec2fArray>(node, name, scope, _tokens->VECTOR2, AI_TYPE_VECTOR2, value);
+        return _DeclareAndConvertArray<const GfVec2f&>(
+            node, name, scope, _tokens->VECTOR2, AI_TYPE_VECTOR2, value, isConstant, nodeSetVec2FromVec2);
     } else if (value.IsHolding<VtVec3fArray>()) {
         if (isColor) {
-            return _DeclareAndConvertArray<VtVec3fArray>(node, name, scope, _tokens->RGB, AI_TYPE_RGB, value);
+            return _DeclareAndConvertArray<const GfVec3f&>(
+                node, name, scope, _tokens->RGB, AI_TYPE_RGB, value, isConstant, nodeSetRGBFromVec3);
         } else {
-            return _DeclareAndConvertArray<VtVec3fArray>(node, name, scope, _tokens->VECTOR, AI_TYPE_VECTOR, value);
+            return _DeclareAndConvertArray<const GfVec3f&>(
+                node, name, scope, _tokens->VECTOR, AI_TYPE_VECTOR, value, isConstant, nodeSetVecFromVec3);
         }
     } else if (value.IsHolding<VtVec4fArray>()) {
-        return _DeclareAndConvertArray<VtVec4fArray>(node, name, scope, _tokens->RGBA, AI_TYPE_RGBA, value);
+        return _DeclareAndConvertArray<const GfVec4f&>(
+            node, name, scope, _tokens->RGBA, AI_TYPE_RGBA, value, isConstant, nodeSetRGBAFromVec4);
+    } else if (value.IsHolding<VtStringArray>()) {
+        return _DeclareAndConvertArray<const std::string&>(
+            node, name, scope, _tokens->STRING, AI_TYPE_STRING, value, isConstant, nodeSetStrFromStdStr);
+    } else if (value.IsHolding<VtTokenArray>()) {
+        return _DeclareAndConvertArray<TfToken>(
+            node, name, scope, _tokens->STRING, AI_TYPE_STRING, value, isConstant, nodeSetStrFromToken);
+    } else if (value.IsHolding<VtArray<SdfAssetPath>>()) {
+        return _DeclareAndConvertArray<const SdfAssetPath&>(
+            node, name, scope, _tokens->STRING, AI_TYPE_STRING, value, isConstant, nodeSetStrFromAssetPath);
     }
     return 0;
 }
@@ -183,28 +289,34 @@ inline void _DeclareAndAssignConstant(AtNode* node, const TfToken& name, const V
         if (!declareConstant(_tokens->VECTOR2)) {
             return;
         }
-        const auto& v = value.UncheckedGet<GfVec2f>();
-        AiNodeSetVec2(node, name.GetText(), v[0], v[1]);
+        nodeSetVec2FromVec2(node, AtString{name.GetText()}, value.UncheckedGet<GfVec2f>());
     } else if (value.IsHolding<GfVec3f>()) {
         if (isColor) {
             if (!declareConstant(_tokens->RGB)) {
                 return;
             }
-            const auto& v = value.UncheckedGet<GfVec3f>();
-            AiNodeSetRGB(node, name.GetText(), v[0], v[1], v[2]);
+            nodeSetRGBFromVec3(node, AtString{name.GetText()}, value.UncheckedGet<GfVec3f>());
         } else {
             if (!declareConstant(_tokens->VECTOR)) {
                 return;
             }
-            const auto& v = value.UncheckedGet<GfVec3f>();
-            AiNodeSetVec(node, name.GetText(), v[0], v[1], v[2]);
+            nodeSetVecFromVec3(node, AtString{name.GetText()}, value.UncheckedGet<GfVec3f>());
         }
     } else if (value.IsHolding<GfVec4f>()) {
         if (!declareConstant(_tokens->RGBA)) {
             return;
         }
-        const auto& v = value.UncheckedGet<GfVec4f>();
-        AiNodeSetRGBA(node, name.GetText(), v[0], v[1], v[2], v[3]);
+        nodeSetRGBAFromVec4(node, AtString{name.GetText()}, value.UncheckedGet<GfVec4f>());
+    } else if (value.IsHolding<TfToken>()) {
+        if (!declareConstant(_tokens->STRING)) {
+            return;
+        }
+        nodeSetStrFromToken(node, AtString{name.GetText()}, value.UncheckedGet<TfToken>());
+    } else if (value.IsHolding<std::string>()) {
+        if (!declareConstant(_tokens->STRING)) {
+            return;
+        }
+        nodeSetStrFromStdStr(node, AtString{name.GetText()}, value.UncheckedGet<std::string>());
     } else {
         // Display color is a special case, where an array with a single
         // element should be translated to a single, constant RGB.
@@ -217,7 +329,7 @@ inline void _DeclareAndAssignConstant(AtNode* node, const TfToken& name, const V
                 }
             }
         }
-        _DeclareAndAssignFromArray(node, name, _tokens->constantArray, value, isColor);
+        _DeclareAndAssignFromArray(node, name, _tokens->constantArray, value, isColor, true);
     }
 }
 
@@ -280,6 +392,39 @@ inline void _HdArnoldInsertPrimvar(
         it->second.interpolation = interpolation;
         it->second.dirtied = true;
     }
+}
+
+// We are using function pointers instead of template arguments to deduct the function type, because
+// Arnold's AiNodeSetXXX functions have overrides in the form of, void (*) (AtNode*, const char*, T v) and
+// void (*) (AtNode*, AtString, T v), so the compiler is unable to deduct which function to use.
+// Using function pointers to force deduction is the easiest way, yet lambdas are still inlined.
+// This way, we can still use AiNodeSetXXX functions where possible, and we only need to create a handful
+// of functions to wrap the more complex type conversions.
+template <typename T>
+inline bool _SetFromValueOrArray(
+    AtNode* node, const AtString& paramName, const VtValue& value, void (*f)(AtNode*, const AtString, T))
+{
+    using CT = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+    if (value.IsHolding<CT>()) {
+        f(node, paramName, value.UncheckedGet<CT>());
+    } else if (value.IsHolding<VtArray<CT>>()) {
+        const auto& arr = value.UncheckedGet<VtArray<CT>>();
+        if (!arr.empty()) {
+            f(node, paramName, arr[0]);
+        }
+    } else {
+        return false;
+    }
+    return true;
+}
+
+template <typename T0, typename... T>
+inline bool _SetFromValueOrArray(
+    AtNode* node, const AtString& paramName, const VtValue& value, void (*f0)(AtNode*, const AtString, T0),
+    void (*... fs)(AtNode*, const AtString, T))
+{
+    return _SetFromValueOrArray<T0>(node, paramName, value, std::forward<decltype(f0)>(f0)) ||
+           _SetFromValueOrArray<T...>(node, paramName, value, std::forward<decltype(fs)>(fs)...);
 }
 
 } // namespace
@@ -432,92 +577,49 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
     }
     switch (paramType) {
         case AI_TYPE_BYTE:
-            if (value.IsHolding<int>()) {
-                AiNodeSetByte(node, paramName, static_cast<uint8_t>(value.UncheckedGet<int>()));
-            }
+            _SetFromValueOrArray<int, unsigned char, long>(
+                node, paramName, value, nodeSetByteFromInt, nodeSetByteFromUChar, nodeSetByteFromLong);
             break;
         case AI_TYPE_INT:
-            if (value.IsHolding<int>()) {
-                AiNodeSetInt(node, paramName, value.UncheckedGet<int>());
-            } else if (value.IsHolding<long>()) {
-                AiNodeSetInt(node, paramName, value.UncheckedGet<long>());
-            }
+            _SetFromValueOrArray<int, long>(node, paramName, value, AiNodeSetInt, nodeSetIntFromLong);
             break;
         case AI_TYPE_UINT:
         case AI_TYPE_USHORT:
-            if (value.IsHolding<unsigned int>()) {
-                AiNodeSetUInt(node, paramName, value.UncheckedGet<unsigned int>());
-            }
+            _SetFromValueOrArray<unsigned int>(node, paramName, value, AiNodeSetUInt);
             break;
         case AI_TYPE_BOOLEAN:
-            if (value.IsHolding<bool>()) {
-                AiNodeSetBool(node, paramName, value.UncheckedGet<bool>());
-            } else if (value.IsHolding<int>()) {
-                AiNodeSetBool(node, paramName, value.UncheckedGet<int>() != 0);
-            } else if (value.IsHolding<long>()) {
-                AiNodeSetBool(node, paramName, value.UncheckedGet<long>() != 0);
-            }
+            _SetFromValueOrArray<bool, int, long>(
+                node, paramName, value, AiNodeSetBool, nodeSetBoolFromInt, nodeSetBoolFromLong);
             break;
         case AI_TYPE_FLOAT:
         case AI_TYPE_HALF:
-            if (value.IsHolding<float>()) {
-                AiNodeSetFlt(node, paramName, value.UncheckedGet<float>());
-            } else if (value.IsHolding<double>()) {
-                AiNodeSetFlt(node, paramName, static_cast<float>(value.UncheckedGet<double>()));
-            }
+            _SetFromValueOrArray<float, GfHalf, double>(
+                node, paramName, value, AiNodeSetFlt, nodeSetFltFromHalf, nodeSetFltFromDouble);
             break;
         case AI_TYPE_RGB:
-            if (value.IsHolding<GfVec3f>()) {
-                const auto& v = value.UncheckedGet<GfVec3f>();
-                AiNodeSetRGB(node, paramName, v[0], v[1], v[2]);
-            }
+            _SetFromValueOrArray<const GfVec3f&>(node, paramName, value, nodeSetRGBFromVec3);
             break;
         case AI_TYPE_RGBA:
-            if (value.IsHolding<GfVec4f>()) {
-                const auto& v = value.UncheckedGet<GfVec4f>();
-                AiNodeSetRGBA(node, paramName, v[0], v[1], v[2], v[3]);
-            }
+            _SetFromValueOrArray<const GfVec4f&>(node, paramName, value, nodeSetRGBAFromVec4);
             break;
         case AI_TYPE_VECTOR:
-            if (value.IsHolding<GfVec3f>()) {
-                const auto& v = value.UncheckedGet<GfVec3f>();
-                AiNodeSetVec(node, paramName, v[0], v[1], v[2]);
-            }
+            _SetFromValueOrArray<const GfVec3f&>(node, paramName, value, nodeSetVecFromVec3);
             break;
         case AI_TYPE_VECTOR2:
-            if (value.IsHolding<GfVec2f>()) {
-                const auto& v = value.UncheckedGet<GfVec2f>();
-                AiNodeSetVec2(node, paramName, v[0], v[1]);
-            }
+            _SetFromValueOrArray<const GfVec2f&>(node, paramName, value, nodeSetVec2FromVec2);
             break;
         case AI_TYPE_STRING:
-            if (value.IsHolding<TfToken>()) {
-                AiNodeSetStr(node, paramName, value.UncheckedGet<TfToken>().GetText());
-            } else if (value.IsHolding<SdfAssetPath>()) {
-                const auto& assetPath = value.UncheckedGet<SdfAssetPath>();
-                AiNodeSetStr(
-                    node, paramName,
-                    assetPath.GetResolvedPath().empty() ? assetPath.GetAssetPath().c_str()
-                                                        : assetPath.GetResolvedPath().c_str());
-            } else if (value.IsHolding<std::string>()) {
-                AiNodeSetStr(node, paramName, value.UncheckedGet<std::string>().c_str());
-            }
+            _SetFromValueOrArray<TfToken, const SdfAssetPath&, const std::string&>(
+                node, paramName, value, nodeSetStrFromToken, nodeSetStrFromAssetPath, nodeSetStrFromStdStr);
             break;
         case AI_TYPE_POINTER:
         case AI_TYPE_NODE:
-            break; // TODO: Should be in the relationships list.
+            break; // TODO(pal): Should be in the relationships list.
         case AI_TYPE_MATRIX:
-            break; // TODO
+            break; // TODO(pal): Implement!
         case AI_TYPE_ENUM:
-            if (value.IsHolding<int>()) {
-                AiNodeSetInt(node, paramName, value.UncheckedGet<int>());
-            } else if (value.IsHolding<long>()) {
-                AiNodeSetInt(node, paramName, value.UncheckedGet<long>());
-            } else if (value.IsHolding<TfToken>()) {
-                AiNodeSetStr(node, paramName, value.UncheckedGet<TfToken>().GetText());
-            } else if (value.IsHolding<std::string>()) {
-                AiNodeSetStr(node, paramName, value.UncheckedGet<std::string>().c_str());
-            }
+            _SetFromValueOrArray<int, long, TfToken, const std::string&>(
+                node, paramName, value, AiNodeSetInt, nodeSetIntFromLong, nodeSetStrFromToken, nodeSetStrFromStdStr);
             break;
         case AI_TYPE_CLOSURE:
             break; // Should be in the relationships list.

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -89,7 +89,8 @@ void HdArnoldSetTransform(const std::vector<AtNode*>& nodes, HdSceneDelegate* de
 /// @param value VtValue of the Value to be set.
 HDARNOLD_API
 void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValue& value);
-/// Converts constant scope primvars to built-in parameters.
+/// Converts constant scope primvars to built-in parameters. When the attribute holds an array, the first element will
+/// be used.
 ///
 /// If @param visibility is not a nullptr, the visibility calculation will store the value in the pointed uint8_t
 /// instead of setting it on the node.

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -9,4 +9,10 @@ if (BUILD_UNIT_TESTS)
             MAIN_DEPENDENCY hdArnold
     )
 
+    add_unit_test(
+            GTEST
+            TEST_NAME test_0134
+            MAIN_DEPENDENCY hdArnold
+    )
+
 endif ()

--- a/testsuite/groups
+++ b/testsuite/groups
@@ -45,7 +45,7 @@ ignore: test_0011 test_0040 test_0101 test_0108
 # Notes: - test_0011 needs alembic - test_0040 needs the writer to be compiled - 
 
 # Tests that require the render delegate library, its dependencies and google test
-unit_render_delegate: test_0039
+unit_render_delegate: test_0039 test_0134
 
 # Tests that require the ndr, its dependencies and google test
 unit_ndr_plugin: test_0044

--- a/testsuite/test_0134/README
+++ b/testsuite/test_0134/README
@@ -1,0 +1,5 @@
+Testing the Hydra attribute conversion functions.
+
+see #456
+
+author: Pal Mezei

--- a/testsuite/test_0134/data/test.cpp
+++ b/testsuite/test_0134/data/test.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+
+#include <pxr/base/gf/vec2f.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec4f.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/types.h>
+#include <pxr/usd/sdf/assetPath.h>
+
+#include "render_delegate/utils.h"
+
+#include <cinttypes>
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TEST(ConvertPrimvarToBuiltinParameter, PrimvarConversion)
+{
+    auto* node = AiNode("polymesh");
+    uint8_t visibility = AI_RAY_ALL;
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_iterations"}, VtValue{int{4}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_iterations"), 4);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_iterations"}, VtValue{long{6}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_iterations"), 6);
+    EXPECT_FALSE(ConvertPrimvarToBuiltinParameter(node, TfToken{"subdiv_iterations"}, VtValue{long{12}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_iterations"), 6);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_iterations"}, VtValue{double{16}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_iterations"), 6);
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_type"), 0);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_type"}, VtValue{TfToken{"catclark"}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_type"), 1);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_type"}, VtValue{std::string{"linear"}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_type"), 2);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_type"}, VtValue{long{0}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_type"), 0);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:subdiv_type"}, VtValue{VtArray<std::string>{std::string{"linear"}}}));
+    EXPECT_EQ(AiNodeGetInt(node, "subdiv_type"), 2);
+}
+
+TEST(ConvertPrimvarToBuiltinParameter, Visibility)
+{
+    auto* node = AiNode("polymesh");
+    uint8_t visibility = AI_RAY_ALL;
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:visibility:volume"}, VtValue{false}, &visibility));
+    EXPECT_EQ(visibility, AI_RAY_ALL & ~AI_RAY_VOLUME);
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:visibility:volume"}, VtValue{false}));
+    EXPECT_EQ(visibility, AiNodeGetByte(node, "visibility"));
+}
+
+TEST(ConvertPrimvarToBuiltinParameter, Sidedness)
+{
+    auto* node = AiNode("polymesh");
+    EXPECT_TRUE(ConvertPrimvarToBuiltinParameter(node, TfToken{"arnold:sidedness:volume"}, VtValue{false}));
+    EXPECT_EQ(AI_RAY_ALL & ~AI_RAY_VOLUME, AiNodeGetByte(node, "sidedness"));
+}
+
+TEST(HdArnoldSetParameter, Base)
+{
+    auto* node = AiNode("standard_surface");
+    auto* entry = AiNodeGetNodeEntry(node);
+    auto getParam = [&] (const char* paramName) -> const AtParamEntry* {
+        return AiNodeEntryLookUpParameter(entry, paramName);
+    };
+    HdArnoldSetParameter(node, getParam("base_color"), VtValue{GfVec3f{0.0f, 2.0f, 0.0}});
+    EXPECT_EQ(AiNodeGetRGB(node, "base_color"), AtRGB(0.0f, 2.0f, 0.0f));
+    HdArnoldSetParameter(node, getParam("base_color"), VtValue{GfVec2f{0.0f, 4.0f}});
+    EXPECT_EQ(AiNodeGetRGB(node, "base_color"), AtRGB(0.0f, 2.0f, 0.0f));
+    HdArnoldSetParameter(node, getParam("base"), VtValue{double{2.0}});
+    EXPECT_EQ(AiNodeGetFlt(node, "base"), 2.0f);
+}
+
+TEST(HdArnoldSetParameter, Array)
+{
+    auto* node = AiNode("standard_surface");
+    auto* entry = AiNodeGetNodeEntry(node);
+    auto getParam = [&] (const char* paramName) -> const AtParamEntry* {
+        return AiNodeEntryLookUpParameter(entry, paramName);
+    };
+    HdArnoldSetParameter(node, getParam("base"), VtValue{VtArray<double>{2.0}});
+    EXPECT_EQ(AiNodeGetFlt(node, "base"), 2.0f);
+    HdArnoldSetParameter(node, getParam("base"), VtValue{VtArray<double>{4.0, 2.0}});
+    EXPECT_EQ(AiNodeGetFlt(node, "base"), 4.0f);
+    HdArnoldSetParameter(node, getParam("base"), VtValue{VtArray<double>{}});
+    EXPECT_EQ(AiNodeGetFlt(node, "base"), 4.0f);
+    HdArnoldSetParameter(node, getParam("subsurface_type"), VtValue{VtArray<double>{1.0}});
+    EXPECT_EQ(AiNodeGetStr(node, "subsurface_type"), AtString("randomwalk"));
+    HdArnoldSetParameter(node, getParam("subsurface_type"), VtValue{VtArray<TfToken>{TfToken{"diffusion"}}});
+    EXPECT_EQ(AiNodeGetStr(node, "subsurface_type"), AtString("diffusion"));
+    HdArnoldSetParameter(node, getParam("subsurface_type"), VtValue{VtArray<std::string>{"randomwalk_v2"}});
+    EXPECT_EQ(AiNodeGetStr(node, "subsurface_type"), AtString("randomwalk_v2"));
+}
+
+TEST(HdArnoldSetParameter, AssetPath)
+{
+    auto* node = AiNode("image");
+    auto* entry = AiNodeGetNodeEntry(node);
+    auto* filename = AiNodeEntryLookUpParameter(entry, "filename");
+    HdArnoldSetParameter(node, filename, VtValue{SdfAssetPath("first", "second")});
+    EXPECT_EQ(AiNodeGetStr(node, "filename"), AtString("second"));
+    HdArnoldSetParameter(node, filename, VtValue{SdfAssetPath("first", "")});
+    EXPECT_EQ(AiNodeGetStr(node, "filename"), AtString("first"));
+    HdArnoldSetParameter(node, filename, VtValue{VtArray<SdfAssetPath>{SdfAssetPath("first", "second")}});
+    EXPECT_EQ(AiNodeGetStr(node, "filename"), AtString("second"));
+}
+
+TEST(HdArnoldSetConstantPrimvar, Base)
+{
+    auto* node = AiNode("polymesh");
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue{int{4}});
+    EXPECT_EQ(AiNodeGetInt(node, "primvar1"), 4);
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue{std::string{"hello"}});
+    EXPECT_EQ(AiNodeGetStr(node, "primvar2"), AtString{"hello"});
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue{TfToken{"world"}});
+    EXPECT_EQ(AiNodeGetStr(node, "primvar3"), AtString{"world"});
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar4"}, HdPrimvarRoleTokens->color, VtValue{GfVec3f{1.0f, 2.0f, 3.0f}});
+    EXPECT_NE(AiNodeGetVec(node, "primvar4"), AtVector(1.0f, 2.0f, 3.0f));
+    EXPECT_EQ(AiNodeGetRGB(node, "primvar4"), AtRGB(1.0f, 2.0f, 3.0f));
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar5"}, HdPrimvarRoleTokens->none, VtValue{GfVec3f{1.0f, 2.0f, 3.0f}});
+    EXPECT_EQ(AiNodeGetVec(node, "primvar5"), AtVector(1.0f, 2.0f, 3.0f));
+    EXPECT_NE(AiNodeGetRGB(node, "primvar5"), AtRGB(1.0f, 2.0f, 3.0f));
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar6"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec3f>{GfVec3f{1.0f, 2.0f, 3.0f}}});
+    EXPECT_EQ(AiNodeGetVec(node, "primvar6"), AtVector(1.0f, 2.0f, 3.0f));
+}
+
+TEST(HdArnoldSetConstantPrimvar, Builtin)
+{
+    auto* node = AiNode("polymesh");
+    HdArnoldSetConstantPrimvar(node, TfToken{"arnold:subdiv_iterations"}, HdPrimvarRoleTokens->none, VtValue{int{4}});
+    EXPECT_EQ(AiNodeGetByte(node, "subdiv_iterations"), 4);
+    HdArnoldSetConstantPrimvar(node, TfToken{"arnold:subdiv_iterations"}, HdPrimvarRoleTokens->none, VtValue{VtArray<int>{8}});
+    EXPECT_EQ(AiNodeGetByte(node, "subdiv_iterations"), 8);
+    HdArnoldSetConstantPrimvar(node, TfToken{"arnold:subdiv_iterations"}, HdPrimvarRoleTokens->none, VtValue{VtArray<long>{12, 16}});
+    EXPECT_EQ(AiNodeGetByte(node, "subdiv_iterations"), 12);
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    AiBegin();
+    AiMsgSetConsoleFlags(AI_LOG_NONE);
+    auto result = RUN_ALL_TESTS();
+    AiEnd();
+    return result;
+}


### PR DESCRIPTION
**Changes proposed in this pull request**
- std::string and TfToken is supported when reading in constant primvars
- When using HdArnoldSetParameter, we are also checking for Arrays with at least one compatible element.
- When setting constant primvars, we treat single element arrays as single values
- Adding test_0134 to test the new behavior of `HdArnoldSetParameter`, `HdArnoldSetConstantPrimvar` and `ConvertPrimvarToBuiltinParameter`.

**Issues fixed in this pull request**
Fixes #456
