### PR TITLE
Removing override from HdArnoldMaterial::Reload

### DIFF
--- a/render_delegate/material.cpp
+++ b/render_delegate/material.cpp
@@ -465,8 +465,6 @@ void HdArnoldMaterial::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rende
 
 HdDirtyBits HdArnoldMaterial::GetInitialDirtyBitsMask() const { return HdMaterial::DirtyResource; }
 
-void HdArnoldMaterial::Reload() {}
-
 AtNode* HdArnoldMaterial::GetSurfaceShader() const { return _surface; }
 
 AtNode* HdArnoldMaterial::GetDisplacementShader() const { return _displacement; }

--- a/render_delegate/material.h
+++ b/render_delegate/material.h
@@ -72,9 +72,11 @@ public:
 
     /// Reloads the shader.
     ///
+    /// Note: this function is a pure virtual in USD up to 20.08, but removed after.
+    ///
     /// Currently does nothing.
-    HDARNOLD_API
-    void Reload() override;
+   HDARNOLD_API
+    void Reload() { }
 
     /// Returns the Entry Point to the Surface Shader Network.
     ///


### PR DESCRIPTION
**Changes proposed in this pull request**
- Removing override from HdArnoldMaterial::Reload.

**Issues fixed in this pull request**
Fixes #567