### PR TITLE
Enforce writing multiple frames when no default is authored

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -1036,6 +1036,20 @@ void UsdArnoldPrimWriter::_WriteMatrix(UsdGeomXformable& xformable, const AtNode
 
     UsdGeomXformOp xformOp = xformable.MakeMatrixXform();
     UsdAttribute attr = xformOp.GetAttr();
+
+    if (!writer.GetAuthoredFrames().empty()) {
+        VtValue previousVal;
+        // If previous frames were authored, we want to verify
+        // that a value was already set. If not, it means that
+        // the previous value was an identify matrix, and thus
+        // skipped a few lines above. We need to set it now
+        // before we call SetAttribute (see #871)
+        if (!attr.Get(&previousVal)) {
+            GfMatrix4d m;
+            attr.Set(m);
+        }
+    }
+
     std::vector<double> xform;
     xform.reserve(16);
     // Get array of times based on motion_start / motion_end

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -91,6 +91,8 @@ public:
     }
     void CreateHierarchy(const SdfPath &path, bool leaf = true) const;
 
+    const std::vector<float> &GetAuthoredFrames() const {return _authoredFrames;}
+
     /** Set a parameter value on a usd attribute. If we're appending data from varying times, 
      *  this function will take care of creating time samples if needed, or just keeping a 
      *  constant value otherwise. A sub-frame can eventually be provided, in case we need to 
@@ -112,7 +114,11 @@ public:
                     // so far it just has a constant value. 
                     // We want to check if it's different from the current one
                     VtValue previousVal;
-                    if (attr.Get(&previousVal) && previousVal != value) {
+                    if (!attr.Get(&previousVal))
+                    {
+                        // couldn't get the previous value, just set the current time
+                        attr.Set(value, subFrame ? GetTime(*subFrame) : GetTime());
+                    } else if (previousVal != value) {
                         // the attribute value has changed since the previously 
                         // authored frame ! We need to make it time-varying now
 


### PR DESCRIPTION
**Changes proposed in this pull request**
When appending matrix attributes to existing usd files, if no value was previously authored, it means that it was originally equal to identity matrix. In that case we ensure that a default value is set before calling `writer.SetAttribute`.
In this later function, we also ensure that we set the attribute value if no value had been previously authored.

**Issues fixed in this pull request**
Fixes #871
