### PR TITLE
Don't write the default color manager node to usd 

### DIFF
--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -150,9 +150,10 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
 
     static const AtString rootStr("root");
     static const AtString ai_default_reflection_shaderStr("ai_default_reflection_shader");
+    static const AtString ai_default_color_managerStr("ai_default_color_manager_ocio");
 
     // some Arnold nodes shouldn't be saved
-    if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr) {
+    if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr || nodeName == ai_default_color_managerStr) {
         return;
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
Just as we were doing for the default reflection shader, we're now ensuring we don't write out the default color manager node.

**Issues fixed in this pull request**
Fixes #924 
