### PR TITLE
render_delegate: Accept both strings and tokens for `varname` on `Pri…

### DIFF
--- a/render_delegate/material.cpp
+++ b/render_delegate/material.cpp
@@ -205,15 +205,11 @@ RemapNodeFunc float2PrimvarRemap = [](MaterialEditContext* ctx) {
     if (varnameValue.IsHolding<TfToken>()) {
         varname = varnameValue.UncheckedGet<TfToken>();
 	} else if (varnameValue.IsHolding<std::string>()) {
-        varname = pxr::TfToken(varnameValue.UncheckedGet<std::string>());
+        varname = TfToken(varnameValue.UncheckedGet<std::string>());
     }
 
-	if (varname.IsEmpty()) {
-        return;
-	}
-
     // uv and st is remapped to UV coordinates
-    if (varname == str::t_uv || varname == str::t_st) {
+    if (!varname.IsEmpty() && (varname == str::t_uv || varname == str::t_st)) {
         // We are reading the uv from the mesh.
         ctx->SetNodeId(str::t_utility);
         ctx->SetParam(str::t_color_mode, VtValue(str::t_uv));
@@ -340,12 +336,17 @@ void _RemapNetwork(HdMaterialNetwork& network, bool isDisplacement)
         for (const auto& material : network.nodes) {
             if (material.path == id && material.identifier == str::t_UsdPrimvarReader_float2) {
                 const auto paramIt = material.parameters.find(str::t_varname);
-                if (paramIt == material.parameters.end() ||
-					(!paramIt->second.IsHolding<TfToken>() && !paramIt->second.IsHolding<std::string>())) {
-                    return true;
+                TfToken token;
+
+                if (paramIt != material.parameters.end()) {
+                    if (paramIt->second.IsHolding<TfToken>()) {
+                        token = paramIt->second.UncheckedGet<TfToken>();
+                    } else if (paramIt->second.IsHolding<std::string>()) {
+                        token = TfToken(paramIt->second.UncheckedGet<std::string>());
+                    }
                 }
-                const auto& token = paramIt->second.UncheckedGet<TfToken>();
-                return token == str::t_uv || token == str::t_st;
+
+                return !token.IsEmpty() && (token == str::t_uv || token == str::t_st);
             }
         }
         return false;

--- a/render_delegate/material.cpp
+++ b/render_delegate/material.cpp
@@ -204,7 +204,7 @@ RemapNodeFunc float2PrimvarRemap = [](MaterialEditContext* ctx) {
     TfToken varname;
     if (varnameValue.IsHolding<TfToken>()) {
         varname = varnameValue.UncheckedGet<TfToken>();
-	} else if (varnameValue.IsHolding<std::string>()) {
+    } else if (varnameValue.IsHolding<std::string>()) {
         varname = TfToken(varnameValue.UncheckedGet<std::string>());
     }
 


### PR DESCRIPTION
…mvarReader_float2`

This matches UsdPreviewSurface specification (string) and hdStorm behavior (both string and token).
https://graphics.pixar.com/usd/docs/UsdPreviewSurface-Proposal.html#UsdPreviewSurfaceProposal-PrimvarReader

**Issues fixed in this pull request**
Fixes #518
