### PR TITLE
Adding BUILD_BOOST_ALL_NO_LIB to the cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ if (NOT BUILD_USE_CUSTOM_BOOST)
         find_package(Boost REQUIRED)
     endif ()
 endif ()
+# This disables explicit linking from boost headers on Windows.
+if (BUILD_BOOST_ALL_NO_LIB AND WIN32)
+    add_compile_definitions(BOOST_ALL_NO_LIB=1)
+    # This is for Houdini's boost libs.
+    add_compile_definitions(HBOOST_ALL_NO_LIB=1)
+endif ()
+
 find_package(TBB REQUIRED)
 
 configure_file(

--- a/cmake/utils/options.cmake
+++ b/cmake/utils/options.cmake
@@ -17,6 +17,7 @@ option(USD_STATIC_BUILD "USD is built as a static, monolithic library." OFF)
 option(TBB_STATIC_BUILD "TBB is built as a static library." OFF)
 option(TBB_NO_EXPLICIT_LINKAGE "Explicit linkage of TBB libraries is disabled on windows." OFF)
 option(BUILD_USE_CUSTOM_BOOST "Using a custom boost layout." OFF)
+option(BUILD_BOOST_ALL_NO_LIB "Disable linking of boost libraries from boost headers." OFF)
 option(BUILD_DISABLE_CXX11_ABI "Disable the use of the new CXX11 ABI" OFF)
 option(BUILD_HEADERS_AS_SOURCES "Add headers are source files to the target to help when generating IDE projects." OFF)
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding BUILD_BOOST_ALL_NO_LIB to the cmake configuration.

**Issues fixed in this pull request**
Fixes #828