### PR TITLE
Add writer API to skip material bindings #939

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -1132,6 +1132,10 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
 void UsdArnoldPrimWriter::_WriteMaterialBinding(
     const AtNode* node, UsdPrim& prim, UsdArnoldWriter& writer, AtArray* shidxsArray)
 {
+
+    if (!writer.GetWriteMaterialBindings())
+        return;
+
     _exportedAttrs.insert("shader");
     _exportedAttrs.insert("disp_map");
 

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -37,6 +37,7 @@ public:
         : _universe(nullptr),
           _registry(nullptr),
           _writeBuiltin(true),
+          _writeMaterialBindings(true),
           _mask(AI_NODE_ALL),
           _shutterStart(0.f),
           _shutterEnd(0.f),
@@ -89,6 +90,10 @@ public:
         }
         
     }
+
+    bool GetWriteMaterialBindings() const {return _writeMaterialBindings;}
+    void SetWriteMaterialBindings(bool b) {_writeMaterialBindings = b;}
+
     void CreateHierarchy(const SdfPath &path, bool leaf = true) const;
 
     const std::vector<float> &GetAuthoredFrames() const {return _authoredFrames;}
@@ -167,6 +172,7 @@ private:
                                         // registry will be used.
     UsdStageRefPtr _stage;              // USD stage where the primitives are added
     bool _writeBuiltin;                 // do we want to create usd-builtin primitives, or arnold schemas
+    bool _writeMaterialBindings;        // do we want to write usd material bindings (otherwise save arnold shader connections)
     int _mask;                          // Mask based on arnold flags (AI_NODE_SHADER, etc...),
                                         // determining what arnold nodes must be saved out
     float _shutterStart;


### PR DESCRIPTION
**Changes proposed in this pull request**
We add an API in `UsdArnoldWriter` to enable/disable the authoring of USD material bindings. When that option is enabled, we early out in `_WriteMaterialBinding`, thus we don't add `shader` and `disp_map` to the list of arnold attributes that were already exported. Then, in `_WriteArnoldParameters` , we don't see these attributes in the list so we author them as arnold custom attributes with the `primvars:arnold` namespace.

Note that, as the mayaUSD API evolves, we might not need this API anymore. This is why I'm not adding it to the scene format API.

**Issues fixed in this pull request**
Fixes #939 
