### PR TITLE
Adding per-face material assignment support to the Render Delegate.

### DIFF
--- a/render_delegate/constant_strings.h
+++ b/render_delegate/constant_strings.h
@@ -255,6 +255,7 @@ ASTR(roughness);
 ASTR(scale);
 ASTR(shade_mode);
 ASTR(shader);
+ASTR(shidxs);
 ASTR(shutter_end);
 ASTR(shutter_start);
 ASTR(sidedness);

--- a/render_delegate/instancer.cpp
+++ b/render_delegate/instancer.cpp
@@ -67,7 +67,6 @@ void HdArnoldInstancer::_SyncPrimvars()
     std::lock_guard<std::mutex> lock(_mutex);
     dirtyBits = changeTracker.GetInstancerDirtyBits(id);
 
-
     if (HdChangeTracker::IsAnyPrimvarDirty(dirtyBits, id)) {
         HdArnoldGetPrimvars(GetDelegate(), id, dirtyBits, false, _primvars);
     }
@@ -170,11 +169,8 @@ void HdArnoldInstancer::SetPrimvars(AtNode* node, const SdfPath& prototypeId, si
     VtIntArray instanceIndices;
     for (const auto& primvar : _primvars) {
         const auto& desc = primvar.second;
-        if (desc.interpolation != HdInterpolationInstance ||
-            !desc.dirtied ||
-            primvar.first == _tokens->rotate ||
-            primvar.first == _tokens->translate ||
-            primvar.first == _tokens->scale ||
+        if (desc.interpolation != HdInterpolationInstance || !desc.dirtied || primvar.first == _tokens->rotate ||
+            primvar.first == _tokens->translate || primvar.first == _tokens->scale ||
             primvar.first == _tokens->instanceTransform) {
             continue;
         }

--- a/render_delegate/material.cpp
+++ b/render_delegate/material.cpp
@@ -27,8 +27,8 @@
 // limitations under the License.
 #include "material.h"
 
-#include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/rotation.h>
+#include <pxr/base/gf/vec2f.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
 #include "constant_strings.h"
@@ -276,7 +276,7 @@ const std::unordered_map<TfToken, RemapNodeFunc, TfToken::HashFunctor> nodeRemap
     {str::t_UsdPrimvarReader_float3, float3PrimvarRemap}, {str::t_UsdPrimvarReader_point, float3PrimvarRemap},
     {str::t_UsdPrimvarReader_normal, float3PrimvarRemap}, {str::t_UsdPrimvarReader_vector, float3PrimvarRemap},
     {str::t_UsdPrimvarReader_float4, float4PrimvarRemap}, {str::t_UsdPrimvarReader_int, intPrimvarRemap},
-    {str::t_UsdPrimvarReader_string, stringPrimvarRemap}, {str::t_UsdTransform2d, transform2dRemap },
+    {str::t_UsdPrimvarReader_string, stringPrimvarRemap}, {str::t_UsdTransform2d, transform2dRemap},
 };
 
 // A single preview surface connected to surface and displacement slots is a common use case, and it needs special

--- a/render_delegate/mesh.h
+++ b/render_delegate/mesh.h
@@ -102,6 +102,7 @@ protected:
 
     HdArnoldShape _shape;             ///< Utility class for the mesh and instances.
     HdArnoldPrimvarMap _primvars;     ///< Precomputed list of primvars.
+    HdArnoldSubsets _subsets;         ///< Material ids from subsets.
     VtIntArray _vertexCounts;         ///< Vertex Counts array for reversing vertex and primvar polygon order.
     size_t _numberOfPositionKeys = 1; ///< Number of vertex position keys for the mesh.
 };

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -505,11 +505,10 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                     } else {
                         aovName = sourceName.c_str();
                     }
-                    *outputs =
-                        AtString(TfStringPrintf(
-                                     "%s %s %s %s", aovName, arnoldTypes.outputString,
-                                     filterName != nullptr ? filterName : boxName, AiNodeGetName(buffer.driver))
-                                     .c_str());
+                    *outputs = AtString(TfStringPrintf(
+                                            "%s %s %s %s", aovName, arnoldTypes.outputString,
+                                            filterName != nullptr ? filterName : boxName, AiNodeGetName(buffer.driver))
+                                            .c_str());
                 }
                 outputs += 1;
             }

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -38,6 +38,9 @@
 
 #include <pxr/base/vt/value.h>
 
+#include <pxr/usd/sdf/path.h>
+
+#include <pxr/imaging/hd/meshTopology.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/timeSampleArray.h>
 
@@ -49,6 +52,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 constexpr int HD_ARNOLD_MAX_PRIMVAR_SAMPLES = 2;
 using HdArnoldSampledPrimvarType = HdTimeSampleArray<VtValue, HD_ARNOLD_MAX_PRIMVAR_SAMPLES>;
+
+using HdArnoldSubsets = std::vector<SdfPath>;
 
 /// Converts a double precision GfMatrix to AtMatrix.
 ///
@@ -298,5 +303,15 @@ bool HdArnoldGetComputedPrimvars(
 void HdArnoldGetPrimvars(
     HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, bool multiplePositionKeys,
     HdArnoldPrimvarMap& primvars);
+
+/// Get the shidxs from a topology and save the material paths to @param arnoldSubsets.
+///
+/// @param subsets Const reference to HdGeomSubsets of the shape.
+/// @param numFaces Number of faces on the object.
+/// @param arnoldSubsets Output parameter containing the path to all the materials for each geometry subset. The
+/// ordering
+///  of the materials matches the ordering of the shader indices in the returned array.
+/// @return Arnold array of uint8_t, with the shader indices for each face.
+AtArray* HdArnoldGetShidxs(const HdGeomSubsets& subsets, int numFaces, HdArnoldSubsets& arnoldSubsets);
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/testsuite/test_0036/data/scene.usda
+++ b/testsuite/test_0036/data/scene.usda
@@ -28,7 +28,6 @@ def "pCube1"
         int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
         uniform token orientation = "rightHanded"
         point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
-        string[] primvars:arnold:disp_map = ["/displacementShader1", "/displacementShader2", "/displacementShader3"]
         float primvars:arnold:disp_padding = 0
         uint primvars:arnold:id = 528272281
         bool primvars:arnold:smoothing = 1


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding per-face material assignment support to the Render Delegate.
- Ran clang-format on render_delegate.
- Removed the disp_map primvar from test_0036, test 36 is testing material assignments via GeomSubsets, so it shouldn't be there.

**Issues fixed in this pull request**
Fixes #29