### PR TITLE
Adding missing defines to constant_strings.h and fixing test_0045/data/test.cpp.

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -61,6 +61,8 @@ ASTR2(catmull_rom, "catmull-rom");
 ASTR2(constantArray, "constant ARRAY");
 ASTR2(constantArrayFloat, "CONSTANT ARRAY FLOAT");
 ASTR2(constantInt, "constant INT");
+ASTR2(deformKeys, "arnold:deform_keys");
+ASTR2(houdiniFps, "houdini:fps");
 ASTR2(hydraPrimId, "hydra_primId");
 ASTR2(inputs_code, "inputs:code");
 ASTR2(primvars_arnold_subdiv_type, "primvars:arnold:subdiv_type");

--- a/testsuite/test_0045/data/test.cpp
+++ b/testsuite/test_0045/data/test.cpp
@@ -5,6 +5,8 @@
 #include "translator/writer/registry.h"
 #include "translator/writer/write_geometry.h"
 
+#include <common_utils.h>
+
 #include <string>
 #include <vector>
 
@@ -14,6 +16,7 @@ TEST(ArnoldUsdMakeCamelCase, ArnoldUsdMakeCamelCase)
 {
     EXPECT_EQ(ArnoldUsdMakeCamelCase("camelCase"), "camelCase");
     EXPECT_EQ(ArnoldUsdMakeCamelCase("snake_case"), "snakeCase");
+    EXPECT_EQ(ArnoldUsdMakeCamelCase("_snake_case"), "SnakeCase");
     EXPECT_EQ(ArnoldUsdMakeCamelCase("snake__case"), "snakeCase");
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Adding missing deformKeys and houdiniFps defines to constant_strings.
- Including common_utils in test_0045 and adding a new test for ArnoldUsdMakeCamelCase.

**Additional context**
These are changes missing from #833 and I noticed a build error with test_0045.