### PR TITLE
Converting string/token/asset path primvar arrays to built-in string arrays

### DIFF
--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -1043,6 +1043,25 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
                     }
                 }
                 break;
+            case AI_TYPE_STRING:
+                if (value.IsHolding<VtArray<std::string>>()) {
+                    AiNodeSetArray(
+                        node, paramName,
+                        _ArrayConvert<std::string>(value.UncheckedGet<VtArray<std::string>>(), AI_TYPE_STRING));
+                } else if (value.IsHolding<VtArray<TfToken>>()) {
+                    AiNodeSetArray(
+                        node, paramName,
+                        _ArrayConvert<TfToken>(value.UncheckedGet<VtArray<TfToken>>(), AI_TYPE_STRING));
+                } else if (value.IsHolding<VtArray<SdfAssetPath>>()) {
+                    AiNodeSetArray(
+                        node, paramName,
+                        _ArrayConvert<SdfAssetPath>(value.UncheckedGet<VtArray<SdfAssetPath>>(), AI_TYPE_STRING));
+                } else {
+                    AiMsgError(
+                        "Unsupported string array parameter %s.%s", AiNodeGetName(node),
+                        AiParamGetName(pentry).c_str());
+                }
+                break;
             default:
                 AiMsgError("Unsupported array parameter %s.%s", AiNodeGetName(node), AiParamGetName(pentry).c_str());
         }
@@ -1093,7 +1112,8 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
         case AI_TYPE_NODE:
             break; // TODO(pal): Should be in the relationships list.
         case AI_TYPE_MATRIX:
-            _SetFromValueOrArray<const GfMatrix4d&, const GfMatrix4f&>(node, paramName, value, nodeSetMatrixFromMatrix4d, nodeSetMatrixFromMatrix4f);
+            _SetFromValueOrArray<const GfMatrix4d&, const GfMatrix4f&>(
+                node, paramName, value, nodeSetMatrixFromMatrix4d, nodeSetMatrixFromMatrix4f);
             break;
         case AI_TYPE_ENUM:
             _SetFromValueOrArray<int, long, TfToken, const std::string&>(

--- a/testsuite/test_0134/data/test.cpp
+++ b/testsuite/test_0134/data/test.cpp
@@ -107,6 +107,35 @@ TEST(HdArnoldSetParameter, Array)
     EXPECT_EQ(AiNodeGetStr(node, "subsurface_type"), AtString("randomwalk_v2"));
 }
 
+TEST(HdArnoldSetParameter, StringArray)
+{
+    auto* node = AiNode("polymesh");
+    auto* entry = AiNodeGetNodeEntry(node);
+    auto* traceSetsEntry = AiNodeEntryLookUpParameter(entry, AtString{"trace_sets"});
+    auto compareSets = [&](const std::vector<const char*>& strings) -> bool {
+        const auto* arr = AiNodeGetArray(node, AtString{"trace_sets"});
+        if (AiArrayGetNumElements(arr) != strings.size()) {
+            return false;
+        }
+        auto id = 0;
+        for (auto str : strings) {
+            if (AiArrayGetStr(arr, id) != AtString{str}) {
+                return false;
+            }
+            id += 1;
+        }
+        return true;
+    };
+    HdArnoldSetParameter(node, traceSetsEntry, VtValue{VtArray<std::string>{"set1"}});
+    EXPECT_TRUE(compareSets({"set1"}));
+    HdArnoldSetParameter(node, traceSetsEntry, VtValue{VtArray<TfToken>{TfToken{"set1"}, TfToken{"set2"}}});
+    EXPECT_TRUE(compareSets({"set1", "set2"}));
+    HdArnoldSetParameter(
+        node, traceSetsEntry,
+        VtValue{VtArray<SdfAssetPath>{SdfAssetPath{"/set1"}, SdfAssetPath{"/set2"}, SdfAssetPath{"/set3"}}});
+    EXPECT_TRUE(compareSets({"/set1", "/set2", "/set3"}));
+}
+
 TEST(HdArnoldSetParameter, AssetPath)
 {
     auto* node = AiNode("image");


### PR DESCRIPTION
**Changes proposed in this pull request**
- Converting string/token/asset path primvar arrays to built-in string arrays.
- Updating test 134 to cover the new functionality.

**Issues fixed in this pull request**
Fixes #808