### PR TITLE
Using modff instead of modf in basis_curves

### DIFF
--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -77,7 +77,7 @@ struct RemapVertexPrimvar<T, true> {
     static inline void fn(T& remapped, const T* original, float originalVertex)
     {
         float originalVertexFloor = 0;
-        const auto originalVertexFrac = modf(originalVertex, &originalVertexFloor);
+        const auto originalVertexFrac = modff(originalVertex, &originalVertexFloor);
         const auto originalVertexFloorInt = static_cast<int>(originalVertexFloor);
         remapped = AiLerp(originalVertexFrac, original[originalVertexFloorInt], original[originalVertexFloorInt + 1]);
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Using modff instead of modf to avoid bad type deduction with GCC 4.8.5. 

**Issues fixed in this pull request**
Fixes #501