### PR TITLE
Namespace arnold schemas params with arnold

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -266,7 +266,7 @@ class ArnoldUsdLuxLightFilter "ArnoldUsdLuxLightFilter" (
 def createArnoldClass(entryName, parentClass, paramList, nentry, parentParamList = None, isAPI = False, isInstantiable=True):
 
     schemaName = 'Arnold{}'.format(makeCamelCase(entryName))
-    attrScope = ''
+    attrScope = 'arnold:'
 
     if isAPI:
         file.write('class "{}API"(\n'.format(schemaName))

--- a/translator/reader/prim_reader.h
+++ b/translator/reader/prim_reader.h
@@ -49,7 +49,7 @@ public:
 protected:
     void _ReadArnoldParameters(
         const UsdPrim &prim, UsdArnoldReaderContext &context, AtNode *node, const TimeSettings &time,
-        const std::string &scope = "arnold");
+        const std::string &scope = "arnold", bool acceptEmptyScope = false);
     void _ReadArrayLink(
         const UsdPrim &prim, const UsdAttribute &attr, UsdArnoldReaderContext &context, AtNode *node,
         const std::string &scope);

--- a/translator/reader/read_arnold_type.cpp
+++ b/translator/reader/read_arnold_type.cpp
@@ -41,6 +41,13 @@ void UsdArnoldReadArnoldType::Read(const UsdPrim &prim, UsdArnoldReaderContext &
     // convert them. If this primitive if a UsdShader "Shader" type, we're
     // looking for an attribute namespace "inputs", otherwise this is just an
     // arnold typed schema and we don't want any namespace.
-    _ReadArnoldParameters(prim, context, node, time, (objType == "Shader") ? "inputs" : "");
+    if (objType == "Shader")
+    	_ReadArnoldParameters(prim, context, node, time, "inputs");
+    else {
+    	// the last argument is set to true in order to be backwards compatible
+    	// and to keep supporting usd files authored with previous versions of USD
+    	// (before #583). To be removed
+    	_ReadArnoldParameters(prim, context, node, time, "arnold", true); 
+    }
     ReadPrimvars(prim, node, time, context);
 }

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -252,10 +252,13 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
     // render camera and check its shutter, in order to know if we need to read motion data or not (#346)
     if (_procParent == nullptr) {
         UsdPrim options = _stage->GetPrimAtPath(SdfPath("/options"));
-        static const TfToken cameraToken("camera");
+        static const TfToken cameraToken("arnold:camera");
+        static const TfToken oldCameraToken("camera");
+        bool hasCameraToken = options && options.HasAttribute(cameraToken);
+        bool hasOldCameraToken = !hasCameraToken && options && options.HasAttribute(oldCameraToken);
 
-        if (options && options.HasAttribute(cameraToken)) {
-            UsdAttribute cameraAttr = options.GetAttribute(cameraToken);
+        if (hasCameraToken || hasOldCameraToken) {
+            UsdAttribute cameraAttr = options.GetAttribute((hasCameraToken) ? cameraToken : oldCameraToken);
             if (cameraAttr) {
                 std::string cameraName;
                 cameraAttr.Get(&cameraName);

--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -54,7 +54,7 @@ void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer
     }
     prim = stage->DefinePrim(objPath, TfToken(_usdName));
 
-    _WriteArnoldParameters(node, writer, prim, "");
+    _WriteArnoldParameters(node, writer, prim, "arnold");
 }
 
 void UsdArnoldWriteGinstance::_ProcessInstanceAttribute(
@@ -110,5 +110,5 @@ void UsdArnoldWriteGinstance::Write(const AtNode *node, UsdArnoldWriter &writer)
         _ProcessInstanceAttribute(prim, node, target, "self_shadows", AI_TYPE_BOOLEAN);
     }
 
-    _WriteArnoldParameters(node, writer, prim, "");
+    _WriteArnoldParameters(node, writer, prim, "arnold");
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
In order to address #583 , we need to add an `arnold:` namespace to all the attributes from arnold schemas.
This PR handles this in the writer, reader and the schemas generation code.

In order to be backwards compatible, the reader needs to add a special case in a couple of places. 
Note that I could have made this case more "generic", by adding a list of allowed namespaces in `_ReadArnoldParameters` instead of an additional flag.
But after trying it, I felt like it made the whole code more complicated, and possibly less efficient, for a very special use case that should probably be removed after a couple of versions. So the optional boolean argument seemed less intrusive to me.

I verified that the testsuite passes, and it also passes if I remove the "writer" modification. This means that we read properly previous files. In fact, there are already a few tests with usd files having the "old" namespacing, so we're already testing the compatibility with old scenes.

I'm not marking this PR as fixing issue #583 , since I'm not dealing with the schema inheritance yet. This will be done in a following PR.