### PR TITLE
Simplify accessing Arnold parameters using UsdImagingPrimAdater::Get.

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -51,6 +51,7 @@ namespace str {
 ASTR2(_default, "default");
 ASTR2(_max, "max");
 ASTR2(_min, "min");
+ASTR2(arnold__attributes, "arnold::attributes");
 ASTR2(arnold_camera, "arnold:camera");
 ASTR2(arnold_filename, "arnold:filename");
 ASTR2(arnold_node_entry, "arnold:node_entry");

--- a/common/shape_utils.cpp
+++ b/common/shape_utils.cpp
@@ -15,7 +15,20 @@
 
 #include "constant_strings.h"
 
+#include <pxr/base/tf/staticTokens.h>
+
 PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    ((matrix, "arnold:matrix"))
+    ((disp_map, "arnold:disp_map"))
+    ((visibility, "arnold:visibility"))
+    ((name, "arnold:name"))
+    ((shader, "arnold:shader"))
+    ((id, "arnold:id"))
+);
+// clang-format on
 
 void ArnoldUsdReadCreases(
     AtNode* node, const VtIntArray& cornerIndices, const VtFloatArray& cornerWeights, const VtIntArray& creaseIndices,
@@ -133,6 +146,18 @@ void ArnoldUsdCurvesData::SetRadiusFromValue(AtNode* node, const VtValue& value)
     }
 
     AiNodeSetArray(node, str::radius, arr);
+}
+
+bool ArnoldUsdIgnoreUsdParameter(const TfToken& name)
+{
+    return name == _tokens->matrix || name == _tokens->disp_map || name == _tokens->visibility ||
+           name == _tokens->name || name == _tokens->shader || name == _tokens->id;
+}
+
+bool ArnoldUsdIgnoreParameter(const AtString& name)
+{
+    return name == str::matrix || name == str::disp_map || name == str::visibility ||
+           name == str::name || name == str::shader || name == str::id;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/common/shape_utils.h
+++ b/common/shape_utils.h
@@ -177,4 +177,19 @@ private:
     };
 };
 
+/// Function to query if an arnold: prefixed parameter can be ignored on an Arnold schema.
+///
+/// @param name Name of the parameter (including the "arnold:" prefix).
+/// @return True if the parameter can be ignored, false otherwise.
+bool ArnoldUsdIgnoreUsdParameter(const TfToken& name);
+
+/// Function to query if an arnold parameter can be ignored on an Arnold schema.
+///
+/// @param name Name of the parameter (NOT including the "arnold:" prefix).
+/// @return True if the parameter can be ignored, false otherwise.
+bool ArnoldUsdIgnoreParameter(const AtString& name);
+
+/// Type to store arnold param names and values.
+using ArnoldUsdParamValueList = std::vector<std::pair<AtString, VtValue>>;
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -39,6 +39,7 @@
 
 #include <common_utils.h>
 #include <constant_strings.h>
+#include <shape_utils.h>
 
 #include "basis_curves.h"
 #include "camera.h"
@@ -340,8 +341,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate()
         while (!AiParamIteratorFinished(paramIter)) {
             const auto* param = AiParamIteratorGetNext(paramIter);
             const auto paramName = AiParamGetName(param);
-            if (paramName == str::matrix || paramName == str::disp_map || paramName == str::visibility ||
-                paramName == str::name || paramName == str::shader || paramName == str::id) {
+            if (ArnoldUsdIgnoreParameter(paramName)) {
                 continue;
             }
 #if PXR_VERSION >= 2011

--- a/usd_imaging/shape_adapter.h
+++ b/usd_imaging/shape_adapter.h
@@ -19,6 +19,8 @@
 
 #include <pxr/usdImaging/usdImaging/gprimAdapter.h>
 
+#include <ai.h>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class UsdImagingArnoldShapeAdapter : public UsdImagingGprimAdapter {
@@ -39,6 +41,30 @@ public:
 
     USDIMAGINGARNOLD_API
     HdDirtyBits ProcessPropertyChange(const UsdPrim& prim, const SdfPath& cachePath, const TfToken& property) override;
+
+#if PXR_VERSION >= 2011
+    /// Gets the value of the parameter named key for the given prim (which
+    /// has the given cache path) and given time.
+    ///
+    /// @param prim Primitive to query the parameters from.
+    /// @param cachePath Path to the value cache.
+    /// @param key Parameter name to query.
+    /// @param time Time to query the attribute at.
+    /// @return Return the value of the attribute, or an empty VtValue.
+    USDIMAGINGARNOLD_API
+    VtValue Get(const UsdPrim& prim, const SdfPath& cachePath, const TfToken& key, UsdTimeCode time) const override;
+
+private:
+    std::vector<std::pair<TfToken, AtString>> _paramNames; ///< Lookup table with USD and Arnold param names.
+#endif
+protected:
+    /// Caches param names for later lookup.
+    /// Does nothing if USD is earlier than 20.11.
+    ///
+    /// @param arnoldTypeName Type of the arnold node.
+    USDIMAGINGARNOLD_API
+    void _CacheParamNames(const TfToken& arnoldTypeName);
+
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/usd_imaging/shape_adapters.cpp.in
+++ b/usd_imaging/shape_adapters.cpp.in
@@ -23,7 +23,10 @@ PXR_NAMESPACE_OPEN_SCOPE
                                                                                                   \
     class UsdImagingArnold##suffix##Adapter : public UsdImagingArnoldShapeAdapter {               \
     public:                                                                                       \
-        UsdImagingArnold##suffix##Adapter() = default;                                            \
+        UsdImagingArnold##suffix##Adapter() : UsdImagingArnoldShapeAdapter()                      \
+        {                                                                                         \
+            _CacheParamNames(_##suffix##tokens->suffix);                                          \
+        }                                                                                         \
         ~UsdImagingArnold##suffix##Adapter() = default;                                           \
         TfToken ArnoldDelegatePrimType() const override { return _##suffix##tokens->suffix; }     \
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Simplify accessing Arnold parameters using UsdImagingPrimAdater::Get.

**Issues fixed in this pull request**
Fixes #743