### PR TITLE
Revamping visibility, sidedness and autobump_visibility support and c…

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -536,7 +536,8 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
 #else
                     primvar.name
 #endif
-                    ));
+                    ),
+                nullptr, nullptr, nullptr);
         }
         const auto filtersValue = sceneDelegate->GetLightParamValue(id, _tokens->filters);
         if (filtersValue.IsHolding<SdfPathVector>()) {

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -236,11 +236,7 @@ void HdArnoldMesh::Sync(
         AiNodeSetArray(GetArnoldNode(), str::shidxs, HdArnoldGetShidxs(topology.GetGeomSubsets(), numFaces, _subsets));
     }
 
-    if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        param.Interrupt();
-        _UpdateVisibility(sceneDelegate, dirtyBits);
-        SetShapeVisibility(_sharedData.visible ? AI_RAY_ALL : uint8_t{0});
-    }
+    CheckVisibilityAndSidedness(sceneDelegate, id, dirtyBits, param);
 
     if (HdChangeTracker::IsDisplayStyleDirty(*dirtyBits, id)) {
         param.Interrupt();
@@ -315,9 +311,11 @@ void HdArnoldMesh::Sync(
 
     if (dirtyPrimvars) {
         HdArnoldGetPrimvars(sceneDelegate, id, *dirtyBits, _numberOfPositionKeys > 1, _primvars);
+        _visibilityFlags.ClearPrimvarFlags();
+        _sidednessFlags.ClearPrimvarFlags();
+        _autobumpVisibilityFlags.ClearPrimvarFlags();
         param.Interrupt();
         const auto isVolume = _IsVolume();
-        auto visibility = GetShapeVisibility();
         for (auto& primvar : _primvars) {
             auto& desc = primvar.second;
             if (!desc.NeedsUpdate()) {
@@ -325,7 +323,9 @@ void HdArnoldMesh::Sync(
             }
 
             if (desc.interpolation == HdInterpolationConstant) {
-                HdArnoldSetConstantPrimvar(GetArnoldNode(), primvar.first, desc.role, desc.value, &visibility);
+                HdArnoldSetConstantPrimvar(
+                    GetArnoldNode(), primvar.first, desc.role, desc.value, &_visibilityFlags, &_sidednessFlags,
+                    &_autobumpVisibilityFlags);
             } else if (desc.interpolation == HdInterpolationVertex || desc.interpolation == HdInterpolationVarying) {
                 if (primvar.first == _tokens->st || primvar.first == _tokens->uv) {
                     _ConvertVertexPrimvarToBuiltin<GfVec2f, AI_TYPE_VECTOR2>(
@@ -373,7 +373,9 @@ void HdArnoldMesh::Sync(
             }
         }
 
-        SetShapeVisibility(visibility);
+        UpdateVisibilityAndSidedness();
+        const auto autobumpVisibility = _autobumpVisibilityFlags.Compose();
+        AiNodeSetByte(GetArnoldNode(), str::autobump_visibility, autobumpVisibility);
         // The mesh has changed, so we need to reassign materials.
         if (isVolume != _IsVolume()) {
             assignMaterials();
@@ -394,9 +396,9 @@ void HdArnoldMesh::Sync(
 HdDirtyBits HdArnoldMesh::GetInitialDirtyBitsMask() const
 {
     return HdChangeTracker::Clean | HdChangeTracker::InitRepr | HdChangeTracker::DirtyPoints |
-           HdChangeTracker::DirtyDisplayStyle | HdChangeTracker::DirtySubdivTags | HdChangeTracker::DirtyTopology |
-           HdChangeTracker::DirtyTransform | HdChangeTracker::DirtyMaterialId | HdChangeTracker::DirtyPrimvar |
-           HdChangeTracker::DirtyVisibility | HdArnoldShape::GetInitialDirtyBitsMask();
+           HdChangeTracker::DirtyDisplayStyle | HdChangeTracker::DirtyDoubleSided | HdChangeTracker::DirtySubdivTags |
+           HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyTransform | HdChangeTracker::DirtyMaterialId |
+           HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyVisibility | HdArnoldShape::GetInitialDirtyBitsMask();
 }
 
 bool HdArnoldMesh::_IsVolume() const { return AiNodeGetFlt(GetArnoldNode(), str::step_size) > 0.0f; }

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -785,8 +785,11 @@ inline bool _TokenStartsWithToken(const TfToken& t0, const TfToken& t1)
 
 inline bool _CharStartsWithToken(const char* c, const TfToken& t) { return strncmp(c, t.GetText(), t.size()) == 0; }
 
-inline uint8_t _GetRayFlag(uint8_t currentFlag, const char* rayName, const VtValue& value)
+inline void _SetRayFlag(const char* rayName, const VtValue& value, HdArnoldRayFlags* flags)
 {
+    if (flags == nullptr) {
+        return;
+    }
     auto flag = true;
     if (value.IsHolding<bool>()) {
         flag = value.UncheckedGet<bool>();
@@ -795,8 +798,8 @@ inline uint8_t _GetRayFlag(uint8_t currentFlag, const char* rayName, const VtVal
     } else if (value.IsHolding<long>()) {
         flag = value.UncheckedGet<long>() != 0;
     } else {
-        // Invalid value stored, just return the existing value.
-        return currentFlag;
+        // Invalid value stored, exit.
+        return;
     }
     uint8_t bitFlag = 0;
     if (_CharStartsWithToken(rayName, _tokens->camera)) {
@@ -813,13 +816,11 @@ inline uint8_t _GetRayFlag(uint8_t currentFlag, const char* rayName, const VtVal
         bitFlag = AI_RAY_DIFFUSE_REFLECT;
     } else if (_CharStartsWithToken(rayName, _tokens->specular_reflect)) {
         bitFlag = AI_RAY_SPECULAR_REFLECT;
+    } else {
+        // Invalid flag name, exit.
+        return;
     }
-    return flag ? (currentFlag | bitFlag) : (currentFlag & ~bitFlag);
-}
-
-inline void _SetRayFlag(AtNode* node, const AtString& paramName, const char* rayName, const VtValue& value)
-{
-    AiNodeSetByte(node, paramName, _GetRayFlag(AiNodeGetByte(node, paramName), rayName, value));
+    flags->SetPrimvarFlag(bitFlag, flag);
 }
 
 // We are using function pointers instead of template arguments to deduct the function type, because
@@ -1126,7 +1127,9 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
     }
 }
 
-bool ConvertPrimvarToBuiltinParameter(AtNode* node, const TfToken& name, const VtValue& value, uint8_t* visibility)
+bool ConvertPrimvarToBuiltinParameter(
+    AtNode* node, const TfToken& name, const VtValue& value, HdArnoldRayFlags* visibility, HdArnoldRayFlags* sidedness,
+    HdArnoldRayFlags* autobumpVisibility)
 {
     if (!_TokenStartsWithToken(name, _tokens->arnoldPrefix)) {
         return false;
@@ -1137,21 +1140,17 @@ bool ConvertPrimvarToBuiltinParameter(AtNode* node, const TfToken& name, const V
     // primvars:arnold:visibility:xyz where xyz is a name of a ray type.
     if (_CharStartsWithToken(paramName, _tokens->visibilityPrefix)) {
         const auto* rayName = paramName + _tokens->visibilityPrefix.size();
-        if (visibility == nullptr) {
-            _SetRayFlag(node, str::visibility, rayName, value);
-        } else {
-            *visibility = _GetRayFlag(*visibility, rayName, value);
-        }
+        _SetRayFlag(rayName, value, visibility);
         return true;
     }
     if (_CharStartsWithToken(paramName, _tokens->sidednessPrefix)) {
         const auto* rayName = paramName + _tokens->sidednessPrefix.size();
-        _SetRayFlag(node, str::sidedness, rayName, value);
+        _SetRayFlag(rayName, value, sidedness);
         return true;
     }
     if (_CharStartsWithToken(paramName, _tokens->autobumpVisibilityPrefix)) {
         const auto* rayName = paramName + _tokens->autobumpVisibilityPrefix.size();
-        _SetRayFlag(node, str::autobump_visibility, rayName, value);
+        _SetRayFlag(rayName, value, autobumpVisibility);
         return true;
     }
     const auto* nodeEntry = AiNodeGetNodeEntry(node);
@@ -1163,10 +1162,11 @@ bool ConvertPrimvarToBuiltinParameter(AtNode* node, const TfToken& name, const V
 }
 
 void HdArnoldSetConstantPrimvar(
-    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value, uint8_t* visibility)
+    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value, HdArnoldRayFlags* visibility,
+    HdArnoldRayFlags* sidedness, HdArnoldRayFlags* autobumpVisibility)
 {
     // Remap primvars:arnold:xyz parameters to xyz parameters on the node.
-    if (ConvertPrimvarToBuiltinParameter(node, name, value, visibility)) {
+    if (ConvertPrimvarToBuiltinParameter(node, name, value, visibility, sidedness, autobumpVisibility)) {
         return;
     }
     const auto isColor = role == HdPrimvarRoleTokens->color;
@@ -1220,10 +1220,11 @@ void HdArnoldSetConstantPrimvar(
 
 void HdArnoldSetConstantPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const HdPrimvarDescriptor& primvarDesc,
-    uint8_t* visibility)
+    HdArnoldRayFlags* visibility, HdArnoldRayFlags* sidedness, HdArnoldRayFlags* autobumpVisibility)
 {
     HdArnoldSetConstantPrimvar(
-        node, primvarDesc.name, primvarDesc.role, sceneDelegate->Get(id, primvarDesc.name), visibility);
+        node, primvarDesc.name, primvarDesc.role, sceneDelegate->Get(id, primvarDesc.name), visibility, sidedness,
+        autobumpVisibility);
 }
 
 void HdArnoldSetUniformPrimvar(AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value)

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -50,6 +50,50 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+/// Utility class to handle ray flags for shapes.
+class HdArnoldRayFlags {
+public:
+    /// Default constructor.
+    HdArnoldRayFlags() = default;
+
+    /// Constructor to set up the hydra flag.
+    ///
+    /// @param hydraFlag Value of the Hydra flag.
+    HdArnoldRayFlags(uint8_t hydraFlag) : _hydraFlag(hydraFlag) {}
+
+    /// Compose the ray flags to set on an Arnold shape. Bitflags set from primvars will override flags from Hydra.
+    ///
+    /// @return Value of the composed ray flags.
+    uint8_t Compose() const { return (_hydraFlag & ~_primvarFlagState) | (_primvarFlags & _primvarFlagState); }
+
+    /// Sets the flags coming from Hydra.
+    ///
+    /// @param flag Value of the flags from Hydra.
+    void SetHydraFlag(uint8_t flag) { _hydraFlag = flag; }
+
+    /// Set the flag coming from primvars.
+    ///
+    /// @param flag
+    /// @param state
+    void SetPrimvarFlag(uint8_t flag, bool state)
+    {
+        _primvarFlags = state ? _primvarFlags | flag : _primvarFlags & ~flag;
+        _primvarFlagState |= flag;
+    }
+
+    /// Clears the primvar flags and resets to their default state.
+    void ClearPrimvarFlags()
+    {
+        _primvarFlags = AI_RAY_ALL;
+        _primvarFlagState = 0;
+    }
+
+private:
+    uint8_t _hydraFlag = 0;             ///< Ray flags coming from Hydra.
+    uint8_t _primvarFlags = AI_RAY_ALL; ///< Ray flags coming from primvars.
+    uint8_t _primvarFlagState = 0;      ///< State of each flag coming from primvars.
+};
+
 constexpr unsigned int HD_ARNOLD_MAX_PRIMVAR_SAMPLES = 3;
 template <typename T>
 using HdArnoldSampledType = HdTimeSampleArray<T, HD_ARNOLD_MAX_PRIMVAR_SAMPLES>;
@@ -109,10 +153,13 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
 /// @param name Name of the primvar.
 /// @param value Value of the primvar.
 /// @param visibility Pointer to the output visibility parameter.
+/// @param sidedness Pointer to the output sidedness parameter.
+/// @param autobumpVisibility Pointer to the output autobump_visibility parameter.
 /// @return Returns true if the conversion was successful.
 HDARNOLD_API
 bool ConvertPrimvarToBuiltinParameter(
-    AtNode* node, const TfToken& name, const VtValue& value, uint8_t* visibility = nullptr);
+    AtNode* node, const TfToken& name, const VtValue& value, HdArnoldRayFlags* visibility, HdArnoldRayFlags* sidedness,
+    HdArnoldRayFlags* autobumpVisibility);
 /// Sets a Constant scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// There is some additional type remapping done to deal with various third
@@ -128,9 +175,12 @@ bool ConvertPrimvarToBuiltinParameter(
 /// @param role Role of the primvar.
 /// @param value Value of the primvar.
 /// @param visibility Pointer to the output visibility parameter.
+/// @param sidedness Pointer to the output sidedness parameter.
+/// @param autobumpVisibility Pointer to the output autobump_visibility parameter.
 HDARNOLD_API
 void HdArnoldSetConstantPrimvar(
-    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value, uint8_t* visibility = nullptr);
+    AtNode* node, const TfToken& name, const TfToken& role, const VtValue& value, HdArnoldRayFlags* visibility,
+    HdArnoldRayFlags* sidedness, HdArnoldRayFlags* autobumpVisibility);
 /// Sets a Constant scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// There is some additional type remapping done to deal with various third
@@ -146,10 +196,12 @@ void HdArnoldSetConstantPrimvar(
 /// @param sceneDelegate Pointer to the Scene Delegate.
 /// @param primvarDesc Description of the primvar.
 /// @param visibility Pointer to the output visibility parameter.
+/// @param sidedness Pointer to the output sidedness parameter.
+/// @param autobumpVisibility Pointer to the output autobump_visibility parameter.
 HDARNOLD_API
 void HdArnoldSetConstantPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const HdPrimvarDescriptor& primvarDesc,
-    uint8_t* visibility = nullptr);
+    HdArnoldRayFlags* visibility, HdArnoldRayFlags* sidedness, HdArnoldRayFlags* autobumpVisibility);
 /// Sets a Uniform scope Primvar on an Arnold node from a Hydra Primitive.
 ///
 /// @param node Pointer to an Arnold Node.

--- a/render_delegate/volume.h
+++ b/render_delegate/volume.h
@@ -134,10 +134,12 @@ protected:
         }
     }
 
-    HdArnoldRenderDelegate* _renderDelegate;      ///< Pointer to the Render Delegate.
-    HdArnoldMaterialTracker _materialTracker;     ///< Utility to track material assignments to the volume.
-    std::vector<HdArnoldShape*> _volumes;         ///< Vector storing all the Volumes created.
-    std::vector<HdArnoldShape*> _inMemoryVolumes; ///< Vectoring storing all the Volumes for in-memory VDB storage.
+    HdArnoldRenderDelegate* _renderDelegate;       ///< Pointer to the Render Delegate.
+    HdArnoldMaterialTracker _materialTracker;      ///< Utility to track material assignments to the volume.
+    std::vector<HdArnoldShape*> _volumes;          ///< Vector storing all the Volumes created.
+    std::vector<HdArnoldShape*> _inMemoryVolumes;  ///< Vectoring storing all the Volumes for in-memory VDB storage.
+    HdArnoldRayFlags _visibilityFlags{AI_RAY_ALL}; ///< Visibility of the shape.
+    HdArnoldRayFlags _sidednessFlags{AI_RAY_SUBSURFACE}; ///< Sidedness of the shape.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/testsuite/test_0146/data/test.cpp
+++ b/testsuite/test_0146/data/test.cpp
@@ -30,35 +30,54 @@ std::vector<AtString> _GetStringArray(const AtNode* node, const char* paramName)
 TEST(HdArnoldSetConstantPrimvar, SingleString)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue{std::string{"hello"}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue{std::string{"hello"}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetStr(node, "primvar1"), AtString{"hello"});
-    HdArnoldSetConstantPrimvar(node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue{TfToken{"world"}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue{TfToken{"world"}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetStr(node, "primvar2"), AtString{"world"});
-    HdArnoldSetConstantPrimvar(node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue{SdfAssetPath{"mypath"}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue{SdfAssetPath{"mypath"}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetStr(node, "primvar3"), AtString{"mypath"});
 }
 
-#define TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(FUNCNAME)                                                                   \
+#define TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(FUNCNAME, ADDITIONAL_PARAMS)                                                \
     TEST(FUNCNAME, StringsArray)                                                                                     \
     {                                                                                                                \
         auto* node = AiNode("polymesh");                                                                             \
         FUNCNAME(                                                                                                    \
-            node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none,                                                    \
-            VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});                              \
+            node, TfToken{"primvar1"}, HdPrimvarRoleTokens->none, VtValue {                                          \
+                VtArray<std::string>                                                                                 \
+                {                                                                                                    \
+                    std::string{"hello"}, std::string { "world" }                                                    \
+                }                                                                                                    \
+            } ADDITIONAL_PARAMS);                                                                                    \
         EXPECT_EQ(_GetStringArray(node, "primvar1"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
         FUNCNAME(                                                                                                    \
-            node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none,                                                    \
-            VtValue{VtArray<TfToken>{TfToken{"hello"}, TfToken{"world"}}});                                          \
+            node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtValue {                                          \
+                VtArray<TfToken>                                                                                     \
+                {                                                                                                    \
+                    TfToken{"hello"}, TfToken { "world" }                                                            \
+                }                                                                                                    \
+            } ADDITIONAL_PARAMS);                                                                                    \
         EXPECT_EQ(_GetStringArray(node, "primvar2"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
         FUNCNAME(                                                                                                    \
-            node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none,                                                    \
-            VtValue{VtArray<SdfAssetPath>{SdfAssetPath{"hello"}, SdfAssetPath{"world"}}});                           \
+            node, TfToken{"primvar3"}, HdPrimvarRoleTokens->none, VtValue {                                          \
+                VtArray<SdfAssetPath>                                                                                \
+                {                                                                                                    \
+                    SdfAssetPath{"hello"}, SdfAssetPath { "world" }                                                  \
+                }                                                                                                    \
+            } ADDITIONAL_PARAMS);                                                                                    \
         EXPECT_EQ(_GetStringArray(node, "primvar3"), std::vector<AtString>({AtString{"hello"}, AtString{"world"}})); \
     }
 
-TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetConstantPrimvar)
-TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetUniformPrimvar)
-TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetVertexPrimvar)
+#define NULLPTR_ADDITONAL_PARAMS , nullptr, nullptr, nullptr
+#define EMPTY_ADDITIONAL_PARAMS
+
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetConstantPrimvar, NULLPTR_ADDITONAL_PARAMS)
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetUniformPrimvar, EMPTY_ADDITIONAL_PARAMS)
+TEST_SET_PRIMVAR_ARRAY_FUNCTIONS(HdArnoldSetVertexPrimvar, EMPTY_ADDITIONAL_PARAMS)
 
 TEST(HdArnoldSetInstancePrimvar, StringArray)
 {
@@ -96,8 +115,7 @@ TEST(HdArnoldSetInstancePrimvar, InvalidIndex)
         node, TfToken{"primvar2"}, HdPrimvarRoleTokens->none, VtIntArray{0, 42, -1337},
         VtValue{VtArray<std::string>{std::string{"hello"}, std::string{"world"}}});
     EXPECT_EQ(
-        _GetStringArray(node, "instance_primvar2"),
-        std::vector<AtString>({AtString{"hello"}, AtString{}, AtString{}}));
+        _GetStringArray(node, "instance_primvar2"), std::vector<AtString>({AtString{"hello"}, AtString{}, AtString{}}));
 }
 
 int main(int argc, char** argv)

--- a/testsuite/test_0152/data/test.cpp
+++ b/testsuite/test_0152/data/test.cpp
@@ -21,14 +21,17 @@ TEST(HdArnoldSetConstantPrimvar, HalfColorBuiltin)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{GfVec4h{1.0f, 2.0f, 3.0f, 4.0f}});
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{GfVec4h{1.0f, 2.0f, 3.0f, 4.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(1.0f, 2.0f, 3.0f, 4.0f));
     node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4fArray{GfVec4h{2.0f, 3.0f, 4.0f, 5.0f}}});
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4fArray{GfVec4h{2.0f, 3.0f, 4.0f, 5.0f}}},
+        nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(2.0f, 3.0f, 4.0f, 5.0f));
     node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4hArray{}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4hArray{}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(0.0f, 0.0f, 0.0f, 0.0f));
 }
 
