### PR TITLE
Interrupting renders before deleting render pass nodes.

### DIFF
--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -402,6 +402,7 @@ HdArnoldRenderPass::HdArnoldRenderPass(
 
 HdArnoldRenderPass::~HdArnoldRenderPass()
 {
+    reinterpret_cast<HdArnoldRenderParam*>(_renderDelegate->GetRenderParam())->Interrupt();
     AiNodeDestroy(_camera);
     AiNodeDestroy(_defaultFilter);
     AiNodeDestroy(_closestFilter);


### PR DESCRIPTION
**Changes proposed in this pull request**
- Interrupting the render before deleting nodes in HdArnoldRenderPass.

**Issues fixed in this pull request**
Fixes #797