### PR TITLE
Converting HdInterpolationVarying primvars to vertex user data.

### DIFF
--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -267,7 +267,8 @@ void HdArnoldBasisCurves::Sync(
             }
 
             if (primvar.first == HdTokens->widths) {
-                if (desc.interpolation == HdInterpolationVertex && _interpolation != HdTokens->linear) {
+                if ((desc.interpolation == HdInterpolationVertex || desc.interpolation == HdInterpolationVarying) &&
+                    _interpolation != HdTokens->linear) {
                     auto value = desc.value;
                     setArnoldVertexCounts();
                     // Remapping the per vertex parameters to match the arnold requirements.
@@ -307,7 +308,7 @@ void HdArnoldBasisCurves::Sync(
                 } else {
                     HdArnoldSetUniformPrimvar(GetArnoldNode(), primvar.first, desc.role, desc.value);
                 }
-            } else if (desc.interpolation == HdInterpolationVertex) {
+            } else if (desc.interpolation == HdInterpolationVertex || desc.interpolation == HdInterpolationVarying) {
                 if (primvar.first == HdTokens->points) {
                     HdArnoldSetPositionFromValue(GetArnoldNode(), str::curves, desc.value);
                 } else if (primvar.first == HdTokens->normals) {

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -348,7 +348,7 @@ void HdArnoldMesh::Sync(
 
             if (desc.interpolation == HdInterpolationConstant) {
                 HdArnoldSetConstantPrimvar(GetArnoldNode(), primvar.first, desc.role, desc.value, &visibility);
-            } else if (desc.interpolation == HdInterpolationVertex) {
+            } else if (desc.interpolation == HdInterpolationVertex || desc.interpolation == HdInterpolationVarying) {
                 if (primvar.first == _tokens->st || primvar.first == _tokens->uv) {
                     _ConvertVertexPrimvarToBuiltin<GfVec2f, AI_TYPE_VECTOR2>(
                         GetArnoldNode(), desc.value, str::uvlist, str::uvidxs);

--- a/render_delegate/points.cpp
+++ b/render_delegate/points.cpp
@@ -108,6 +108,11 @@ void HdArnoldPoints::Sync(
             // Per vertex attributes are uniform on points.
             convertToUniformPrimvar(primvar);
         }
+
+        for (const auto& primvar : sceneDelegate->GetPrimvarDescriptors(id, HdInterpolation::HdInterpolationVarying)) {
+            // Per vertex attributes are uniform on points.
+            convertToUniformPrimvar(primvar);
+        }
     }
 
     SyncShape(*dirtyBits, sceneDelegate, param, transformDirtied);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Converting HdInterpolationVarying primvars to vertex user data.

**Issues fixed in this pull request**
Fixes #667