@@ -36,99 +39,120 @@ TEST(HdArnoldSetConstantPrimvar, DoubleColorBuiltin)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{GfVec4d{1.0f, 2.0f, 3.0f, 4.0f}});
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{GfVec4d{1.0f, 2.0f, 3.0f, 4.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(1.0f, 2.0f, 3.0f, 4.0f));
     node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4dArray{GfVec4d{2.0f, 3.0f, 4.0f, 5.0f}}});
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4dArray{GfVec4d{2.0f, 3.0f, 4.0f, 5.0f}}},
+        nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(2.0f, 3.0f, 4.0f, 5.0f));
     node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4dArray{}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"color"}, HdPrimvarRoleTokens->color, VtValue{VtVec4dArray{}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "color"), AtRGBA(0.0f, 0.0f, 0.0f, 0.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, Half)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfHalf{2.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfHalf{2.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetFlt(node, "test1"), 2.0f);
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:subdiv_adaptive_error"}, HdPrimvarRoleTokens->none, VtValue{GfHalf{0.5f}});
+        node, TfToken{"arnold:subdiv_adaptive_error"}, HdPrimvarRoleTokens->none, VtValue{GfHalf{0.5f}}, nullptr,
+        nullptr, nullptr);
     EXPECT_EQ(AiNodeGetFlt(node, "subdiv_adaptive_error"), 0.5f);
 }
 
 TEST(HdArnoldSetConstantPrimvar, Double)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{2.0});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{2.0}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetFlt(node, "test1"), 2.0f);
