### PR TITLE
Support USD 21.11

### DIFF
--- a/schemas/SConscript
+++ b/schemas/SConscript
@@ -52,7 +52,9 @@ schemasBuildFolder = os.path.join(schemasBuildBase, 'source')
 
 schemaFile = os.path.join(schemasBuildBase, 'schema.usda')
 schemaPreviousFile = '{}.bak'.format(schemaFile)
-generateSchemaFiles = (not os.path.exists(schemaPreviousFile))
+
+generatedSchema = os.path.join(schemasBuildFolder, 'generatedSchema.usda')
+generateSchemaFiles = not (os.path.exists(schemaPreviousFile) and os.path.exists(generatedSchema))
 
 '''
 First, call the script createSchemaFiles that will create a file schemas.usda.
@@ -101,7 +103,7 @@ elif not os.path.exists(genSchema):
 if not os.path.exists(schemasBuildFolder):
     os.makedirs(schemasBuildFolder)
     generateSchemaFiles = True
-elif os.path.exists(schemaPreviousFile):
+elif os.path.exists(schemaPreviousFile) and os.path.exists(generatedSchema):
     # we have a backup file. Let's compare it with the new one to see if it has changed
     generateSchemaFiles = (not filecmp.cmp(schemaPreviousFile, schemaFile))
     
@@ -126,7 +128,7 @@ if generateSchemaFiles:
 
     update_plug_info(os.path.join(schemasBuildFolder, 'plugInfo.json'))
 
-generatedSchema = os.path.join(schemasBuildFolder, 'generatedSchema.usda')
+
 plugInfo = os.path.join(schemasBuildFolder, 'plugInfo.json')
 Return([
     'schemaFile',

--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -446,8 +446,8 @@ for entry in entryList:
     createArnoldClass(entryName, parentClass, parametersList, nentry, typeParams[entryTypeName], False)
     
     if entryName in nativeUsdList:
-        createArnoldClass(entryName, parentClass + 'API', parametersList, nentry, 
-            typeParams[entryTypeName] + nativeUsdList[entryName], True)
+        createArnoldClass(entryName, 'APISchemaBase', parametersList, nentry, 
+            nativeUsdList[entryName], True)
 
 
 # --- Special case for custom procedurals. We want a schema ArnoldProceduralCustom,

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -34,9 +34,14 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-void writeLightCommon(const AtNode *node, UsdLuxLight &light, UsdArnoldPrimWriter &primWriter, UsdArnoldWriter &writer)
+void writeLightCommon(const AtNode *node, UsdPrim &prim, UsdArnoldPrimWriter &primWriter, UsdArnoldWriter &writer)
 {
-    UsdPrim prim = light.GetPrim();
+#if PXR_VERSION >= 2111
+    UsdLuxLightAPI light(prim);
+#else
+    UsdLuxLight light(prim);
+#endif
+    
     primWriter.WriteAttribute(node, "intensity", prim, light.GetIntensityAttr(), writer);
     primWriter.WriteAttribute(node, "exposure", prim, light.GetExposureAttr(), writer);
     primWriter.WriteAttribute(node, "color", prim, light.GetColorAttr(), writer);
@@ -56,7 +61,7 @@ void UsdArnoldWriteDistantLight::Write(const AtNode *node, UsdArnoldWriter &writ
     UsdPrim prim = light.GetPrim();
 
     WriteAttribute(node, "angle", prim, light.GetAngleAttr(), writer);
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
     _WriteMatrix(light, node, writer);
     _WriteArnoldParameters(node, writer, prim, "primvars:arnold");
 }
@@ -70,7 +75,7 @@ void UsdArnoldWriteDomeLight::Write(const AtNode *node, UsdArnoldWriter &writer)
     UsdLuxDomeLight light = UsdLuxDomeLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
     _WriteMatrix(light, node, writer);
 
     AtNode *linkedTexture = AiNodeGetLink(node, "color");
@@ -110,7 +115,7 @@ void UsdArnoldWriteDiskLight::Write(const AtNode *node, UsdArnoldWriter &writer)
     UsdLuxDiskLight light = UsdLuxDiskLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
     WriteAttribute(node, "radius", prim, light.GetRadiusAttr(), writer);
     WriteAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
     _WriteMatrix(light, node, writer);
@@ -126,7 +131,7 @@ void UsdArnoldWriteSphereLight::Write(const AtNode *node, UsdArnoldWriter &write
     UsdLuxSphereLight light = UsdLuxSphereLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
 
     float radius = AiNodeGetFlt(node, "radius");
     if (radius > AI_EPSILON) {
@@ -151,7 +156,7 @@ void UsdArnoldWriteRectLight::Write(const AtNode *node, UsdArnoldWriter &writer)
     UsdLuxRectLight light = UsdLuxRectLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
 
     _WriteMatrix(light, node, writer);
     WriteAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
@@ -210,7 +215,7 @@ void UsdArnoldWriteGeometryLight::Write(const AtNode *node, UsdArnoldWriter &wri
     UsdLuxGeometryLight light = UsdLuxGeometryLight::Define(stage, objPath);
     UsdPrim prim = light.GetPrim();
 
-    writeLightCommon(node, light, *this, writer);
+    writeLightCommon(node, prim, *this, writer);
     WriteAttribute(node, "normalize", prim, light.GetNormalizeAttr(), writer);
     _WriteMatrix(light, node, writer);
 


### PR DESCRIPTION
**Changes proposed in this pull request**
In order to compile arnold-usd against USD 21.11, I've just had to do a few changes in the translator code regarding the removal of `UsdLuxLight` 
The code is still compatible with older versions of USD
Testsuite seems to be ok, so we don't need to update test scenes apparently

**Issues fixed in this pull request**
Fixes #957