### PR TITLE
Allow users to overwrite the default filter and use it for any rendervar without a filter

### DIFF
--- a/render_delegate/render_pass.h
+++ b/render_delegate/render_pass.h
@@ -98,7 +98,7 @@ private:
 
     HdArnoldRenderDelegate* _delegate; ///< Pointer to the Render Delegate.
     AtNode* _camera = nullptr;         ///< Pointer to the Arnold Camera.
-    AtNode* _beautyFilter = nullptr;   ///< Pointer to the beauty Arnold Filter.
+    AtNode* _defaultFilter = nullptr;  ///< Pointer to the default Arnold Filter.
     AtNode* _closestFilter = nullptr;  ///< Pointer to the closest Arnold Filter.
     AtNode* _mainDriver = nullptr;     ///< Pointer to the Arnold Driver writing color, position and depth.
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Allow users to overwrite the default filter and use it for any rendervar without a filter.

**Issues fixed in this pull request**
Fixes #475