-    HdArnoldSetConstantPrimvar(node, TfToken{"arnold:subdiv_adaptive_error"}, HdPrimvarRoleTokens->none, VtValue{0.5});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"arnold:subdiv_adaptive_error"}, HdPrimvarRoleTokens->none, VtValue{0.5}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetFlt(node, "subdiv_adaptive_error"), 0.5f);
 }
 
 TEST(HdArnoldSetConstantPrimvar, Half2)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec2h{1.0f, 2.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec2h{1.0f, 2.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetVec2(node, "test1"), AtVector2(1.0f, 2.0f));
     node = AiNode("image");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:uvcoords"}, HdPrimvarRoleTokens->none, VtValue{GfVec2h{2.0f, 3.0f}});
+        node, TfToken{"arnold:uvcoords"}, HdPrimvarRoleTokens->none, VtValue{GfVec2h{2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetVec2(node, "uvcoords"), AtVector2(2.0f, 3.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, Double2)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec2d{1.0f, 2.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec2d{1.0f, 2.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetVec2(node, "test1"), AtVector2(1.0f, 2.0f));
     node = AiNode("image");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:uvcoords"}, HdPrimvarRoleTokens->none, VtValue{GfVec2d{2.0f, 3.0f}});
+        node, TfToken{"arnold:uvcoords"}, HdPrimvarRoleTokens->none, VtValue{GfVec2d{2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetVec2(node, "uvcoords"), AtVector2(2.0f, 3.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, Half3)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec3h{1.0f, 2.0f, 3.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec3h{1.0f, 2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetVec(node, "test1"), AtVector(1.0f, 2.0f, 3.0f));
     node = AiNode("noise");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:scale"}, HdPrimvarRoleTokens->none, VtValue{GfVec3h{2.0f, 3.0f, 4.0f}});
+        node, TfToken{"arnold:scale"}, HdPrimvarRoleTokens->none, VtValue{GfVec3h{2.0f, 3.0f, 4.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetVec(node, "scale"), AtVector(2.0f, 3.0f, 4.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, Double3)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec3d{1.0f, 2.0f, 3.0f}});
+    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{GfVec3d{1.0f, 2.0f, 3.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetVec(node, "test1"), AtVector(1.0f, 2.0f, 3.0f));
     node = AiNode("noise");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:scale"}, HdPrimvarRoleTokens->none, VtValue{GfVec3d{2.0f, 3.0f, 4.0f}});
+        node, TfToken{"arnold:scale"}, HdPrimvarRoleTokens->none, VtValue{GfVec3d{2.0f, 3.0f, 4.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetVec(node, "scale"), AtVector(2.0f, 3.0f, 4.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, ColorHalf3)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3h{1.0f, 2.0f, 3.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3h{1.0f, 2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGB(node, "test1"), AtRGB(1.0f, 2.0f, 3.0f));
     node = AiNode("noise");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:color1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3h{2.0f, 3.0f, 4.0f}});
+        node, TfToken{"arnold:color1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3h{2.0f, 3.0f, 4.0f}}, nullptr,
+        nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGB(node, "color1"), AtRGB(2.0f, 3.0f, 4.0f));
 }
 
 TEST(HdArnoldSetConstantPrimvar, ColorDouble3)
 {
     auto* node = AiNode("polymesh");
-    HdArnoldSetConstantPrimvar(node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3d{1.0f, 2.0f, 3.0f}});
+    HdArnoldSetConstantPrimvar(
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3d{1.0f, 2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGB(node, "test1"), AtRGB(1.0f, 2.0f, 3.0f));
     node = AiNode("noise");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"arnold:color1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3d{2.0f, 3.0f, 4.0f}});
+        node, TfToken{"arnold:color1"}, HdPrimvarRoleTokens->color, VtValue{GfVec3d{2.0f, 3.0f, 4.0f}}, nullptr,
+        nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGB(node, "color1"), AtRGB(2.0f, 3.0f, 4.0f));
 }
 
@@ -136,12 +160,13 @@ TEST(HdArnoldSetConstantPrimvar, ColorHalf4)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec4h{1.0f, 2.0f, 3.0f, 4.0f}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec4h{1.0f, 2.0f, 3.0f, 4.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "test1"), AtRGBA(1.0f, 2.0f, 3.0f, 4.0f));
     node = AiNode("image");
     HdArnoldSetConstantPrimvar(
         node, TfToken{"arnold:missing_texture_color"}, HdPrimvarRoleTokens->color,
-        VtValue{GfVec4h{2.0f, 3.0f, 4.0f, 5.0f}});
+        VtValue{GfVec4h{2.0f, 3.0f, 4.0f, 5.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "missing_texture_color"), AtRGBA(2.0f, 3.0f, 4.0f, 5.0f));
 }
 
@@ -149,12 +174,13 @@ TEST(HdArnoldSetConstantPrimvar, ColorDouble4)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec4d{1.0f, 2.0f, 3.0f, 4.0f}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->color, VtValue{GfVec4d{1.0f, 2.0f, 3.0f, 4.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "test1"), AtRGBA(1.0f, 2.0f, 3.0f, 4.0f));
     node = AiNode("image");
     HdArnoldSetConstantPrimvar(
         node, TfToken{"arnold:missing_texture_color"}, HdPrimvarRoleTokens->color,
-        VtValue{GfVec4d{2.0f, 3.0f, 4.0f, 5.0f}});
+        VtValue{GfVec4d{2.0f, 3.0f, 4.0f, 5.0f}}, nullptr, nullptr, nullptr);
     EXPECT_EQ(AiNodeGetRGBA(node, "missing_texture_color"), AtRGBA(2.0f, 3.0f, 4.0f, 5.0f));
 }
 

--- a/testsuite/test_0153/data/test.cpp
+++ b/testsuite/test_0153/data/test.cpp
@@ -37,7 +37,8 @@ TEST(HdArnoldSetConstantPrimvar, HalfArray)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfHalf>{1.0f, 2.0f, 3.0f}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfHalf>{1.0f, 2.0f, 3.0f}}, nullptr, nullptr,
+        nullptr);
     EXPECT_TRUE(_Compare<float>(AiNodeGetArray(node, "test1"), {1.0f, 2.0f, 3.0f}));
 }
 
