### PR TITLE
Only dump a warning if root prim is not active

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -243,11 +243,17 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
     if (!path.empty()) {
         SdfPath sdfPath(path);
         rootPrim = _stage->GetPrimAtPath(sdfPath);
-        if ((!rootPrim) || (!rootPrim.IsActive())) {
+        if (!rootPrim) {
             AiMsgError(
                 "[usd] %s : Object Path %s is not valid", (_procParent) ? AiNodeGetName(_procParent) : "",
                 path.c_str());
             return;
+        }
+        if (!rootPrim.IsActive()) {
+            AiMsgWarning(
+                "[usd] %s : Object Path primitive %s is not active", (_procParent) ? AiNodeGetName(_procParent) : "",
+                path.c_str());
+            return;   
         }
         rootPrimPtr = &rootPrim;
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
When the procedural `object_path` points at a root primitive that is not active, we just throw a warning instead of an error.
We still dump an error if the object path doesn't match any primitive in the usd stage

**Issues fixed in this pull request**
Fixes #643
