### PR TITLE
Using GetVolumeShader if native rprim is volume

### DIFF
--- a/render_delegate/native_rprim.cpp
+++ b/render_delegate/native_rprim.cpp
@@ -83,7 +83,11 @@ void HdArnoldNativeRprim::Sync(
         const auto* material = reinterpret_cast<const HdArnoldMaterial*>(
             sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
         if (material != nullptr) {
-            AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetSurfaceShader());
+            if (AiNodeIs(GetArnoldNode(), str::volume)) {
+                AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetVolumeShader());
+            } else {
+                AiNodeSetPtr(GetArnoldNode(), str::shader, material->GetSurfaceShader());
+            }
         } else {
             AiNodeResetParameter(GetArnoldNode(), str::shader);
         }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Using GetVolumeShader if native rprim is volume.

**Issues fixed in this pull request**
Fixes #915