### PR TITLE
Tracking material assignments to shapes and resyncing material IDs if terminals have changed

### DIFF
--- a/render_delegate/CMakeLists.txt
+++ b/render_delegate/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
     instancer.cpp
     light.cpp
     material.cpp
+    material_tracker.cpp
     mesh.cpp
     native_rprim.cpp
     openvdb_asset.cpp
@@ -35,6 +36,7 @@ set(HDR
     instancer.h
     light.h
     material.h
+    material_tracker.h
     mesh.h
     native_rprim.h
     openvdb_asset.h

--- a/render_delegate/SConscript
+++ b/render_delegate/SConscript
@@ -26,6 +26,7 @@ source_files = [
     'instancer.cpp',
     'light.cpp',
     'material.cpp',
+    'material_tracker.cpp',
     'mesh.cpp',
     'native_rprim.cpp',
     'openvdb_asset.cpp',

--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -132,8 +132,10 @@ void HdArnoldBasisCurves::Sync(
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         param.Interrupt();
+        const auto materialId = sceneDelegate->GetMaterialId(id);
+        _materialTracker.TrackSingleMaterial(GetRenderDelegate(), id, materialId);
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
-            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, sceneDelegate->GetMaterialId(id)));
+            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
         if (material != nullptr) {
             AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetSurfaceShader());
         } else {

--- a/render_delegate/material.h
+++ b/render_delegate/material.h
@@ -181,6 +181,7 @@ protected:
     AtNode* _displacement = nullptr;
     /// Pointer to the entry point to the Volume Shader Network.
     AtNode* _volume = nullptr;
+    bool _wasSyncedOnce = false; ///< Whether or not the material has been synced at least once.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/material_tracker.cpp
+++ b/render_delegate/material_tracker.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "material_tracker.h"
+
+#include "render_delegate.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+VtArray<SdfPath> HdArnoldMaterialTracker::GetCurrentMaterials(size_t newArraySize)
+{
+    auto currentMaterials = _materials;
+    if (_materials.size() != newArraySize) {
+        _materials.resize(newArraySize);
+    }
+    return currentMaterials;
+}
+
+void HdArnoldMaterialTracker::SetMaterial(const SdfPath& id, size_t arrayId)
+{
+    if (Ai_likely(_materials.size() > arrayId)) {
+        // cdata is a simple way to access the data without triggering a copy.
+        if (id != _materials.cdata()[arrayId]) {
+            // Trigger detaching.
+            _materials[arrayId] = id;
+        }
+    }
+}
+
+void HdArnoldMaterialTracker::TrackMaterialChanges(
+    HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const VtArray<SdfPath>& oldMaterials)
+{
+    if (!oldMaterials.IsIdentical(_materials)) {
+        // All the VtArrays are shared, so we don't have to worry about duplicating data here.
+        // Untracking the old materials.
+        if (!oldMaterials.empty()) {
+            renderDelegate->UntrackShapeMaterials(shapeId, oldMaterials);
+        }
+        // Tracking the new materials.
+        renderDelegate->TrackShapeMaterials(shapeId, _materials);
+    }
+}
+
+void HdArnoldMaterialTracker::TrackSingleMaterial(
+    HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const SdfPath& materialId)
+{
+    // Initial assignment.
+    if (_materials.empty()) {
+        _materials.assign(1, materialId);
+        renderDelegate->TrackShapeMaterials(shapeId, _materials);
+        // We already have a single material stored, check if it has changed.
+    } else {
+        if (_materials.cdata()[0] != materialId) {
+            renderDelegate->UntrackShapeMaterials(shapeId, _materials);
+            _materials[0] = materialId;
+            renderDelegate->TrackShapeMaterials(shapeId, _materials);
+        }
+    }
+}
+
+void HdArnoldMaterialTracker::UntrackMaterials(HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId)
+{
+    if (!_materials.empty()) {
+        renderDelegate->UntrackShapeMaterials(shapeId, _materials);
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/material_tracker.h
+++ b/render_delegate/material_tracker.h
@@ -1,0 +1,76 @@
+// Copyright 2021 Autodesk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/// @file material_tracker.h
+///
+/// Utilities for tracking material changes on shapes.
+#pragma once
+
+#include "api.h"
+
+#include <pxr/pxr.h>
+
+#include <pxr/base/vt/array.h>
+
+#include <pxr/usd/sdf/path.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdArnoldRenderDelegate;
+
+/// Class to track material assignments to shapes.
+class HdArnoldMaterialTracker {
+public:
+    /// Queries the list of current materials.
+    ///
+    /// @param newArraySize Size of the materials after querying the old array.
+    /// @return A copy of the current materials.
+    HDARNOLD_API
+    VtArray<SdfPath> GetCurrentMaterials(size_t newArraySize);
+
+    /// Check if a material has changed and store the new material.
+    ///
+    /// @param id Path to the new material.
+    /// @param arrayId Index of the material.
+    HDARNOLD_API
+    void SetMaterial(const SdfPath& id, size_t arrayId);
+
+    /// Track material changes if materials has been changed.
+    ///
+    /// @param renderDelegate Pointer to the Arnold Render Delegate.
+    /// @param shapeId Id of the current shape.
+    /// @param oldMaterials List of the materials assigned to the shape before assigning materials.
+    HDARNOLD_API
+    void TrackMaterialChanges(
+        HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const VtArray<SdfPath>& oldMaterials);
+
+    /// Track material if there is only a single material assigned to the shape.
+    ///
+    /// @param renderDelegate Pointer to the Arnold Render Delegate.
+    /// @param shapeId Id of the current shape.
+    /// @param materialId The material assigned to the shape.
+    HDARNOLD_API
+    void TrackSingleMaterial(HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const SdfPath& materialId);
+
+    /// Untrack all materials assigned to the shape. Typically used when deleting the shape.
+    ///
+    /// @param renderDelegate Pointer to the Arnold Render Delegate.
+    /// @param shapeId Id of the current shape.
+    HDARNOLD_API
+    void UntrackMaterials(HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId);
+
+private:
+    VtArray<SdfPath> _materials; ///< List of materials currently assigned.
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -278,8 +278,11 @@ void HdArnoldMesh::Sync(
         auto* dispMapArray = AiArrayAllocate(numShaders, 1, AI_TYPE_POINTER);
         auto* shader = static_cast<AtNode**>(AiArrayMap(shaderArray));
         auto* dispMap = static_cast<AtNode**>(AiArrayMap(dispMapArray));
+        // We are using VtAray here, so it's going to be COW.
+        auto oldMaterials = _materialTracker.GetCurrentMaterials(numShaders);
 
         auto setMaterial = [&](const SdfPath& materialId, size_t arrayId) {
+            _materialTracker.SetMaterial(materialId, arrayId);
             const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
                 sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
             if (material == nullptr) {
@@ -295,6 +298,8 @@ void HdArnoldMesh::Sync(
             setMaterial(_subsets[subset], subset);
         }
         setMaterial(sceneDelegate->GetMaterialId(id), numSubsets);
+        // If there has been a change in data, we already detached materials and the two arrays are different.
+        _materialTracker.TrackMaterialChanges(GetRenderDelegate(), id, oldMaterials);
         AiArrayUnmap(shaderArray);
         AiArrayUnmap(dispMapArray);
         AiNodeSetArray(GetArnoldNode(), str::shader, shaderArray);

--- a/render_delegate/native_rprim.cpp
+++ b/render_delegate/native_rprim.cpp
@@ -53,7 +53,8 @@ void HdArnoldNativeRprim::Sync(
             if (val.IsHolding<ArnoldUsdParamValueList>()) {
                 const auto* nodeEntry = AiNodeGetNodeEntry(GetArnoldNode());
                 for (const auto& param : val.UncheckedGet<ArnoldUsdParamValueList>()) {
-                    HdArnoldSetParameter(GetArnoldNode(), AiNodeEntryLookUpParameter(nodeEntry, param.first), param.second);
+                    HdArnoldSetParameter(
+                        GetArnoldNode(), AiNodeEntryLookUpParameter(nodeEntry, param.first), param.second);
                 }
             }
 #else
@@ -81,8 +82,10 @@ void HdArnoldNativeRprim::Sync(
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         param.Interrupt();
+        const auto materialId = sceneDelegate->GetMaterialId(id);
+        _materialTracker.TrackSingleMaterial(GetRenderDelegate(), id, materialId);
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
-            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, sceneDelegate->GetMaterialId(id)));
+            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
         if (material != nullptr) {
             AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetSurfaceShader());
         } else {

--- a/render_delegate/points.cpp
+++ b/render_delegate/points.cpp
@@ -68,8 +68,10 @@ void HdArnoldPoints::Sync(
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         param.Interrupt();
+        const auto materialId = sceneDelegate->GetMaterialId(id);
+        _materialTracker.TrackSingleMaterial(GetRenderDelegate(), id, materialId);
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
-            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, sceneDelegate->GetMaterialId(id)));
+            sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
         if (material != nullptr) {
             AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetSurfaceShader());
         } else {

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -33,10 +33,14 @@
 #include <pxr/pxr.h>
 #include "api.h"
 
+#include <pxr/base/vt/array.h>
+
 #include <pxr/imaging/hd/light.h>
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/renderThread.h>
 #include <pxr/imaging/hd/resourceRegistry.h>
+
+#include <tbb/concurrent_queue.h>
 
 #include "hdarnold.h"
 #include "render_param.h"
@@ -316,11 +320,43 @@ public:
 #if PXR_VERSION >= 2011
     using NativeRprimParamList = std::unordered_map<TfToken, const AtParamEntry*, TfToken::HashFunctor>;
 #else
-    using NativeRprimParamList = std::vector<std::pair<TfToken, const AtParamEntry*>>;
+    using NativeRprimParamList = std::vector<std::pair<TfToken, const AtParamEntry*> >;
 #endif
 
+    /// Returns a list of parameters for each native rprim.
+    ///
+    /// @param arnoldNodeType Type of the arnold node.
+    /// @return Constant Pointer to the list of parameters for each native rprim.
     HDARNOLD_API
     const NativeRprimParamList* GetNativeRprimParamList(const AtString& arnoldNodeType) const;
+
+    /// Dirties a material when terminals change.
+    /// Use this to trigger forced updates on shapes, in cases where it's uncertain if the shape has it's material id
+    /// updated.
+    ///
+    /// @param id Path to the material.
+    HDARNOLD_API
+    void DirtyMaterial(const SdfPath& id);
+
+    /// Remove material from the list tracking dependencies between shapes and materials.
+    ///
+    /// @param id Path to the material.
+    HDARNOLD_API
+    void RemoveMaterial(const SdfPath& id);
+
+    /// Track materials assigned to a shape.
+    ///
+    /// @param shape Id of the shape to track.
+    /// @param materials List of materials to track for each shape.
+    HDARNOLD_API
+    void TrackShapeMaterials(const SdfPath& shape, const VtArray<SdfPath>& materials);
+
+    /// Untrack materials assigned to a shape.
+    ///
+    /// @param shape Id of the shape to track.
+    /// @param materials List of materials to untrack for each shape.
+    HDARNOLD_API
+    void UntrackShapeMaterials(const SdfPath& shape, const VtArray<SdfPath>& materials);
 
 private:
     HdArnoldRenderDelegate(const HdArnoldRenderDelegate&) = delete;
@@ -340,6 +376,28 @@ private:
     using LightLinkingMap = std::unordered_map<TfToken, std::vector<HdLight*>, TfToken::HashFunctor>;
     using NativeRprimTypeMap = std::unordered_map<TfToken, AtString, TfToken::HashFunctor>;
     using NativeRprimParams = std::unordered_map<AtString, NativeRprimParamList, AtStringHash>;
+    // Should we use a std::vector here instead?
+    using MaterialToShapeMap = std::unordered_map<SdfPath, std::unordered_set<SdfPath, SdfPath::Hash>, SdfPath::Hash>;
+    using MaterialChangesQueue = tbb::concurrent_queue<SdfPath>;
+
+    struct ShapeMaterialChange {
+        SdfPath shape;
+        VtArray<SdfPath> materials;
+
+        ShapeMaterialChange() = default;
+
+        ShapeMaterialChange(const SdfPath& _shape, const VtArray<SdfPath>& _materials)
+            : shape(_shape), materials(_materials)
+        {
+        }
+    };
+    using ShapeMaterialChangesQueue = tbb::concurrent_queue<ShapeMaterialChange>;
+
+    MaterialChangesQueue _materialDirtyQueue;             ///< Queue to track material terminal dirty events.
+    MaterialChangesQueue _materialRemovalQueue;           ///< Queue to track material removal events.
+    ShapeMaterialChangesQueue _shapeMaterialTrackQueue;   ///< Queue to track shape material assignment changes.
+    ShapeMaterialChangesQueue _shapeMaterialUntrackQueue; ///< Queue to untrack shape material assignment changes.
+    MaterialToShapeMap _materialToShapeMap;               ///< Map to track dependencies between materials and shapes.
 
     std::mutex _lightLinkingMutex;                     ///< Mutex to lock all light linking operations.
     LightLinkingMap _lightLinks;                       ///< Light Link categories.

--- a/render_delegate/rprim.h
+++ b/render_delegate/rprim.h
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-/// @file gprim.h
+/// @file rprim.h
 ///
-/// Utilities for handling common gprim behavior.
+/// Utilities for handling common rprim behavior.
 #pragma once
 
 #include "api.h"
@@ -27,6 +27,7 @@
 #endif
 #include <pxr/imaging/hd/rprim.h>
 
+#include "material_tracker.h"
 #include "render_delegate.h"
 #include "shape.h"
 
@@ -67,7 +68,7 @@ public:
     /// Destructor for HdArnoldRprim.
     ///
     /// Frees the shape and all the ginstances created.
-    virtual ~HdArnoldRprim() = default;
+    ~HdArnoldRprim() override { _materialTracker.UntrackMaterials(_renderDelegate, HydraType::GetId()); }
     /// Gets the Arnold Shape.
     ///
     /// @return Reference to the Arnold Shape.
@@ -130,8 +131,9 @@ public:
     }
 
 protected:
-    HdArnoldShape _shape;                    ///< HdArnoldShape to handle instances and shape creation.
-    HdArnoldRenderDelegate* _renderDelegate; ///< Pointer to the Arnold Render Delegate.
+    HdArnoldShape _shape;                                ///< HdArnoldShape to handle instances and shape creation.
+    HdArnoldRenderDelegate* _renderDelegate;             ///< Pointer to the Arnold Render Delegate.
+    HdArnoldMaterialTracker _materialTracker;            ///< Utility to track material assignments ot shapes.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/volume.h
+++ b/render_delegate/volume.h
@@ -36,6 +36,7 @@
 #include <pxr/imaging/hd/volume.h>
 
 #include "hdarnold.h"
+#include "material_tracker.h"
 #include "render_delegate.h"
 #include "shape.h"
 
@@ -134,6 +135,7 @@ protected:
     }
 
     HdArnoldRenderDelegate* _renderDelegate;      ///< Pointer to the Render Delegate.
+    HdArnoldMaterialTracker _materialTracker;     ///< Utility to track material assignments to the volume.
     std::vector<HdArnoldShape*> _volumes;         ///< Vector storing all the Volumes created.
     std::vector<HdArnoldShape*> _inMemoryVolumes; ///< Vectoring storing all the Volumes for in-memory VDB storage.
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
- Tracking material assignments to shapes and resyncing material IDs if terminals have changed.

**Issues fixed in this pull request**
Fixes #751