### PR TITLE
Fix build issue with Houdini 18.0 (#792)

### DIFF
--- a/render_delegate/native_rprim.h
+++ b/render_delegate/native_rprim.h
@@ -49,7 +49,7 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     HDARNOLD_API
-    const TfTokenVector& GetBuiltinPrimvarNames() const override;
+    const TfTokenVector& GetBuiltinPrimvarNames() const;
 
 private:
     /// List of parameters to query from the Hydra Primitive.


### PR DESCRIPTION
We need to remove override from GetBuiltinPrimvarNames()