### PR TITLE
Setting motion_start and motion_end when applying transformation matrices

### DIFF
--- a/render_delegate/constant_strings.h
+++ b/render_delegate/constant_strings.h
@@ -221,6 +221,8 @@ ASTR(metallic);
 ASTR(metalness);
 ASTR(mirrored_ball);
 ASTR(missing_texture_color);
+ASTR(motion_end);
+ASTR(motion_start);
 ASTR(name);
 ASTR(near_clip);
 ASTR(nidxs);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Setting motion_start and motion_end when applying transformation matrices.

**Issues fixed in this pull request**
Fixes #638