### PR TITLE
Support connections to array elements in the delegate

### DIFF
--- a/testsuite/test_0048/data/scene.usda
+++ b/testsuite/test_0048/data/scene.usda
@@ -104,7 +104,7 @@ def Shader "ramp1_trigo"
     float inputs:frequency = 6.2831855
     string inputs:function = "sin"
     color3f inputs:input = (0, 0, 0)
-    prepend color3f inputs:input.connect = </ramp1_trigo_input>
+    prepend color3f inputs:input.connect = </ramp1_trigo_input.outputs:out>
     color3f outputs:out
 }
 
@@ -116,6 +116,7 @@ def Shader "ramp1_trigo_input"
     float inputs:g = 0
     prepend float inputs:g.connect = </ramp1_state_u.outputs:out>
     float inputs:r = 0
+    color3f outputs:out
 }
 
 def Shader "ramp1_state_u"


### PR DESCRIPTION
**Changes proposed in this pull request**
When reading shader connections, we consider eventual array connections, using the format that we introduced in #375.
For example, if an array attribute `color` has a connection on its first element (index 0), we will expect in USD a connection on an attribute `color:i0`.  What the delegate needs to do in that case, is to replace that string with `color[0]` which is a format that arnold understands.

In the testsuite we have this use case in test_0048 (a ramp's array color connected to a shader), I verified that it worked well in Solaris. There was a mismatch with the test result though, that ended up being caused by the test scene itself : the output attribute wasn't defined in the scene. This is tolerated in the procedural but not in hydra. I've fixed the test scene to have the expected format, so that we don't get confused again

**Issues fixed in this pull request**
Fixes #970 
