### PR TITLE
Adding velocity and acceleration based interpolation to points and removing USD_HAS_UPDATED_TIME_SAMPLE_ARRAY from hdarnold.h (#673)

### DIFF
--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -73,7 +73,7 @@ void HdArnoldBasisCurves::Sync(
                                (*dirtyBits & HdChangeTracker::DirtyPrimvar);
     if (_primvars.count(HdTokens->points) == 0 && HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
         param.Interrupt();
-        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points);
+        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points, param());
     }
 
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {

--- a/render_delegate/hdarnold.h
+++ b/render_delegate/hdarnold.h
@@ -15,13 +15,6 @@
 
 #include "../arnold_usd.h"
 
-#if PXR_VERSION >= 1911
-/// Hydra has the new renderer plugin base class
-#define USD_HAS_UPDATED_TIME_SAMPLE_ARRAY
-/// Hydra has the updated render buffer class.
-#define USD_HAS_UPDATED_RENDER_BUFFER
-#endif
-
 #if PXR_VERSION >= 2002
 /// Depth range in Hydra was changed from -1 .. 1 to 0 .. 1.
 #define USD_HAS_ZERO_TO_ONE_DEPTH

--- a/render_delegate/native_rprim.h
+++ b/render_delegate/native_rprim.h
@@ -55,7 +55,6 @@ public:
     const TfTokenVector& GetBuiltinPrimvarNames() const;
 #endif
 
-
 private:
     /// List of parameters to query from the Hydra Primitive.
     const HdArnoldRenderDelegate::NativeRprimParamList* _paramList = nullptr;

--- a/render_delegate/points.h
+++ b/render_delegate/points.h
@@ -63,13 +63,16 @@ public:
     /// Syncs the Hydra Points to the Arnold Points.
     ///
     /// @param sceneDelegate Pointer to the Scene Delegate.
-    /// @param renderPaaram Pointer to a HdArnoldRenderParam instance.
+    /// @param renderParam Pointer to a HdArnoldRenderParam instance.
     /// @param dirtyBits Dirty Bits to sync.
     /// @param reprToken Token describing the representation of the points.
     HDARNOLD_API
     void Sync(
         HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits,
         const TfToken& reprToken) override;
+
+private:
+    HdArnoldPrimvarMap _primvars; ///< Precomputed list of primvars.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_buffer.cpp
+++ b/render_delegate/render_buffer.cpp
@@ -219,11 +219,7 @@ bool HdArnoldRenderBuffer::Allocate(const GfVec3i& dimensions, HdFormat format, 
     return true;
 }
 
-#ifdef USD_HAS_UPDATED_RENDER_BUFFER
 void* HdArnoldRenderBuffer::Map()
-#else
-uint8_t* HdArnoldRenderBuffer::Map()
-#endif
 {
     _mutex.lock();
     if (_buffer.empty()) {

--- a/render_delegate/render_buffer.h
+++ b/render_delegate/render_buffer.h
@@ -68,11 +68,7 @@ public:
     /// Map the buffer for reading.
     /// @return The render buffer mapped to memory.
     HDARNOLD_API
-#ifdef USD_HAS_UPDATED_RENDER_BUFFER
     void* Map() override;
-#else
-    uint8_t* Map() override;
-#endif
     /// Unmap the buffer. It is no longer safe to read from the buffer.
     HDARNOLD_API
     void Unmap() override;

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -338,7 +338,7 @@ public:
     /// @param shutterClose Shutter Close value of the active camera.
     /// @return True if the iteration should be skipped.
     HDARNOLD_API
-    bool ShouldSkipIteration(HdRenderIndex* renderIndex, float shutterOpen, float shutterClose);
+    bool ShouldSkipIteration(HdRenderIndex* renderIndex, const GfVec2f& shutter);
 
     using DelegateRenderProducts = std::vector<HdArnoldDelegateRenderProduct>;
     /// Returns the list of available Delegate Render Products.
@@ -468,11 +468,11 @@ private:
     AtNode* _fallbackShader;       ///< Pointer to the fallback Arnold Shader.
     AtNode* _fallbackVolumeShader; ///< Pointer to the fallback Arnold Volume Shader.
     std::string _logFile;
+    /// FPS value from render settings.
+    float _fps;
     /// Top level render context using Hydra. Ie. Hydra, Solaris, Husk.
     HdArnoldRenderContext _context = HdArnoldRenderContext::Hydra;
     int _verbosityLogFlags = AI_LOG_WARNINGS | AI_LOG_ERRORS;
-    float _shutterOpen = 0.0f;  ///< Saved Shutter Open value of the active camera.
-    float _shutterClose = 0.0f; ///< Saved Shutter Close value of the active camera.
     bool _ignoreVerbosityLogFlags = false;
 };
 

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -171,4 +171,22 @@ void HdArnoldRenderParam::Restart()
     _needsRestart.store(true, std::memory_order_release);
 }
 
+bool HdArnoldRenderParam::UpdateShutter(const GfVec2f& shutter)
+{
+    if (!GfIsClose(_shutter[0], shutter[0], AI_EPSILON) || !GfIsClose(_shutter[1], shutter[1], AI_EPSILON)) {
+        _shutter = shutter;
+        return true;
+    }
+    return false;
+}
+
+bool HdArnoldRenderParam::UpdateFPS(const float FPS)
+{
+    if (!GfIsClose(_fps, FPS, AI_EPSILON)) {
+        _fps = FPS;
+        return true;
+    }
+    return false;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -34,7 +34,11 @@
 
 #include <pxr/pxr.h>
 
+#include <pxr/base/gf/vec2f.h>
+
 #include <pxr/imaging/hd/renderDelegate.h>
+
+#include <ai.h>
 
 #include "hdarnold.h"
 
@@ -90,6 +94,33 @@ public:
     HDARNOLD_API
     void Restart();
 
+    /// Gets the shutter range.
+    ///
+    /// @return Constant reference to the shutter range.
+    const GfVec2f& GetShutterRange() const { return _shutter; }
+
+    /// Gets the FPS.
+    ///
+    /// @return Constant reference to the FPS.
+    const float& GetFPS() const { return _fps; }
+
+    /// Tells if shutter is instananeous.
+    ///
+    /// @return True if shutter range is zero, false otherwise.
+    bool InstananeousShutter() const { return GfIsClose(_shutter[0], _shutter[1], AI_EPSILON); }
+
+    /// Updates the shutter range.
+    ///
+    /// @param shutter New shutter range to use.
+    /// @return True if shutter range has changed.
+    bool UpdateShutter(const GfVec2f& shutter);
+
+    /// Updates the FPS.
+    ///
+    /// @param FPS New FPS to use.
+    /// @return True if FPS has changed.
+    bool UpdateFPS(const float FPS);
+
 private:
 #ifdef ARNOLD_MULTIPLE_RENDER_SESSIONS
     /// The render delegate
@@ -101,6 +132,10 @@ private:
     std::atomic<bool> _aborted;
     /// Indicate if rendering has been paused.
     std::atomic<bool> _paused;
+    /// Shutter range.
+    GfVec2f _shutter = {0.0f, 0.0f};
+    /// FPS.
+    float _fps = 24.0f;
 };
 
 class HdArnoldRenderParamInterrupt {
@@ -120,6 +155,16 @@ public:
             _param->Interrupt();
         }
     }
