### PR TITLE
Remove the dependency between the testsuite and the procedural

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -530,12 +530,18 @@ if BUILD_TESTSUITE:
         exports     = ['env'],
         duplicate   = 0)
     SConscriptChdir(1)
+    '''
+    This is currently causing issues when running the testsuite (see #746).
+    We're disabling it for now, so devs will need to first build the repo 
+    and then run the testsuite. This will also allow to run the tests on 
+    a prebuilt library
     Depends(TESTSUITE, PROCEDURAL)
     if env['ENABLE_UNIT_TESTS']:
         if RENDERDELEGATE:
             Depends(TESTSUITE, RENDERDELEGATE)
         if NDRPLUGIN:
             Depends(TESTSUITE, NDRPLUGIN)
+    '''
 else:
     TESTSUITE = None
 


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR I'm removing the dependency between the testsuite and the procedural (which is what I've been doing locally for months, to avoid the issues described in #746)
In order to be consistent, I'm also doing the same with the render delegate and the ndr plugins.

**Issues fixed in this pull request**
Fixes #746 
