### PR TITLE
Don't apply skinning if a cache ID  is set 

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -304,7 +304,12 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
     // Apply eventual skinning in the scene, for the desired time interval
     UsdPrimRange range = (rootPrimPtr) ? UsdPrimRange(*rootPrimPtr) : _stage->Traverse();
     GfInterval interval(_time.start(), _time.end());
-    UsdSkelBakeSkinning(range, interval);
+
+    // Apply the skinning to the whole scene. Note that we don't want to do this
+    // with a cache id since the usd stage is owned by someone else and we 
+    // shouldn't modify it
+    if (_cacheId == 0)
+        UsdSkelBakeSkinning(range, interval);
 
     size_t threadCount = _threadCount; // do we want to do something
                                        // automatic when threadCount = 0 ?


### PR DESCRIPTION
**Changes proposed in this pull request**
When the usdStage comes for the stage cache with a given cache ID, we should not modify it.
Therefore we skip the call to `UsdSkelBakeSkinning` that is meant to apply the skinning on the whole scene, 
and thus modify it.

**Issues fixed in this pull request**
Fixes #683 
