### PR TITLE
Removing NeedsUpdate check when setting primvars on the Point Instancer

### DIFF
--- a/render_delegate/instancer.cpp
+++ b/render_delegate/instancer.cpp
@@ -253,9 +253,8 @@ void HdArnoldInstancer::SetPrimvars(AtNode* node, const SdfPath& prototypeId, si
     VtIntArray instanceIndices;
     for (auto& primvar : _primvars) {
         auto& desc = primvar.second;
-        if (!desc.NeedsUpdate()) {
-            continue;
-        }
+        // We don't need to call NeedsUpdate here, as this function is called once per Prototype, not
+        // once per instancer.
         if (instanceIndices.empty()) {
             instanceIndices = GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
             if (instanceIndices.empty() || instanceIndices.size() != instanceCount) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Removing the NeedsUpdate check when setting primvars on the Point Instancer

**Issues fixed in this pull request**
Fixes #759

**Additional context**
The HdArnoldPrimvar::NeedsUpdate function's purpose is to avoid setting the same primvar multiple times on a shape when it didn't change between sync function calls. While this works well for all the primitives, the Point Instancer is an exception. Here, we run the primvar conversion loop several times, and calling `NeedsUpdate` will remove the dirty call the first loop (which is non-sequential, so happens randomly), so when we are calling the loop for the second time, all the primvars will be ignored.

This syncing behavior happens due to how Hydra handles instancers compared to USD. In Hydra, we need to create an instancer procedural once for each prototype (thus the multiple primvar translation loops per update).
