### PR TITLE
Fixing test 166

### DIFF
--- a/testsuite/test_0166/data/test.ass
+++ b/testsuite/test_0166/data/test.ass
@@ -8,7 +8,6 @@ options
 {
  AA_samples 3
  AA_samples_max 8
- abort_on_license_fail on
  outputs "RGBA RGBA myfilter mydriver"
  xres 160
  yres 120


### PR DESCRIPTION
**Changes proposed in this pull request**
Test 166, added for #697 had `abort_on_license_fail on`. This will prevent the test from succeeding if no valid license is found