### PR TITLE
Fixing testsuite issues using 21.02+ and supporting new and old light parameter naming conventions.

### DIFF
--- a/testsuite/test_0015/data/scene.usda
+++ b/testsuite/test_0015/data/scene.usda
@@ -20,6 +20,7 @@ def "World"
         {
             uniform token info:id = "arnold:flat"
             color3f inputs:color = (0,0,1)
+            token outputs:surface
         }
     }
 
@@ -41,6 +42,7 @@ def "World"
         {
             uniform token info:id = "arnold:standard_surface"
             color3f inputs:base_color = (0.5,1,1)
+            token outputs:surface
         }
     }
 

--- a/testsuite/test_0140/data/test.usda
+++ b/testsuite/test_0140/data/test.usda
@@ -159,14 +159,14 @@ def Xform "lights"
         prepend apiSchemas = ["ShapingAPI"]
     )
     {
-        color3f color = (1, 0.3, 0.2)
-        float diffuse = 1
-        bool enableColorTemperature = 0
-        float exposure = 7
-        float intensity = 2
-        bool normalize = 1
-        asset shaping:ies:file = "file.ies"
-        float specular = 1
+        color3f inputs:color = (1, 0.3, 0.2)
+        float inputs:diffuse = 1
+        bool inputs:enableColorTemperature = 0
+        float inputs:exposure = 7
+        float inputs:intensity = 2
+        bool inputs:normalize = 1
+        asset inputs:shaping:ies:file = "file.ies"
+        float inputs:specular = 1
         bool treatAsPoint = 0
         matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 0.7037717123658266, -0.7104261938257008, 0), (0, 0.7104261938257008, 0.7037717123658266, 0), (0, 4, 0, 1) )
         uniform token[] xformOpOrder = ["xformOp:transform"]

--- a/testsuite/test_0181/data/test.usda
+++ b/testsuite/test_0181/data/test.usda
@@ -76,16 +76,21 @@ def Xform "pointLight1"(apiSchemas = ["CollectionAPI:lightLink", "CollectionAPI:
 {
     def SphereLight "pointLightShape1"
     {
-        color3f color = (1, 0, 0)
-        float diffuse = 1
-        float exposure = 0
-        float intensity = 64
+        color3f inputs:color = (1, 0, 0)
+        float inputs:diffuse = 1
+        float inputs:exposure = 0
+        float inputs:intensity = 64
+        color3f color = (1, 1, 1)
+        float diffuse = 5
+        float exposure = 2
+        float intensity = 14
         vector3f[] primvars:arnold:position = [(0, 0, 0)]
         string primvars:dcc_name = "pointLightShape1" (
             elementSize = 1
             interpolation = "constant"
         )
-        float specular = 1
+        float inputs:specular = 1
+        float specular = 5
         bool treatAsPoint = 1
         matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 6.294501781463623, 3.448580503463745, 1) )
         uniform token[] xformOpOrder = ["xformOp:transform"]
@@ -112,7 +117,8 @@ def Xform "transform1"
         color3f color = (0, 1, 0)
         float diffuse = 1
         float exposure = 0
-        float height = 2
+        float inputs:height = 2
+        float height = 20
         float intensity = 64
         bool normalize = 1
         string[] primvars:arnold:filters = ["defaultLightDecay"]
@@ -122,7 +128,8 @@ def Xform "transform1"
             interpolation = "constant"
         )
         float specular = 1
-        float width = 2
+        float width = 15
+        float inputs:width = 2
         matrix4d xformOp:transform = ( (0.95982426404953, 0.28060176968574524, 0, 0), (0.012077394872903824, -0.0413118451833725, -0.999073326587677, 0), (-0.2803417146205902, 0.9589348435401917, -0.04304105043411255, 0), (0, 6.185134410858154, 0, 1) )
         uniform token[] xformOpOrder = ["xformOp:transform"]
 
@@ -145,8 +152,10 @@ def Xform "transform2"
 {
     def DomeLight "aiSkyDomeLight"
     {
-        color3f color = (1, 1, 1)
-        prepend color3f color.connect = </ramp1.outputs:out>
+        color3f inputs:color = (1, 1, 1)
+        prepend color3f inputs:color.connect = </ramp1.outputs:out>
+        color3f color = (0.5, 0.5, 0.5)
+        prepend color3f color.connect = </ramp2.outputs:out>
         float diffuse = 1
         float exposure = 0
         float intensity = 1
@@ -190,6 +199,19 @@ def Shader "ramp1"
 {
     uniform token info:id = "arnold:ramp_rgb"
     color3f[] inputs:color = [(0.185, 0.13418667, 0.032560002), (0.753, 0.753, 1), (0, 0, 1)]
+    int[] inputs:interpolation = [1, 1, 1]
+    string inputs:name = "ramp1"
+    float[] inputs:position = [0.45, 0.5, 1]
+    string inputs:type = "v"
+    string inputs:use_implicit_uvs = "curves_only"
+    bool inputs:wrap_uvs = 1
+    color3f outputs:out
+}
+
+def Shader "ramp2"
+{
+    uniform token info:id = "arnold:ramp_rgb"
+    color3f[] inputs:color = [(0.585, 0.53418667, 0.032560002), (0.753, 0.753, 1), (0, 0, 1)]
     int[] inputs:interpolation = [1, 1, 1]
     string inputs:name = "ramp1"
     float[] inputs:position = [0.45, 0.5, 1]

--- a/translator/reader/read_light.cpp
+++ b/translator/reader/read_light.cpp
@@ -148,7 +148,7 @@ void _ReadLightCommon(const UsdLuxLight& light, AtNode *node, const TimeSettings
 
     /*
     This is preventing distant lights from working properly, so we should only
-    do it where it makes sense VtValue normalizeAttr;thank
+    do it where it makes sense VtValue normalizeAttr.
     if(light.GetNormalizeAttr().Get(&normalizeAttr, time.frame))
        AiNodeSetBool(node, "normalize", normalizeAttr.Get<bool>());
     */


### PR DESCRIPTION
**Changes proposed in this pull request**
- Supporting both new and old light parameter naming conventions, without using the UsdLux APIs.
- Changing tests 140 and 181, so we make sure the new parameters are preferred over the old ones.
- Fixing test 15 with 21.08.
- Adding support for animated color temperature.

**Issues fixed in this pull request**
Fixes #880
Fixes #772

**Additional context**
I benchmarked the new code vs the old code, using the worst possible case: when no parameters are set we are checking both the new and old parameter names. The results were: 1-3 seconds when translating 1 million UsdLux lights to Arnold primitives on a single thread. This means about 1-3 microseconds of overhead for each light, which seems acceptable.

In scenes with many lights (above 10k), we have significant other overheads than just 10ms+ introduced in this PR.