@@ -45,7 +46,8 @@ TEST(HdArnoldSetConstantPrimvar, DoubleArray)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<double>{1.0, 2.0, 3.0}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<double>{1.0, 2.0, 3.0}}, nullptr, nullptr,
+        nullptr);
     EXPECT_TRUE(_Compare<float>(AiNodeGetArray(node, "test1"), {1.0f, 2.0f, 3.0f}));
 }
 
@@ -53,7 +55,8 @@ TEST(HdArnoldSetConstantPrimvar, Half2Array)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec2h>{{1.0f, 2.0f}, {3.0f, 4.0f}}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec2h>{{1.0f, 2.0f}, {3.0f, 4.0f}}},
+        nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec2f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f}, {3.0f, 4.0f}}));
 }
 
@@ -61,7 +64,8 @@ TEST(HdArnoldSetConstantPrimvar, Double2Array)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec2d>{{1.0, 2.0}, {3.0, 4.0}}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec2d>{{1.0, 2.0}, {3.0, 4.0}}}, nullptr,
+        nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec2f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f}, {3.0f, 4.0f}}));
 }
 
@@ -70,11 +74,11 @@ TEST(HdArnoldSetConstantPrimvar, Half3Array)
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
         node, TfToken{"test1"}, HdPrimvarRoleTokens->none,
