### PR TITLE
Write UV coordinates as primvars:st

### DIFF
--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -64,7 +64,7 @@ void UsdArnoldWriteMesh::Write(const AtNode *node, UsdArnoldWriter &writer)
 
     // export UVs
     AtArray *uvlist = AiNodeGetArray(node, "uvlist");
-    static TfToken uvToken("uv");
+    static TfToken uvToken("st");
     unsigned int uvlistNumElems = (uvlist) ? AiArrayGetNumElements(uvlist) : 0;
     if (uvlistNumElems > 0) {
         UsdGeomPrimvarsAPI primvarAPI(prim);


### PR DESCRIPTION
**Changes proposed in this pull request**
The usd reader will read either "uv" or "st" primvars as being the native uv coordinates of the mesh. 
So the usd writer could write to either one or the other without causing any major change.
This PR writes them as "st" for the reasons described in #542 , I verified that the whole testsuite still passes correctly, and that all tests that resave a file do save the coordinates as "st".
I'm not sure of how to test this, since both will end up being read the same way by the usd reader. Maybe the important test is to verify that the roundtrip works well, which is what lots of existing tests are doing.


**Issues fixed in this pull request**
Fixes #542 
