### PR TITLE
Only force the ID to shapes if the reader has a parent procedural

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -715,8 +715,8 @@ void UsdArnoldReaderThreadContext::SetDispatcher(WorkDispatcher *dispatcher)
 AtNode *UsdArnoldReaderThreadContext::CreateArnoldNode(const char *type, const char *name)
 {    
     AtNode *node = AiNode(_reader->GetUniverse(), type, name, _reader->GetProceduralParent());
-    // All shape nodes should have an id parameter.
-    if (AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE) {
+    // All shape nodes should have an id parameter if we're coming from a parent procedural
+    if (_reader->GetProceduralParent() && AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE) {
         AiNodeSetUInt(node, str::id, _reader->GetId());
     }
     


### PR DESCRIPTION
**Changes proposed in this pull request**
As a complement to #734 , we're now only setting the id on shapes if the reader has a parent procedural.
This way, when we're using the scene format to convert from usd to arnold scenes, we're not forcing the id to be 0.
