### PR TITLE
More fixes, and test for the export scope

### DIFF
--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -254,13 +254,16 @@ scene_load
     reader->SetUniverse(universe);
     // default to options.frame
     float frame = AiNodeGetFlt(AiUniverseGetOptions(), "frame");
-    // eventually check the input param map in case we have an entry for "frame"
-    AiParamValueMapGetFlt(params, AtString("frame"), &frame);
-    reader->SetFrame(frame);
 
-    int mask = AI_NODE_ALL;
-    if (AiParamValueMapGetInt(params, AtString("mask"), &mask))
-        reader->SetMask(mask);
+    if (params) {
+        // eventually check the input param map in case we have an entry for "frame"
+        AiParamValueMapGetFlt(params, AtString("frame"), &frame);
+        
+        int mask = AI_NODE_ALL;
+        if (AiParamValueMapGetInt(params, AtString("mask"), &mask))
+            reader->SetMask(mask);
+    }
+    reader->SetFrame(frame);
 
     // Read the USD file
     reader->Read(filename, nullptr);
@@ -302,16 +305,17 @@ scene_write
     writer->SetUsdStage(stage); // give it the output stage
 
     // Check if a mask has been set through the params map
-    int mask = AI_NODE_ALL;
-    static const AtString maskStr("mask");
-    if (AiParamValueMapGetInt(params, maskStr, &mask))
-        writer->SetMask(mask); // only write out this type or arnold nodes
+    if (params) {
+        int mask = AI_NODE_ALL;
+        static const AtString maskStr("mask");
+        if (AiParamValueMapGetInt(params, maskStr, &mask))
+            writer->SetMask(mask); // only write out this type or arnold nodes
 
-    static const AtString scopeStr("scope");
-    AtString scope;
-    if (AiParamValueMapGetStr(params, scopeStr, &scope))
-        writer->SetScope(std::string(scope.c_str()));
-    
+        static const AtString scopeStr("scope");
+        AtString scope;
+        if (AiParamValueMapGetStr(params, scopeStr, &scope))
+            writer->SetScope(std::string(scope.c_str()));
+    }
     writer->Write(universe);       // convert this universe please
     stage->GetRootLayer()->Save(); // Ask USD to save out the file
 

--- a/testsuite/test_0138/README
+++ b/testsuite/test_0138/README
@@ -1,0 +1,5 @@
+Write USD primitives in a given scope
+
+see #292
+
+author: sebastien ortega

--- a/testsuite/test_0138/data/scene.ass
+++ b/testsuite/test_0138/data/scene.ass
@@ -1,0 +1,123 @@
+options
+{
+ AA_samples 3
+ outputs "RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"
+ xres 160
+ yres 120
+ pixel_aspect_ratio 1.33333325
+ texture_per_file_stats on
+ texture_automip off
+ camera "/persp/perspShape"
+ frame 1
+ GI_diffuse_depth 1
+ GI_specular_depth 1
+ GI_transmission_depth 8
+ declare render_layer constant STRING
+ render_layer "defaultRenderLayer"
+}
+
+gaussian_filter
+{
+ name defaultArnoldFilter@gaussian_filter
+}
+
+driver_tiff
+{
+ name defaultArnoldDriver@driver_tiff.RGBA
+ filename "testrender.tif"
+ color_space ""
+}
+
+persp_camera
+{
+ name /persp/perspShape
+ matrix
+ 0.707106769 0 -0.707106769 0
+ -0.331294566 0.883452237 -0.331294566 0
+ 0.624695063 0.468521297 0.624695063 0
+ 2.86004019 2.14503026 2.86004019 1
+ near_clip 0.100000001
+ far_clip 10000
+ shutter_start 0
+ shutter_end 0
+ shutter_type "box"
+ rolling_shutter "off"
+ rolling_shutter_duration 0
+ motion_start 0
+ motion_end 0
+ exposure 0
+ fov 54.4322243
+ uv_remap 0 0 0 1
+ declare dcc_name constant STRING
+ dcc_name "perspShape"
+}
+
+distant_light
+{
+ name /directionalLight1/directionalLightShape1
+ exposure 0
+ cast_shadows on
+ cast_volumetric_shadows on
+ shadow_density 1
+ samples 1
+ normalize on
+ diffuse 1
+ specular 1
+ sss 1
+ indirect 1
+ max_bounces 999
+ volume_samples 2
+ volume 1
+ aov "default"
+ angle 0
+ declare dcc_name constant STRING
+ dcc_name "directionalLightShape1"
+}
+
+lambert
+{
+ name lambert1
+ Kd 0.800000012
+ Kd_color 0.5 0.5 0.5
+ opacity 1 1 1
+ declare material_surface constant STRING
+ material_surface "initialShadingGroup"
+}
+
+sphere 
+{
+	name /my/sphere/name
+}
+
+polymesh
+{
+ name my/cube/name
+ visibility 255
+ sidedness 255
+ matrix
+ 1 0 0 0
+ 0 1 0 0
+ 0 0 1 0
+ 0 0 0 1
+ shader "lambert1"
+ id 528272281
+ nsides 6 1 UINT
+4 4 4 4 4 4
+ vidxs 24 1 b85UINT
+B$ZuK*%<ho2%s\>:$$-?2$vMr4%<MT0
+ nidxs 24 1 b85UINT
+B$v2N*&9nA:'RU4J(k<'Z*.woj+G^c%
+ uvidxs 24 1 b85UINT
+B$ZuK*%<ho2%s\>:&UObB$w/J=(3BP?
+ vlist 8 1 b85VECTOR
+aDq99aDq9989+]c89+]caDq9989+]caDq99!89+]c$$$$)aDq9989+]caDq9989+]c89+]c!aDq99$$$$(89+]caDq99aDq99
+ nlist 24 1 b85VECTOR
+zzyzzyzzyzzyzyzzyzzyzzy!$$$$$$$$$'aRT=dzzaRT=dzzaRT=dzzaRT=dzaRT=dzzaRT=dzzaRT=dzzaRT=dzyzzyzzyzzyzzaRT=dzzaRT=dzzaRT=dzzaRT=dzz
+ uvlist 14 1 b85VECTOR2
+82:0xz8<Nt.z82:0x8+HY88<Nt.8+HY882:0x89+]c8<Nt.89+]c82:0x8?r5N8<Nt.8?r5N82:0xy8<Nt.y8C@Knz8C@Kn8+HY87reTbz7reTb8+HY8
+ smoothing on
+ step_size 0
+ volume_padding 0
+ declare dcc_name constant STRING
+ dcc_name "pCubeShape1"
+}

