### PR TITLE
Expose additional path for schemas generation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -74,6 +74,7 @@ vars.AddVariables(
     PathVariable('TBB_INCLUDE', 'Where to find TBB headers.', os.getenv('TBB_INCLUDE', None)),
     PathVariable('TBB_LIB', 'Where to find TBB libraries', os.getenv('TBB_LIB', None)),
     BoolVariable('TBB_STATIC', 'Whether we link against a static TBB library', False),
+    StringVariable('SCHEMA_PREPEND_PATH', 'Folder to prepend to the PATH environment to run usdGenSchema', None),
     # Google test dependency
     PathVariable('GOOGLETEST_PATH', 'Google Test installation root', '.', PathVariable.PathAccept),
     PathVariable('GOOGLETEST_INCLUDE', 'Where to find Google Test includes', os.path.join('$GOOGLETEST_PATH', 'include'), PathVariable.PathAccept),

--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -84,8 +84,18 @@ myenv = env.Clone()
 myenv.AppendENVPath('PYTHONPATH', os.path.join(myenv['USD_LIB'], 'python'), envname='ENV', sep=env_separator, delete_existing=1)
 os.environ['PYTHONPATH'] = myenv['ENV']['PYTHONPATH']
 os.putenv('PYTHONPATH', os.environ['PYTHONPATH'])
+myenv.AppendENVPath('PATH', env['USD_LIB'], envname='ENV', sep=env_separator, delete_existing=1)
 myenv.AppendENVPath('PATH', env['USD_BIN'], envname='ENV', sep=env_separator, delete_existing=1)
+
+schemaPath = myenv.get('SCHEMA_PREPEND_PATH')
+if schemaPath:
+    myenv.PrependENVPath('PATH', schemaPath, envname='ENV', sep=env_separator, delete_existing=1)
+    os.environ['PATH'] = myenv['ENV']['PATH']
+    os.putenv('PATH', os.environ['PATH'])
+
+
 genSchema = os.path.join(env['USD_BIN'], 'usdGenSchema')
+
 if not os.path.exists(genSchema):
     raise RuntimeError('Command {} not found. Impossible to generate Schemas'.format(genSchema))
 

--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -84,14 +84,19 @@ myenv = env.Clone()
 myenv.AppendENVPath('PYTHONPATH', os.path.join(myenv['USD_LIB'], 'python'), envname='ENV', sep=env_separator, delete_existing=1)
 os.environ['PYTHONPATH'] = myenv['ENV']['PYTHONPATH']
 os.putenv('PYTHONPATH', os.environ['PYTHONPATH'])
-myenv.AppendENVPath('PATH', env['USD_LIB'], envname='ENV', sep=env_separator, delete_existing=1)
+# usd libs need to be loaded by usdGenSchema
+myenv.AppendENVPath(dylib, env['USD_LIB'], envname='ENV', sep=env_separator, delete_existing=1)
 myenv.AppendENVPath('PATH', env['USD_BIN'], envname='ENV', sep=env_separator, delete_existing=1)
 
 schemaPath = myenv.get('SCHEMA_PREPEND_PATH')
 if schemaPath:
+    # we need to ensure that when usdGenSchema will run "python", it will run the proper one
     myenv.PrependENVPath('PATH', schemaPath, envname='ENV', sep=env_separator, delete_existing=1)
     os.environ['PATH'] = myenv['ENV']['PATH']
     os.putenv('PATH', os.environ['PATH'])
+    if not IS_WINDOWS:
+        # for linux/mac, we also need to ensure the usd python modules will load the proper python dso
+        myenv.PrependENVPath(dylib, schemaPath, envname='ENV', sep=env_separator, delete_existing=1)
 
 
 genSchema = os.path.join(env['USD_BIN'], 'usdGenSchema')


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds an optional build variable `SCHEMA_PREPEND_PATH`. When set, the given folder is prepended to the environment PATH  before running `usdGenSchema`. 
This allows to run usdGenSchema with a specific python distribution that is different from the system's default one.
I also had to add USD_LIB to the path, so that the usd libs can be found. I'm not sure why the current code currently adds instead USD_BIN to the path. I first wanted to remove it and replace it with USD_LIB, but in case this is needed for HtoA I kept the existing one.

**Issues fixed in this pull request**
Fixes #874
