### PR TITLE
Adding support for converting VtArray/String Types to user data

### DIFF
--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -392,6 +392,11 @@ inline void _DeclareAndAssignConstant(AtNode* node, const TfToken& name, const V
             return;
         }
         nodeSetStrFromStdStr(node, AtString{name.GetText()}, value.UncheckedGet<std::string>());
+    } else if (value.IsHolding<SdfAssetPath>()) {
+        if (!declareConstant(_tokens->STRING)) {
+            return;
+        }
+        nodeSetStrFromAssetPath(node, AtString{name.GetText()}, value.UncheckedGet<SdfAssetPath>());
     } else {
         // Display color is a special case, where an array with a single
         // element should be translated to a single, constant RGB.

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -164,31 +164,47 @@ inline uint32_t _ConvertArray(AtNode* node, const AtString& name, uint8_t arnold
     return 0;
 }
 
+// AtString requires conversion and can't be trivially copied.
+template <typename T>
+inline void _ConvertToString(AtString& to, const T& from)
+{
+    to = {};
+}
+
+template <>
+inline void _ConvertToString<std::string>(AtString& to, const std::string& from)
+{
+    to = AtString{from.c_str()};
+}
+
+template <>
+inline void _ConvertToString<TfToken>(AtString& to, const TfToken& from)
+{
+    to = AtString{from.GetText()};
+}
+
+template <>
+inline void _ConvertToString<SdfAssetPath>(AtString& to, const SdfAssetPath& from)
+{
+    to = AtString{from.GetResolvedPath().empty() ? from.GetAssetPath().c_str() : from.GetResolvedPath().c_str()};
+}
+
+// Anything but string should be trivially copyable.
 template <typename T>
 AtArray* _ArrayConvert(const VtArray<T>& v, uint8_t arnoldType)
 {
-    return AiArrayConvert(v.size(), 1, arnoldType, v.data());
-}
-
-template <>
-AtArray* _ArrayConvert<std::string>(const VtArray<std::string>& v, uint8_t arnoldType)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
-}
-
-template <>
-AtArray* _ArrayConvert<TfToken>(const VtArray<TfToken>& v, uint8_t arnoldType)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
-}
-
-template <>
-AtArray* _ArrayConvert<SdfAssetPath>(const VtArray<SdfAssetPath>& v, uint8_t arnoldType)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
+    if (arnoldType == AI_TYPE_STRING) {
+        auto* arr = AiArrayAllocate(v.size(), 1, AI_TYPE_STRING);
+        auto* mapped = static_cast<AtString*>(AiArrayMap(arr));
+        for (const auto& from : v) {
+            _ConvertToString(*mapped, from);
+            mapped += 1;
+        }
+        AiArrayUnmap(arr);
+        return arr;
+    } else {
+        return AiArrayConvert(v.size(), 1, arnoldType, v.data());
+    }
 }
 
 template <typename T>
