### PR TITLE
Changing the fallback shader to standard surface.

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -423,17 +423,15 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(HdArnoldRenderContext context) : 
 #else
     AiRenderSetHintStr(str::render_context, _context == HdArnoldRenderContext::Hydra ? str::hydra : str::husk);
 #endif
-    _fallbackShader = AiNode(_universe, str::utility);
+    _fallbackShader = AiNode(_universe, str::standard_surface);
     AiNodeSetStr(_fallbackShader, str::name, AtString(TfStringPrintf("fallbackShader_%p", _fallbackShader).c_str()));
-    AiNodeSetStr(_fallbackShader, str::shade_mode, str::ambocc);
-    AiNodeSetStr(_fallbackShader, str::color_mode, str::color);
     auto* userDataReader = AiNode(_universe, str::user_data_rgb);
     AiNodeSetStr(
         userDataReader, str::name,
         AtString(TfStringPrintf("fallbackShader_userDataReader_%p", userDataReader).c_str()));
     AiNodeSetStr(userDataReader, str::attribute, str::displayColor);
     AiNodeSetRGB(userDataReader, str::_default, 1.0f, 1.0f, 1.0f);
-    AiNodeLink(userDataReader, str::color, _fallbackShader);
+    AiNodeLink(userDataReader, str::base_color, _fallbackShader);
 
     _fallbackVolumeShader = AiNode(_universe, str::standard_volume);
     AiNodeSetStr(


### PR DESCRIPTION
**Changes proposed in this pull request**
- Changing the fallback shader to standard surface.

**Issues fixed in this pull request**
Fixes #861

**Additional context**
Forcing the fallback shader on the ALAB scene.
Using the current utility shader:
![alab_utility](https://user-images.githubusercontent.com/582376/129144037-99ab76f0-7613-449c-94c8-417419277e61.png)
After the PR:
![alab_standard_surface](https://user-images.githubusercontent.com/582376/129144058-75317f37-408c-4867-8f90-53523aaabb61.png)
We might want to wait until #462 is fixed, so in case of no lighting in the scene, we can still see something.