### PR TITLE
Fix build issue with Houdini 18.0 (#792)

### DIFF
--- a/render_delegate/native_rprim.h
+++ b/render_delegate/native_rprim.h
@@ -49,7 +49,7 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     HDARNOLD_API
-    const TfTokenVector& GetBuiltinPrimvarNames() const override;
+    const TfTokenVector& GetBuiltinPrimvarNames() const;
 
 private:
     /// List of parameters to query from the Hydra Primitive.

--- a/render_delegate/native_rprim.h
+++ b/render_delegate/native_rprim.h
@@ -49,7 +49,7 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     HDARNOLD_API
-    const TfTokenVector& GetBuiltinPrimvarNames() const;
+    const TfTokenVector& GetBuiltinPrimvarNames() const override;
 
 private:
     /// List of parameters to query from the Hydra Primitive.

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -541,7 +541,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             AiNodeSetPtr(_mainDriver, str::depth_pointer, &_fallbackDepth);
             AiNodeSetPtr(_mainDriver, str::id_pointer, &_fallbackPrimId);
         }
-        if (_fallbackColor.GetWidth() != _width || _fallbackColor.GetHeight() != _height) {
+        if (_fallbackColor.GetWidth() != static_cast<unsigned int>(_width) || _fallbackColor.GetHeight() != static_cast<unsigned int>(_height)) {
             renderParam->Interrupt(true, false);
 #ifdef USD_HAS_UPDATED_COMPOSITOR
             _fallbackColor.Allocate({_width, _height, 1}, HdFormatFloat32Vec4, false);


### PR DESCRIPTION
Remove override for GetBuiltinPrimvarNames and fix another unrelated warning for int cast.