@@ -197,39 +213,30 @@ AtArray* _ArrayConvertIndexed(const VtArray<T>& v, uint8_t arnoldType, const VtI
     const auto numIndices = indices.size();
     const auto numValues = v.size();
     auto* arr = AiArrayAllocate(numIndices, 1, arnoldType);
-    auto* mapped = static_cast<T*>(AiArrayMap(arr));
-    for (auto id = decltype(numIndices){0}; id < numIndices; id += 1) {
-        const auto index = indices[id];
-        if (Ai_likely(index < numValues)) {
-            mapped[id] = v[indices[id]];
-        } else {
-            mapped[id] = {};
+    if (arnoldType == AI_TYPE_STRING) {
+        auto* mapped = static_cast<AtString*>(AiArrayMap(arr));
+        for (auto id = decltype(numIndices){0}; id < numIndices; id += 1) {
+            const auto index = indices[id];
+            if (Ai_likely(index < numValues)) {
+                _ConvertToString(mapped[id], v[indices[id]]);
+            } else {
+                mapped[id] = {};
+            }
+        }
+    } else {
+        auto* mapped = static_cast<T*>(AiArrayMap(arr));
+        for (auto id = decltype(numIndices){0}; id < numIndices; id += 1) {
+            const auto index = indices[id];
+            if (Ai_likely(index < numValues)) {
+                mapped[id] = v[indices[id]];
+            } else {
+                mapped[id] = {};
+            }
         }
     }
+
     AiArrayUnmap(arr);
     return arr;
-}
-
-template <>
-AtArray* _ArrayConvertIndexed<std::string>(const VtArray<std::string>& v, uint8_t arnoldType, const VtIntArray& indices)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
-}
-
-template <>
-AtArray* _ArrayConvertIndexed<TfToken>(const VtArray<TfToken>& v, uint8_t arnoldType, const VtIntArray& indices)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
-}
-
-template <>
-AtArray* _ArrayConvertIndexed<SdfAssetPath>(
-    const VtArray<SdfAssetPath>& v, uint8_t arnoldType, const VtIntArray& indices)
-{
-    // TODO(pal): Implement.
-    return AiArrayAllocate(0, 1, AI_TYPE_STRING);
 }
 
 template <typename T>

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -217,8 +217,8 @@ AtArray* _ArrayConvertIndexed(const VtArray<T>& v, uint8_t arnoldType, const VtI
         auto* mapped = static_cast<AtString*>(AiArrayMap(arr));
         for (auto id = decltype(numIndices){0}; id < numIndices; id += 1) {
             const auto index = indices[id];
-            if (Ai_likely(index < numValues)) {
-                _ConvertToString(mapped[id], v[indices[id]]);
+            if (Ai_likely(index >= 0 && index < numValues)) {
+                _ConvertToString(mapped[id], v[index]);
             } else {
                 mapped[id] = {};
             }
@@ -227,8 +227,8 @@ AtArray* _ArrayConvertIndexed(const VtArray<T>& v, uint8_t arnoldType, const VtI
         auto* mapped = static_cast<T*>(AiArrayMap(arr));
         for (auto id = decltype(numIndices){0}; id < numIndices; id += 1) {
             const auto index = indices[id];
-            if (Ai_likely(index < numValues)) {
-                mapped[id] = v[indices[id]];
+            if (Ai_likely(index >= 0 && index < numValues)) {
+                mapped[id] = v[index];
             } else {
                 mapped[id] = {};
             }

--- a/testsuite/groups
+++ b/testsuite/groups
@@ -45,7 +45,7 @@ ignore: test_0011 test_0040 test_0101 test_0108
 # Notes: - test_0011 needs alembic - test_0040 needs the writer to be compiled - 
 
 # Tests that require the render delegate library, its dependencies and google test
-unit_render_delegate: test_0039 test_0134 test_0136
+unit_render_delegate: test_0039 test_0134 test_0136 test_0146
 
 # Tests that require the ndr, its dependencies and google test
 unit_ndr_plugin: test_0044

--- a/testsuite/test_0134/data/test.cpp
+++ b/testsuite/test_0134/data/test.cpp
@@ -109,10 +109,6 @@ TEST(HdArnoldSetConstantPrimvar, Base)
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue{int{4}});
     EXPECT_EQ(AiNodeGetInt(node, "primvar1"), 4);
-    HdArnoldSetConstantPrimvar(node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue{std::string{"hello"}});
-    EXPECT_EQ(AiNodeGetStr(node, "primvar2"), AtString{"hello"});
-    HdArnoldSetConstantPrimvar(node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue{TfToken{"world"}});
-    EXPECT_EQ(AiNodeGetStr(node, "primvar3"), AtString{"world"});
     HdArnoldSetConstantPrimvar(node, TfToken{"primvar4"}, HdPrimvarRoleTokens->color, VtValue{GfVec3f{1.0f, 2.0f, 3.0f}});
     EXPECT_NE(AiNodeGetVec(node, "primvar4"), AtVector(1.0f, 2.0f, 3.0f));
     EXPECT_EQ(AiNodeGetRGB(node, "primvar4"), AtRGB(1.0f, 2.0f, 3.0f));

--- a/testsuite/test_0146/README
+++ b/testsuite/test_0146/README
@@ -1,0 +1,5 @@
+Testing Hydra string conversion functions.
+
+see #481
+
+author: Pal Mezei

--- a/testsuite/test_0146/data/test.cpp
+++ b/testsuite/test_0146/data/test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/usd/sdf/assetPath.h>
+
+#include "render_delegate/utils.h"
+
+#include <cinttypes>
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+std::vector<AtString> _GetStringArray(const AtNode* node, const char* paramName)
+{
+    auto* arr = AiNodeGetArray(node, paramName);
+    if (arr == nullptr) {
+        return {};
+    }
+    const auto numElements = AiArrayGetNumElements(arr);
+    if (numElements == 0) {
+        return {};
+    }
+    auto* str = static_cast<AtString*>(AiArrayMap(arr));
+    std::vector<AtString> ret(str, str + numElements);
+    AiArrayUnmap(arr);
+    return ret;
+}
+
+TEST(HdArnoldSetConstantPrimvar, SingleString)
+{
+    auto* node = AiNode("polymesh");
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue{std::string{"hello"}});
+    EXPECT_EQ(AiNodeGetStr(node, "primvar1"), AtString{"hello"});
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue{TfToken{"world"}});
+    EXPECT_EQ(AiNodeGetStr(node, "primvar2"), AtString{"world"});
+    HdArnoldSetConstantPrimvar(node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue{SdfAssetPath{"mypath"}});
+    EXPECT_EQ(AiNodeGetStr(node, "primvar3"), AtString{"mypath"});
+}
+
+#define TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(FUNCNAME)                                                                   \
+    TEST(FUNCNAME, StringsArray)                                                                                     \
+    {                                                                                                                \
+        auto* node = AiNode("polymesh");                                                                             \
+        FUNCNAME(                                                                                                    \
+            node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none,                                                    \
+            VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});                              \
+        EXPECT_EQ(_GetStringArray(node, "primvar1"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
+        FUNCNAME(                                                                                                    \
+            node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none,                                                    \
+            VtValue{VtArray<TfToken>{TfToken{"hello"}, TfToken{"world"}}});                                          \
+        EXPECT_EQ(_GetStringArray(node, "primvar2"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
+        FUNCNAME(                                                                                                    \
+            node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none,                                                    \
+            VtValue{VtArray<SdfAssetPath>{SdfAssetPath{"hello"}, SdfAssetPath{"world"}}});                           \
+        EXPECT_EQ(_GetStringArray(node, "primvar3"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
+    }
+
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetConstantPrimvar)
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetUniformPrimvar)
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetVertexPrimvar)
+
+TEST(HdArnoldSetInstancePrimvar, StringArray)
+{
+    auto* node = AiNode("polymesh");
+    HdArnoldSetInstancePrimvar(
+        node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtIntArray{0, 1, 0},
+        VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});
+    EXPECT_EQ(
+        _GetStringArray(node, "instance_primvar1"),
+        std::vector<AtString>({AtString{"hello"}, AtString{"world"}, AtString{"hello"}}));
+    HdArnoldSetInstancePrimvar(
+        node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtIntArray{0, 1, 0},
+        VtValue{VtArray<TfToken>{TfToken{"hello"}, TfToken{"world"}}});
+    EXPECT_EQ(
+        _GetStringArray(node, "instance_primvar2"),
+        std::vector<AtString>({AtString{"hello"}, AtString{"world"}, AtString{"hello"}}));
+    HdArnoldSetInstancePrimvar(
+        node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtIntArray{0, 1, 0},
+        VtValue{VtArray<SdfAssetPath>{SdfAssetPath{"hello"}, SdfAssetPath{"world"}}});
+    EXPECT_EQ(
+        _GetStringArray(node, "instance_primvar3"),
+        std::vector<AtString>({AtString{"hello"}, AtString{"world"}, AtString{"hello"}}));
+}
+
+TEST(HdArnoldSetInstancePrimvar, InvalidIndex)
+{
+    auto* node = AiNode("polymesh");
+    HdArnoldSetInstancePrimvar(
+        node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtIntArray{0, 42, 0},
+        VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});
+    EXPECT_EQ(
+        _GetStringArray(node, "instance_primvar1"),
+        std::vector<AtString>({AtString{"hello"}, AtString{}, AtString{"hello"}}));
+    HdArnoldSetInstancePrimvar(
+        node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtIntArray{0, 42, -1337},
+        VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});
+    EXPECT_EQ(
+        _GetStringArray(node, "instance_primvar2"),
+        std::vector<AtString>({AtString{"hello"}, AtString{}, AtString{}}));
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    AiBegin();
+    AiMsgSetConsoleFlags(AI_LOG_NONE);
+    auto result = RUN_ALL_TESTS();
+    AiEnd();
+    return result;
+}


### PR DESCRIPTION
**Changes proposed in this pull request**
- Support SdfAssetPath in _DeclareAndAssignConstant.
- Converting to AtArray<AtString> from VtArray<std::string>, VtArray<TfToken> and VtArray<SdfAssetPath>.
- Adding test_0146 to test the new string conversion functions.
- Check for below zero indices when writing point instancer user data.

**Issues fixed in this pull request**
Fixes #481