### PR TITLE
Fixing issues with translating crease weights in the render delegate.

### DIFF
--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -79,12 +79,10 @@ public:
     /// Resumes an already paused render, does nothing if no render is running, or the render is not paused.
     HDARNOLD_API
     void Resume();
-    /// Stops an ongoing render, does nothing if no render is running.
-    HDARNOLD_API
-    void Stop();
     /// Resumes an already running,stopped/paused/finished render.
     HDARNOLD_API
     void Restart();
+
 private:
     /// Indicate if render needs restarting, in case interrupt is called after rendering has finished.
     std::atomic<bool> _needsRestart;
@@ -92,6 +90,31 @@ private:
     std::atomic<bool> _aborted;
     /// Indicate if rendering has been paused.
     std::atomic<bool> _paused;
+};
+
+class HdArnoldRenderParamInterrupt {
+public:
+    /// Constructor for HdArnoldRenderParamInterrupt.
+    ///
+    /// @param param Pointer to the HdRenderParam struct.
+    HdArnoldRenderParamInterrupt(HdRenderParam* param) : _param(reinterpret_cast<HdArnoldRenderParam*>(param)) {}
+
+    /// Interrupts an ongoing render.
+    ///
+    /// Only calls interrupt once per created instance of HdArnoldRenderParamInterrupt.
+    void Interrupt()
+    {
+        if (!_hasInterrupted) {
+            _hasInterrupted = true;
+            _param->Interrupt();
+        }
+    }
+
+private:
+    /// Indicate if the render has been interrupted already.
+    bool _hasInterrupted = false;
+    /// Pointer to the Arnold Render Param struct held inside.
+    HdArnoldRenderParam* _param = nullptr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/rprim.h
+++ b/render_delegate/rprim.h
@@ -91,7 +91,7 @@ public:
     /// Syncs internal data and arnold state with hydra.
     HDARNOLD_API
     void SyncShape(
-        HdDirtyBits dirtyBits, HdSceneDelegate* sceneDelegate, HdArnoldRenderParam* param, bool force = false)
+        HdDirtyBits dirtyBits, HdSceneDelegate* sceneDelegate, HdArnoldRenderParamInterrupt& param, bool force = false)
     {
 #if PXR_VERSION >= 2102
         // Newer USD versions need to update the instancer before accessing the instancer id.

--- a/render_delegate/shape.h
+++ b/render_delegate/shape.h
@@ -64,7 +64,7 @@ public:
     HDARNOLD_API
     void Sync(
         HdRprim* rprim, HdDirtyBits dirtyBits, HdArnoldRenderDelegate* renderDelegate, HdSceneDelegate* sceneDelegate,
-        HdArnoldRenderParam* param, bool force = false);
+        HdArnoldRenderParamInterrupt& param, bool force = false);
     /// Sets the internal visibility parameter.
     ///
     /// @param visibility New value for visibility.
@@ -97,16 +97,17 @@ protected:
     ///
     /// @param dirtyBits Dirty Bits to sync.
     /// @param sceneDelegate Pointer to the Scene Delegate.
+    /// @param param Reference to HdArnoldRenderParamInterrupt.
     /// @param id Path to the primitive.
     /// @param instancerId Path to the Point Instancer.
     /// @param force Forces updating of the instances even if they are not dirtied.
     void _SyncInstances(
         HdDirtyBits dirtyBits, HdArnoldRenderDelegate* renderDelegate, HdSceneDelegate* sceneDelegate,
-        HdArnoldRenderParam* param, const SdfPath& id, const SdfPath& instancerId, bool force);
+        HdArnoldRenderParamInterrupt& param, const SdfPath& id, const SdfPath& instancerId, bool force);
     /// Checks if existing instance visibility for the first @param count instances.
     ///
-    /// @param param HdArnoldRenderParam to stop rendering if it's not nullptr.
-    void _UpdateInstanceVisibility(HdArnoldRenderParam* param = nullptr);
+    /// @param param Reference to HdArnoldRenderParamInterrupt.
+    void _UpdateInstanceVisibility(HdArnoldRenderParamInterrupt& param);
 
     AtNode* _instancer = nullptr;     ///< Pointer to the Arnold Instancer.
     AtNode* _shape;                   ///< Pointer to the Arnold Shape.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fixing crease weight translation.
- Renaming parameters and adding more comments to crease weight/corner weight handling.
- Adding a new helper class that only interrupts once per sync function.
- Adding missing initial dirty bits for HdArnoldMesh.
- Removed `vlist` syncing logic from HdArnoldPoints that was never executed.

**Issues fixed in this pull request**
Fixes #660

**Additional context**
I also included some additional changes that are just generic improvements/optimizations.
