### PR TITLE
Only call AiBegin/AiEnd in the delegate if no arnold session is active

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -349,12 +349,16 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(HdArnoldRenderContext context) : 
 {
     _lightLinkingChanged.store(false, std::memory_order_release);
     _id = SdfPath(TfToken(TfStringPrintf("/HdArnoldRenderDelegate_%p", this)));
-    if (AiUniverseIsActive()) {
-        TF_CODING_ERROR("There is already an active Arnold universe!");
+
+    // We first need to check if arnold has already been initialized.
+    // If not, we need to call AiBegin, and the destructor on we'll call AiEnd
+    _isArnoldActive = AiUniverseIsActive();
+    if (!_isArnoldActive) {
+        // TODO(pal): We need to investigate if it's safe to set session to AI_SESSION_BATCH when rendering in husk for
+        //  example. ie. is husk creating a separate render delegate for each frame, or syncs the changes?
+        AiBegin(AI_SESSION_INTERACTIVE);    
     }
-    // TODO(pal): We need to investigate if it's safe to set session to AI_SESSION_BATCH when rendering in husk for
-    //  example. ie. is husk creating a separate render delegate for each frame, or syncs the changes?
-    AiBegin(AI_SESSION_INTERACTIVE);
+    
     _supportedRprimTypes = {
         HdPrimTypeTokens->mesh, HdPrimTypeTokens->volume, HdPrimTypeTokens->points, HdPrimTypeTokens->basisCurves};
     auto* shapeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHAPE);
@@ -466,7 +470,10 @@ HdArnoldRenderDelegate::~HdArnoldRenderDelegate()
 #endif
     hdArnoldUninstallNodes();
     AiUniverseDestroy(_universe);
-    AiEnd();
+    // We must end the arnold session, only if we created it during the constructor.
+    // Otherwise we could be destroying a session that is being used elsewhere
+    if (!_isArnoldActive)
+        AiEnd();
 }
 
 HdRenderParam* HdArnoldRenderDelegate::GetRenderParam() const { return _renderParam.get(); }

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -474,6 +474,7 @@ private:
     HdArnoldRenderContext _context = HdArnoldRenderContext::Hydra;
     int _verbosityLogFlags = AI_LOG_WARNINGS | AI_LOG_ERRORS;
     bool _ignoreVerbosityLogFlags = false;
+    bool _isArnoldActive = false;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
As it's being done in other parts of the code, we only call AiBegin/AiEnd if no Arnold session is active.
Note that this arnold API will be renamed as AiArnoldIsActive, in order to avoid confusions with universes that are something different. That's why the variable I'm adding is called isArnoldActive.

Fixes #884