+
+    /// Returns a constant pointer to HdArnoldRenderParam.
+    ///
+    /// @return Const pointer to HdArnoldRenderParam.
+    const HdArnoldRenderParam* operator()() const { return _param; }
+
+    /// Returns a pointer to HdArnoldRenderParam.
+    ///
+    /// @return Pointer to HdArnoldRenderParam.
+    HdArnoldRenderParam* operator()() { return _param; }
 
 private:
     /// Indicate if the render has been interrupted already.

--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -799,8 +799,8 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     // We skip an iteration step if the render delegate tells us to do so, this is the easiest way to force
     // a sync step before calling the render function. Currently, this is used to trigger light linking updates.
     const auto renderStatus = _renderDelegate->ShouldSkipIteration(
-                                  GetRenderIndex(), AiNodeGetFlt(currentCamera, str::shutter_start),
-                                  AiNodeGetFlt(currentCamera, str::shutter_end))
+                                  GetRenderIndex(), {AiNodeGetFlt(currentCamera, str::shutter_start),
+                                                     AiNodeGetFlt(currentCamera, str::shutter_end)})
                                   ? HdArnoldRenderParam::Status::Converging
                                   : renderParam->Render();
     _isConverged = renderStatus != HdArnoldRenderParam::Status::Converging;

