### PR TITLE
Improving light linking code and fixing a bug

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -478,6 +478,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
         if (linkValue.IsHolding<TfToken>()) {
             const auto& link = linkValue.UncheckedGet<TfToken>();
             if (currentLink != link) {
+                param->Interrupt();
                 // The empty link value only exists when creating the class, so link can never match emptyLink.
                 if (currentLink != _tokens->emptyLink) {
                     _delegate->DeregisterLightLinking(currentLink, this, isShadow);

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -820,15 +820,14 @@ void HdArnoldRenderDelegate::ApplyLightLinking(AtNode* shape, const VtArray<TfTo
                 }
             }
         }
-        // TODO(pal): We should be able to remove this check.
+        // If lights is empty, then no lights affect the shape, and we still have to set useGroup to true.
         if (lights.empty()) {
             AiNodeResetParameter(shape, group);
-            AiNodeResetParameter(shape, useGroup);
         } else {
             AiNodeSetArray(
                 shape, group, AiArrayConvert(static_cast<uint32_t>(lights.size()), 1, AI_TYPE_NODE, lights.data()));
-            AiNodeSetBool(shape, useGroup, true);
         }
+        AiNodeSetBool(shape, useGroup, true);
     };
     if (!lightEmpty) {
         applyGroups(str::light_group, str::use_light_group, _lightLinks);

--- a/render_delegate/shape.cpp
+++ b/render_delegate/shape.cpp
@@ -41,9 +41,11 @@ void HdArnoldShape::Sync(
 {
     auto& id = rprim->GetId();
     if (HdChangeTracker::IsPrimIdDirty(dirtyBits, id)) {
+        param->Interrupt();
         _SetPrimId(rprim->GetPrimId());
     }
     if (dirtyBits | HdChangeTracker::DirtyCategories) {
+        param->Interrupt();
         renderDelegate->ApplyLightLinking(_shape, sceneDelegate->GetCategories(id));
     }
     _SyncInstances(dirtyBits, renderDelegate, sceneDelegate, param, id, rprim->GetInstancerId(), force);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added several render interruptions that were missing previously. Generally, their lack didn't cause any issues, because we were already in an interrupted state, but this way we better match the logic of the other sync functions.
- Fixed a bug when a shape was not affected by any light or shadow.

#412