--- a/testsuite/test_0138/data/test.cpp
+++ b/testsuite/test_0138/data/test.cpp
@@ -1,0 +1,49 @@
+#include <ai.h>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+    AiMsgSetConsoleFlags(AI_LOG_ALL);
+    AiBegin();
+    AiASSLoad("scene.ass");
+    AtParamValueMap* params = AiParamValueMap();
+    AiParamValueMapSetStr(params, AtString("scope"), AtString("beautiful/scope"));
+    AiSceneWrite(nullptr, "scene.usda", params);
+    AiParamValueMapDestroy(params);
+    AiEnd();
+
+    AiBegin();
+    bool success = true;
+    AiSceneLoad(nullptr, "scene.usda", nullptr);
+    
+    if (!AiNodeLookUpByName("/beautiful/scope/my/sphere/name")) {
+        AiMsgError("/beautiful/scope/my/sphere/name doesn't exist");
+        success = false;
+    }
+    if (!AiNodeLookUpByName("/beautiful/scope/my/cube/name")) {
+        AiMsgError("/beautiful/scope/my/cone/name doesn't exist");
+        success = false;
+    }
+    if (!AiNodeLookUpByName("/beautiful/scope/lambert1")) {
+        AiMsgError("/beautiful/scope/lambert1 doesn't exist");
+        success = false;
+    }
+    if (!AiNodeLookUpByName("/beautiful/scope/persp/perspShape")) {
+        AiMsgError("/beautiful/scope/persp/perspShape doesn't exist");
+        success = false;
+    }
+    if (!AiNodeLookUpByName("/beautiful/scope/defaultArnoldFilter_gaussian_filter")) {
+        AiMsgError("/beautiful/scope/defaultArnoldFilter_gaussian_filter doesn't exist");
+        success = false;
+    }
+    if (!AiNodeLookUpByName("/beautiful/scope/directionalLight1/directionalLightShape1")) {
+        AiMsgError("/beautiful/scope/directionalLight1/directionalLightShape1 doesn't exist");
+        success = false;
+    }
+        
+    AiEnd();
+    return (success) ? 0 : 1;
+}


### PR DESCRIPTION
**Changes proposed in this pull request**
In #522 we implemented a scope for the USD writer. However there were a few issues that are addressed in this PR:
  - Calling `scene_write` with an empty `params` was crashing
  - Materials were written as `/materials/{scope}/{material_name}`,  they should instead be written as `/{scope}/materials/{material_name}`
  - Even with a scope in the usd file, we were saving the attributes `name` of the original arnold name, and this name was restored when converting back the scene to arnold. This could have ended up causing name clashes, so we're no longer saving the original arnold name when a scope is used.
  - We were missing a test, that I added as `test_0138`

**Issues fixed in this pull request**
Fixes #292 
