### PR TITLE
Implementing alternative HdRenderDelegate::CreateRenderDelegate function override

### DIFF
--- a/render_delegate/renderer_plugin.cpp
+++ b/render_delegate/renderer_plugin.cpp
@@ -47,6 +47,15 @@ TF_REGISTRY_FUNCTION(TfType) { HdxRendererPluginRegistry::Define<HdArnoldRendere
 
 HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate() { return new HdArnoldRenderDelegate(); }
 
+HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate(const HdRenderSettingsMap& settingsMap)
+{
+    auto* delegate = new HdArnoldRenderDelegate();
+    for (const auto& setting : settingsMap) {
+        delegate->SetRenderSetting(setting.first, setting.second);
+    }
+    return delegate;
+}
+
 void HdArnoldRendererPlugin::DeleteRenderDelegate(HdRenderDelegate* renderDelegate) { delete renderDelegate; }
 
 bool HdArnoldRendererPlugin::IsSupported() const { return true; }

--- a/render_delegate/renderer_plugin.h
+++ b/render_delegate/renderer_plugin.h
@@ -66,6 +66,16 @@ public:
     /// @return Pointer to the newly created Arnold Render Delegate.
     HDARNOLD_API
     HdRenderDelegate* CreateRenderDelegate() override;
+
+    /// Factory a Render Delegate object, that Hydra can use to
+    /// factory prims and communicate with a renderer.  Pass in initial
+    /// settings.
+    ///
+    /// @param settingsMap Initial render settings for the Render Delegate.
+    /// @return Pointer to the newly created Arnold Render Delegate.
+    HD_API
+    HdRenderDelegate* CreateRenderDelegate(const HdRenderSettingsMap& settingsMap) override;
+
     /// Deletes an Arnold Render Delegate.
     ///
     /// @param renderDelegate Pointer to the Arnold Render Delegate to delete.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Implementing alternative HdRenderDelegate::CreateRenderDelegate(const HdRenderSettingsMap& settingsMap)

**Issues fixed in this pull request**
Fixes #488