### PR TITLE
Provide a custom command for usdGenSchema

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -110,6 +110,7 @@ vars.AddVariables(
     StringVariable('USD_MONOLITHIC_LIBRARY', 'Name of the USD monolithic library', 'usd_ms'),
     StringVariable('PYTHON_LIB_NAME', 'Name of the python library', 'python27'),
     StringVariable('USD_PROCEDURAL_NAME', 'Name of the usd procedural.', 'usd'),
+    StringVariable('USDGENSCHEMA_CMD', 'Custom command to run usdGenSchema', None),
     ('TEST_PATTERN', 'Glob pattern of tests to be run', 'test_*'),
     ('KICK_PARAMS', 'Additional parameters for kick', '-v 6')
 )

--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -85,8 +85,17 @@ myenv.AppendENVPath('PYTHONPATH', os.path.join(myenv['USD_LIB'], 'python'), envn
 os.environ['PYTHONPATH'] = myenv['ENV']['PYTHONPATH']
 os.putenv('PYTHONPATH', os.environ['PYTHONPATH'])
 myenv.AppendENVPath('PATH', env['USD_BIN'], envname='ENV', sep=env_separator, delete_existing=1)
+# Ensure USD libs will be found when loaded by the python modules
+myenv.AppendENVPath(dylib, env['USD_LIB'], envname='ENV', sep=env_separator, delete_existing=1)
+os.environ['PATH'] = myenv['ENV']['PATH']   
+os.putenv('PATH', os.environ['PATH'])
+
 genSchema = os.path.join(env['USD_BIN'], 'usdGenSchema')
-if not os.path.exists(genSchema):
+
+if env.get('USDGENSCHEMA_CMD'):
+    # A custom usdGenSchema command was provided, let's run it
+    genSchema = env['USDGENSCHEMA_CMD']
+elif not os.path.exists(genSchema):
     raise RuntimeError('Command {} not found. Impossible to generate Schemas'.format(genSchema))
 
 if not os.path.exists(schemasBuildFolder):
@@ -109,8 +118,9 @@ if generateSchemaFiles:
         'schemaFile': schemaFile,
         'output': schemasBuildFolder
     })
+    print(cmd)
     os.system(cmd)
-
+    
     # We are running the external command
     from updatePlugInfo import update_plug_info
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR exposes a new build argument `USDGENSCHEMA_CMD` that is used to override the original `usdGenSchema` command used to generate the schemas. This can be used if a specific cut of usd is used for the schemas, or if we need to run it with a specific python cut. In our current use case, we want to build schemas for Maya, and we need to run `mayapy usdGenSchemas`.

**Issues fixed in this pull request**
Fixes #874