-        VtValue{VtArray<GfVec3h>{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}});
+        VtValue{VtArray<GfVec3h>{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}}, nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec3f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}));
     HdArnoldSetConstantPrimvar(
         node, TfToken{"test2"}, HdPrimvarRoleTokens->color,
-        VtValue{VtArray<GfVec3h>{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}});
+        VtValue{VtArray<GfVec3h>{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}}, nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec3f>(AiNodeGetArray(node, "test2"), {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}));
     EXPECT_EQ(AiArrayGetType(AiNodeGetArray(node, "test2")), AI_TYPE_RGB);
 }
@@ -83,11 +87,12 @@ TEST(HdArnoldSetConstantPrimvar, Double3Array)
 {
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec3d>{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}});
+        node, TfToken{"test1"}, HdPrimvarRoleTokens->none, VtValue{VtArray<GfVec3d>{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}},
+        nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec3f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}));
     HdArnoldSetConstantPrimvar(
-        node, TfToken{"test2"}, HdPrimvarRoleTokens->color,
-        VtValue{VtArray<GfVec3d>{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}});
+        node, TfToken{"test2"}, HdPrimvarRoleTokens->color, VtValue{VtArray<GfVec3d>{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}},
+        nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec3f>(AiNodeGetArray(node, "test2"), {{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}));
     EXPECT_EQ(AiArrayGetType(AiNodeGetArray(node, "test2")), AI_TYPE_RGB);
 }
