### PR TITLE
Support scope in the USD writer

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -307,6 +307,11 @@ scene_write
     if (AiParamValueMapGetInt(params, maskStr, &mask))
         writer->SetMask(mask); // only write out this type or arnold nodes
 
+    static const AtString scopeStr("scope");
+    AtString scope;
+    if (AiParamValueMapGetStr(params, scopeStr, &scope))
+        writer->SetScope(std::string(scope.c_str()));
+    
     writer->Write(universe);       // convert this universe please
     stage->GetRootLayer()->Save(); // Ask USD to save out the file
 

--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -499,6 +499,7 @@ void UsdArnoldReadGenericPoints::Read(const UsdPrim &prim, UsdArnoldReaderContex
 
     UsdGeomPointBased points(prim);
     ReadArray<GfVec3f, GfVec3f>(points.GetPointsAttr(), node, "points", time);
+    ReadMatrix(prim, node, time, context);
 
     // Check the primitive visibility, set the AtNode visibility to 0 if it's meant to be hidden
     if (!context.GetPrimVisibility(prim, frame))

--- a/translator/writer/prim_writer.h
+++ b/translator/writer/prim_writer.h
@@ -58,7 +58,7 @@ public:
     static const ParamConversion *GetParamConversion(uint8_t type);
     // This function returns the name we want to give to this AtNode when it's
     // converted to USD
-    static std::string GetArnoldNodeName(const AtNode *node);
+    static std::string GetArnoldNodeName(const AtNode *node, const UsdArnoldWriter &writer);
     bool WriteAttribute(
         const AtNode *node, const char *paramName, UsdPrim &prim, const UsdAttribute &attr, UsdArnoldWriter &writer);
 

--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -42,7 +42,8 @@ PXR_NAMESPACE_USING_DIRECTIVE
  **/
 void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what should be the name of this USD primitive
+     // get the output name of this USD primitive 
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
 
@@ -87,7 +88,8 @@ void UsdArnoldWriteGinstance::_ProcessInstanceAttribute(
 
 void UsdArnoldWriteGinstance::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what should be the name of this USD primitive
+    // get the output name of this USD primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
 

--- a/translator/writer/write_camera.cpp
+++ b/translator/writer/write_camera.cpp
@@ -32,7 +32,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdGeomCamera cam = UsdGeomCamera::Define(stage, SdfPath(nodeName));

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -31,7 +31,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 void UsdArnoldWriteMesh::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdGeomMesh mesh = UsdGeomMesh::Define(stage, SdfPath(nodeName));
@@ -164,7 +164,7 @@ void UsdArnoldWriteMesh::Write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteCurves::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdGeomBasisCurves curves = UsdGeomBasisCurves::Define(stage, SdfPath(nodeName));
@@ -227,7 +227,7 @@ void UsdArnoldWriteCurves::Write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWritePoints::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdGeomPoints points = UsdGeomPoints::Define(stage, SdfPath(nodeName));
@@ -256,7 +256,7 @@ void UsdArnoldWritePoints::Write(const AtNode *node, UsdArnoldWriter &writer)
 }
 void UsdArnoldWriteProceduralCustom::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what should be the name of this USD primitive
+    std::string nodeName = GetArnoldNodeName(node, writer); // what should be the name of this USD primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
     _exportedAttrs.insert("name");

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -48,7 +48,7 @@ void writeLightCommon(const AtNode *node, UsdLuxLight &light, UsdArnoldPrimWrite
 
 void UsdArnoldWriteDistantLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxDistantLight light = UsdLuxDistantLight::Define(stage, SdfPath(nodeName));
@@ -62,7 +62,7 @@ void UsdArnoldWriteDistantLight::Write(const AtNode *node, UsdArnoldWriter &writ
 
 void UsdArnoldWriteDomeLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, SdfPath(nodeName));
@@ -101,7 +101,7 @@ void UsdArnoldWriteDomeLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteDiskLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, SdfPath(nodeName));
@@ -116,7 +116,7 @@ void UsdArnoldWriteDiskLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteSphereLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, SdfPath(nodeName));
@@ -140,7 +140,7 @@ void UsdArnoldWriteSphereLight::Write(const AtNode *node, UsdArnoldWriter &write
 
 void UsdArnoldWriteRectLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxRectLight light = UsdLuxRectLight::Define(stage, SdfPath(nodeName));
@@ -198,7 +198,7 @@ void UsdArnoldWriteRectLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 
 void UsdArnoldWriteGeometryLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    std::string nodeName = GetArnoldNodeName(node); // what is the USD name for this primitive
+    std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
 
     UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, SdfPath(nodeName));
@@ -211,7 +211,7 @@ void UsdArnoldWriteGeometryLight::Write(const AtNode *node, UsdArnoldWriter &wri
     AtNode *mesh = (AtNode *)AiNodeGetPtr(node, "mesh");
     if (mesh) {
         writer.WritePrimitive(mesh);
-        std::string meshName = GetArnoldNodeName(mesh);
+        std::string meshName = GetArnoldNodeName(mesh, writer);
         light.CreateGeometryRel().AddTarget(SdfPath(meshName));
     }
     _WriteArnoldParameters(node, writer, prim, "primvars:arnold");

--- a/translator/writer/write_shader.cpp
+++ b/translator/writer/write_shader.cpp
@@ -62,7 +62,7 @@ inline void SplitString(const std::string &input, std::vector<std::string> &resu
 
 void UsdArnoldWriteShader::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
-    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), SdfPath(GetArnoldNodeName(node)));
+    UsdShadeShader shaderAPI = UsdShadeShader::Define(writer.GetUsdStage(), SdfPath(GetArnoldNodeName(node, writer)));
     // set the info:id parameter to the actual shader name
     shaderAPI.CreateIdAttr().Set(TfToken(_usdShaderId));
     UsdPrim prim = shaderAPI.GetPrim();

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -65,6 +65,21 @@ public:
 
     bool IsNodeExported(const AtString &name) { return _exportedNodes.count(name) == 1; }
 
+    const std::string &GetScope() const {return _scope;}
+    void SetScope(const std::string &scope) {
+        _scope = scope;
+        if (!_scope.empty()) { 
+            // First character needs to be a slash
+            if (_scope[0] != '/')
+                _scope = std::string("/") + _scope;
+            // Last character should *not* be slash, otherwise we could have 
+            // double slashes in the nodes names, which can crash usd
+            if (_scope.back() == '/')
+                _scope = _scope.substr(0, _scope.length() - 1);            
+        }
+        
+    }
+
 private:
     const AtUniverse *_universe;        // Arnold universe to be converted
     UsdArnoldWriterRegistry *_registry; // custom registry used for this writer. If null, a global
@@ -76,4 +91,5 @@ private:
     float _shutterStart;
     float _shutterEnd;
     std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported
+    std::string _scope;                // scope in which the primitives must be written
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR, it's possible to give the Usd writer a "scope" string. This scope will be added as a prefix to all the usd primitive names to create.

I have tested the feature relying on MtoA's call to `AiSceneWrite` with this new param map value, but I still need to find a way to test this in the testsuite.

**Issues fixed in this pull request**
Fixes #292
