### PR TITLE
Add render session to AiMsg calls 

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -399,12 +399,12 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(HdArnoldRenderContext context) : 
     const auto& config = HdArnoldConfig::GetInstance();
     if (config.log_flags_console >= 0) {
         _ignoreVerbosityLogFlags = true;
-        AiMsgSetConsoleFlags(config.log_flags_console);
+        AiMsgSetConsoleFlags(_renderSession, config.log_flags_console);
     } else {
-        AiMsgSetConsoleFlags(_verbosityLogFlags);
+        AiMsgSetConsoleFlags(_renderSession, _verbosityLogFlags);
     }
     if (config.log_flags_file >= 0) {
-        AiMsgSetLogFileFlags(config.log_flags_file);
+        AiMsgSetLogFileFlags(_renderSession, config.log_flags_file);
     }
     hdArnoldInstallNodes();
 
@@ -518,7 +518,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         if (value.IsHolding<int>()) {
             _verbosityLogFlags = _GetLogFlagsFromVerbosity(value.UncheckedGet<int>());
             if (!_ignoreVerbosityLogFlags) {
-                AiMsgSetConsoleFlags(_verbosityLogFlags);
+                AiMsgSetConsoleFlags(_renderSession, _verbosityLogFlags);
             }
         }
     } else if (key == str::t_log_file) {


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds the render session pointer to all calls to `AiMsgSetConsoleFlags` / `AiMsgSetLogFileFlags`, so that they're applied to the delegate's render session

**Issues fixed in this pull request**
Fixes #953 
