### PR TITLE
Viewport representation in points mode now reads the matrix

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -499,6 +499,7 @@ void UsdArnoldReadGenericPoints::Read(const UsdPrim &prim, UsdArnoldReaderContex
 
     UsdGeomPointBased points(prim);
     ReadArray<GfVec3f, GfVec3f>(points.GetPointsAttr(), node, "points", time);
+    ReadMatrix(prim, node, time, context);
 
     // Check the primitive visibility, set the AtNode visibility to 0 if it's meant to be hidden
     if (!context.GetPrimVisibility(prim, frame))


### PR DESCRIPTION
**Changes proposed in this pull request**
We were just missing a call to `ReadMatrix` in `UsdArnoldReadGenericPoints::Read` , that is used for the viewport API in points mode

**Issues fixed in this pull request**
Fixes #513