### PR TITLE
Write custom primitives even when they already exist

### DIFF
--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -48,11 +48,6 @@ void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer
     UsdStageRefPtr stage = writer.GetUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
 
-    UsdPrim prim = stage->GetPrimAtPath(objPath);
-    if (prim && prim.IsActive()) {
-        // This primitive was already written, let's early out
-        return;
-    }
     const AtNodeEntry *nodeEntry = AiNodeGetNodeEntry(node);
     int nodeEntryType = AiNodeEntryGetType(nodeEntry);
     bool isXformable = (nodeEntryType == AI_NODE_SHAPE 
@@ -60,7 +55,8 @@ void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer
     
     if (isXformable)
         writer.CreateHierarchy(objPath);
-    prim = stage->DefinePrim(objPath, TfToken(_usdName));
+    
+    UsdPrim prim = stage->DefinePrim(objPath, TfToken(_usdName));
 
     // For arnold nodes that have a transform matrix, we read it as in a 
     // UsdGeomXformable
@@ -150,13 +146,8 @@ void UsdArnoldWriteGinstance::Write(const AtNode *node, UsdArnoldWriter &writer)
     UsdStageRefPtr stage = writer.GetUsdStage();    // get the current stage defined in the writer
     SdfPath objPath(nodeName);
 
-    UsdPrim prim = stage->GetPrimAtPath(objPath);
-    if (prim && prim.IsActive()) {
-        // This primitive was already written, let's early out
-        return;
-    }
     writer.CreateHierarchy(objPath);
-    prim = stage->DefinePrim(objPath, TfToken(_usdName));
+    UsdPrim prim = stage->DefinePrim(objPath, TfToken(_usdName));
 
     AtNode *target = (AtNode *)AiNodeGetPtr(node, "node");
     if (target) {

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -287,14 +287,9 @@ void UsdArnoldWriteProceduralCustom::Write(const AtNode *node, UsdArnoldWriter &
     SdfPath objPath(nodeName);
     _exportedAttrs.insert("name");
 
-    UsdPrim prim = stage->GetPrimAtPath(objPath);
-    if (prim && prim.IsActive()) {
-        // This primitive was already written, let's early out
-        return;
-    }
     // All custom procedurals are written as ArnoldProceduralCustom schema
     writer.CreateHierarchy(objPath);
-    prim = stage->DefinePrim(objPath, TfToken("ArnoldProceduralCustom"));
+    UsdPrim prim = stage->DefinePrim(objPath, TfToken("ArnoldProceduralCustom"));
 
     // Set the procedural node entry name as an attribute "arnold:node_entry"
     UsdAttribute nodeTypeAttr = prim.CreateAttribute(TfToken("arnold:node_entry"), SdfValueTypeNames->String, false);


### PR DESCRIPTION
**Changes proposed in this pull request**
We don't do things differently for arnold schemas as compared to builtin schemas during the writer process.
Note that the writer itself already ensures that we don't go twice through the same node, so this test wasn't actually needed.
This is allowing me to extend maya-usd export to handle arnold custom schemas, and could probably be used in the future as well to append multiple frames to a single usd file.

**Issues fixed in this pull request**
Fixes #768 
