### PR TITLE
Create hierarchy with xform primitives in the writer

### DIFF
--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -53,14 +53,18 @@ void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer
         // This primitive was already written, let's early out
         return;
     }
-    prim = stage->DefinePrim(objPath, TfToken(_usdName));
-
     const AtNodeEntry *nodeEntry = AiNodeGetNodeEntry(node);
     int nodeEntryType = AiNodeEntryGetType(nodeEntry);
+    bool isXformable = (nodeEntryType == AI_NODE_SHAPE 
+        || nodeEntryType == AI_NODE_CAMERA || nodeEntryType == AI_NODE_LIGHT);
+    
+    if (isXformable)
+        writer.CreateHierarchy(objPath);
+    prim = stage->DefinePrim(objPath, TfToken(_usdName));
+
     // For arnold nodes that have a transform matrix, we read it as in a 
     // UsdGeomXformable
-    if (nodeEntryType == AI_NODE_SHAPE 
-        || nodeEntryType == AI_NODE_CAMERA || nodeEntryType == AI_NODE_LIGHT)
+    if (isXformable)
     {
         UsdGeomXformable xformable(prim);
         _WriteMatrix(xformable, node, writer);
@@ -136,6 +140,7 @@ void UsdArnoldWriteGinstance::Write(const AtNode *node, UsdArnoldWriter &writer)
         // This primitive was already written, let's early out
         return;
     }
+    writer.CreateHierarchy(objPath);
     prim = stage->DefinePrim(objPath, TfToken(_usdName));
 
     AtNode *target = (AtNode *)AiNodeGetPtr(node, "node");

--- a/translator/writer/write_camera.cpp
+++ b/translator/writer/write_camera.cpp
@@ -34,8 +34,9 @@ void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdGeomCamera cam = UsdGeomCamera::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);
+    writer.CreateHierarchy(objPath);
+    UsdGeomCamera cam = UsdGeomCamera::Define(stage, objPath);
     UsdPrim prim = cam.GetPrim();
 
     TfToken projection;

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -33,8 +33,9 @@ void UsdArnoldWriteMesh::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdGeomMesh mesh = UsdGeomMesh::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdGeomMesh mesh = UsdGeomMesh::Define(stage, objPath);
     UsdPrim prim = mesh.GetPrim();
 
     _WriteMatrix(mesh, node, writer);
@@ -179,8 +180,9 @@ void UsdArnoldWriteCurves::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdGeomBasisCurves curves = UsdGeomBasisCurves::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdGeomBasisCurves curves = UsdGeomBasisCurves::Define(stage, objPath);
     UsdPrim prim = curves.GetPrim();
 
     _WriteMatrix(curves, node, writer);
@@ -245,8 +247,9 @@ void UsdArnoldWritePoints::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer); // what is the USD name for this primitive
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdGeomPoints points = UsdGeomPoints::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdGeomPoints points = UsdGeomPoints::Define(stage, objPath);
     UsdPrim prim = points.GetPrim();
 
     _WriteMatrix(points, node, writer);
@@ -286,6 +289,7 @@ void UsdArnoldWriteProceduralCustom::Write(const AtNode *node, UsdArnoldWriter &
         return;
     }
     // All custom procedurals are written as ArnoldProceduralCustom schema
+    writer.CreateHierarchy(objPath);
     prim = stage->DefinePrim(objPath, TfToken("ArnoldProceduralCustom"));
 
     // Set the procedural node entry name as an attribute "arnold:node_entry"

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -50,8 +50,9 @@ void UsdArnoldWriteDistantLight::Write(const AtNode *node, UsdArnoldWriter &writ
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxDistantLight light = UsdLuxDistantLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);        
+    writer.CreateHierarchy(objPath);
+    UsdLuxDistantLight light = UsdLuxDistantLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     WriteAttribute(node, "angle", prim, light.GetAngleAttr(), writer);
@@ -64,8 +65,9 @@ void UsdArnoldWriteDomeLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);
+    writer.CreateHierarchy(objPath);
+    UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     writeLightCommon(node, light, *this, writer);
@@ -103,8 +105,9 @@ void UsdArnoldWriteDiskLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     writeLightCommon(node, light, *this, writer);
@@ -118,8 +121,9 @@ void UsdArnoldWriteSphereLight::Write(const AtNode *node, UsdArnoldWriter &write
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     writeLightCommon(node, light, *this, writer);
@@ -142,8 +146,9 @@ void UsdArnoldWriteRectLight::Write(const AtNode *node, UsdArnoldWriter &writer)
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxRectLight light = UsdLuxRectLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdLuxRectLight light = UsdLuxRectLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     writeLightCommon(node, light, *this, writer);
@@ -200,8 +205,9 @@ void UsdArnoldWriteGeometryLight::Write(const AtNode *node, UsdArnoldWriter &wri
 {
     std::string nodeName = GetArnoldNodeName(node, writer);
     UsdStageRefPtr stage = writer.GetUsdStage();    // Get the USD stage defined in the writer
-
-    UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, SdfPath(nodeName));
+    SdfPath objPath(nodeName);    
+    writer.CreateHierarchy(objPath);
+    UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
     writeLightCommon(node, light, *this, writer);

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -19,6 +19,7 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdGeom/xform.h>
 
 #include <cstdio>
 #include <cstring>
@@ -105,3 +106,26 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
 }
 
 void UsdArnoldWriter::SetRegistry(UsdArnoldWriterRegistry *registry) { _registry = registry; }
+
+void UsdArnoldWriter::CreateHierarchy(const SdfPath &path, bool leaf) const
+{
+    if (path == SdfPath::AbsoluteRootPath())
+        return;
+    
+    if (!leaf) {
+        // If this primitive was already written, let's early out.
+        // No need to test this for the leaf node that is about 
+        // to be created
+        if (_stage->GetPrimAtPath(path))
+            return;
+    }
+
+    // Ensure the parents xform are created first, otherwise they'll
+    // be created implicitely without any type
+    CreateHierarchy(path.GetParentPath(), false);
+
+    // Finally, create the current non-leaf prim as a xform
+    if (!leaf) 
+        UsdGeomXform::Define(_stage, path);
+
+}

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -127,5 +127,4 @@ void UsdArnoldWriter::CreateHierarchy(const SdfPath &path, bool leaf) const
     // Finally, create the current non-leaf prim as a xform
     if (!leaf) 
         UsdGeomXform::Define(_stage, path);
-
 }

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -79,6 +79,7 @@ public:
         }
         
     }
+    void CreateHierarchy(const SdfPath &path, bool leaf = true) const;
 
 private:
     const AtUniverse *_universe;        // Arnold universe to be converted


### PR DESCRIPTION
**Changes proposed in this pull request** 
Before authoring a new xformable prim, we now create all the parent prims as xforms instead of letting them be created implicitely by USD as non-typed prims.

**Issues fixed in this pull request**
Fixes #629 