--- a/render_delegate/rprim.h
+++ b/render_delegate/rprim.h
@@ -154,6 +154,14 @@ public:
         TF_UNUSED(dirtyBits);
     }
 
+    bool SetDeformKeys(int keys)
+    {
+        _deformKeys = static_cast<decltype(_deformKeys)>(std::max(0, keys));
+        return _deformKeys > 0;
+    }
+
+    uint8_t GetDeformKeys() const { return _deformKeys; }
+
 protected:
     HdArnoldShape _shape;                                     ///< HdArnoldShape to handle instances and shape creation.
     HdArnoldRenderDelegate* _renderDelegate;                  ///< Pointer to the Arnold Render Delegate.
@@ -161,6 +169,7 @@ protected:
     HdArnoldRayFlags _visibilityFlags{AI_RAY_ALL};            ///< Visibility of the shape.
     HdArnoldRayFlags _sidednessFlags{AI_RAY_SUBSURFACE};      ///< Sidedness of the shape.
     HdArnoldRayFlags _autobumpVisibilityFlags{AI_RAY_CAMERA}; ///< Autobump visibility of the shape.
+    uint8_t _deformKeys = HD_ARNOLD_MAX_PRIMVAR_SAMPLES;      ///< Number of deform keys.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -48,6 +48,8 @@
 
 #include <vector>
 
+#include "render_param.h"
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// Utility class to handle ray flags for shapes.
@@ -100,6 +102,58 @@ using HdArnoldSampledType = HdTimeSampleArray<T, HD_ARNOLD_MAX_PRIMVAR_SAMPLES>;
 using HdArnoldSampledPrimvarType = HdArnoldSampledType<VtValue>;
 using HdArnoldSampledMatrixType = HdArnoldSampledType<GfMatrix4d>;
 using HdArnoldSampledMatrixArrayType = HdArnoldSampledType<VtMatrix4dArray>;
+
+/// Struct storing the cached primvars.
+struct HdArnoldPrimvar {
+    VtValue value;                 ///< Copy-On-Write Value of the primvar.
+    TfToken role;                  ///< Role of the primvar.
+    HdInterpolation interpolation; ///< Type of interpolation used for the value.
+    bool dirtied;                  ///< If the primvar has been dirtied.;
+
+    ///< Constructor for creating the primvar description.
+    ///
+    /// @param _value Value to be stored for the primvar.
+    /// @param _interpolation Interpolation type for the primvar.
+    HdArnoldPrimvar(const VtValue& _value, const TfToken& _role, HdInterpolation _interpolation)
+        : value(_value), role(_role), interpolation(_interpolation), dirtied(true)
+    {
+    }
+
+    bool NeedsUpdate()
+    {
+        if (dirtied) {
+            dirtied = false;
+            return true;
+        }
+        return false;
+    }
+};
+
+/// Hash map for storing precomputed primvars.
+using HdArnoldPrimvarMap = std::unordered_map<TfToken, HdArnoldPrimvar, TfToken::HashFunctor>;
+
+/// Unboxing sampled type with type checking and no error codes thrown. Count on @param out will be equal to the number
+/// of samples that could be converted. Sample conversion exits as soon as a single sample doesn't hold the correct
+/// type.
+///
+/// Alternative to HdTimeSampleArray::UnboxFrom which uses the error-throwing VtValue::Get function.
+///
+/// @param in Input value holding the boxed samples.
+/// @param out Output value with the specified type.
+template <typename T>
+void HdArnoldUnboxSample(const HdArnoldSampledType<VtValue>& in, HdArnoldSampledType<T>& out)
+{
+    const auto count = std::min(std::min(static_cast<uint32_t>(in.count), in.values.size()), in.times.size());
+    out.Resize(count);
+    out.count = 0;
+    for (auto i = decltype(count){0}; i < count; i += 1, out.count += 1) {
+        if (!in.values[i].IsHolding<T>()) {
+            break;
+        }
+        out.values[i] = in.values[i].UncheckedGet<T>();
+        out.times[i] = in.times[i];
+    }
+}
 
 using HdArnoldSubsets = std::vector<SdfPath>;
 
