### PR TITLE
Adding override decorator for GetBuiltinPrimvarNames if PXR_VERSION >= 2002

### DIFF
--- a/render_delegate/native_rprim.h
+++ b/render_delegate/native_rprim.h
@@ -49,7 +49,12 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     HDARNOLD_API
+#if PXR_VERSION >= 2002
+    const TfTokenVector& GetBuiltinPrimvarNames() const override;
+#else
     const TfTokenVector& GetBuiltinPrimvarNames() const;
+#endif
+
 
 private:
     /// List of parameters to query from the Hydra Primitive.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding override decorator for GetBuiltinPrimvarNames if PXR_VERSION >= 2002.

**Issues fixed in this pull request**
Fixes #830