@@ -97,7 +102,7 @@ TEST(HdArnoldSetConstantPrimvar, Half4Array)
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
         node, TfToken{"test1"}, HdPrimvarRoleTokens->none,
-        VtValue{VtArray<GfVec4h>{{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}}});
+        VtValue{VtArray<GfVec4h>{{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}}}, nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec4f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}}));
 }
 
@@ -106,7 +111,7 @@ TEST(HdArnoldSetConstantPrimvar, Double4Array)
     auto* node = AiNode("polymesh");
     HdArnoldSetConstantPrimvar(
         node, TfToken{"test1"}, HdPrimvarRoleTokens->none,
-        VtValue{VtArray<GfVec4d>{{1.0, 2.0, 3.0, 4.0}, {5.0, 6.0, 7.0, 8.0}}});
+        VtValue{VtArray<GfVec4d>{{1.0, 2.0, 3.0, 4.0}, {5.0, 6.0, 7.0, 8.0}}}, nullptr, nullptr, nullptr);
     EXPECT_TRUE(_Compare<GfVec4f>(AiNodeGetArray(node, "test1"), {{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 7.0f, 8.0f}}));
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Revamping the handling of visibility, sidedness, and autobump_visibility.
- Extending tests 134 and 146 to cover the new functionality.
- Setting constant primvars on Arnold native prims and converting them to built-in attributes following the logic of other rprims.
- Removing unused functions from HdArnoldRprim.
- Using the hydra/USD doubleSided parameter.

**Issues fixed in this pull request**
Fixes #805
Fixes #741