### PR TITLE
Fix compilation error with License.md 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -564,8 +564,9 @@ if DOCS:
     INSTALL_DOCS = env.Install(PREFIX_DOCS, DOCS)
     env.Alias('docs-install', INSTALL_DOCS)
 
-INSTALL_LICENSE = env.Install(PREFIX, 'LICENSE.md')
-
-env.Alias('license-install', INSTALL_LICENSE)
+# We don't need to install the license if the prefix is left to its default #553
+if PREFIX != '.':
+    INSTALL_LICENSE = env.Install(PREFIX, 'LICENSE.md')
+    env.Alias('license-install', INSTALL_LICENSE)
 
 Default(PREFIX)


### PR DESCRIPTION
**Changes proposed in this pull request**
We don't need to install the License.md file if  PREFIX is left to its default value, as we'd be installing it in its own folder.
This PR installs the license only if we're choosing a specific installation folder

**Issues fixed in this pull request**
Fixes #553