@@ -278,19 +332,28 @@ void HdArnoldSetInstancePrimvar(
     AtNode* node, const TfToken& name, const TfToken& role, const VtIntArray& indices, const VtValue& value);
 /// Sets positions attribute on an Arnold shape from a VtVec3fArray primvar.
 ///
+/// If velocities or accelerations are non-zero, the shutter range is non-instantaneous and the scene delegate only
+/// returns a single primvar sample, velocities and accelerations are used to extrapolate positions.
+///
 /// @param node Pointer to an Arnold node.
 /// @param paramName Name of the positions parameter on the Arnold node.
 /// @param id Path to the Hydra Primitive.
 /// @param sceneDelegate Pointer to the Scene Delegate.
+/// @param param Constant pointer to the Arnold Render param struct.
+/// @param deformKeys Number of geometry time samples to extrapolate when using acceleration.
+/// @param primvars Optional constant pointer to all the available primvars on a primitive.
 /// @return Number of keys for the position.
 HDARNOLD_API
 size_t HdArnoldSetPositionFromPrimvar(
-    AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const AtString& paramName);
+    AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const AtString& paramName,
+    const HdArnoldRenderParam* param, int deformKeys = HD_ARNOLD_MAX_PRIMVAR_SAMPLES,
+    const HdArnoldPrimvarMap* primvars = nullptr);
 /// Sets positions attribute on an Arnold shape from a VtValue holding VtVec3fArray.
 ///
 /// @param node Pointer to an Arnold node.
 /// @param paramName Name of the positions parameter on the Arnold node.
 /// @param value Value holding a VtVec3fArray.
+HDARNOLD_API
 void HdArnoldSetPositionFromValue(AtNode* node, const AtString& paramName, const VtValue& value);
 /// Sets radius attribute on an Arnold shape from a float primvar.
 ///
@@ -315,35 +378,6 @@ void HdArnoldSetRadiusFromPrimvar(AtNode* node, const SdfPath& id, HdSceneDelega
 HDARNOLD_API
 AtArray* HdArnoldGenerateIdxs(
     unsigned int numIdxs, const VtIntArray* vertexCounts = nullptr, const size_t* vertexCountSum = nullptr);
-
-/// Struct storing the cached primvars.
-struct HdArnoldPrimvar {
-    VtValue value;                 ///< Copy-On-Write Value of the primvar.
-    TfToken role;                  ///< Role of the primvar.
-    HdInterpolation interpolation; ///< Type of interpolation used for the value.
-    bool dirtied;                  ///< If the primvar has been dirtied.;
-
-    ///< Constructor for creating the primvar description.
-    ///
-    /// @param _value Value to be stored for the primvar.
-    /// @param _interpolation Interpolation type for the primvar.
-    HdArnoldPrimvar(const VtValue& _value, const TfToken& _role, HdInterpolation _interpolation)
-        : value(_value), role(_role), interpolation(_interpolation), dirtied(true)
-    {
-    }
-
-    bool NeedsUpdate()
-    {
-        if (dirtied) {
-            dirtied = false;
-            return true;
-        }
-        return false;
-    }
-};
-
-/// Storing precomputed primvars.
-using HdArnoldPrimvarMap = std::unordered_map<TfToken, HdArnoldPrimvar, TfToken::HashFunctor>;
 
 /// Insert a primvar into a primvar map. Add a new entry if the primvar is not part of the map, otherwise update
 /// the existing entry.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding velocity and acceleration based interpolation to points.
- removing `USD_HAS_UPDATED_TIME_SAMPLE_ARRAY` from hdarnold.h.
- Adding a new `HdArnoldUnboxSample` to simplify dealing with hydra primvar samples.

**Issues fixed in this pull request**
Fixes #832

**Additional context**
The pr contains work for #673
