### PR TITLE
Fix arnold node graph adapter for USD 21.08

### DIFF
--- a/usd_imaging/node_graph_adapter.cpp
+++ b/usd_imaging/node_graph_adapter.cpp
@@ -70,9 +70,6 @@ VtValue ArnoldNodeGraphAdapter::GetMaterialResource(
     // since this is simplified.
     HdMaterialNetworkMap materialNetworkMap;
     UsdShadeConnectableAPI connectableAPI(prim);
-    if (!connectableAPI) {
-        return VtValue{materialNetworkMap};
-    }
     const auto outputs = connectableAPI.GetOutputs(true);
     for (auto output : outputs) {
         const auto sources = output.GetConnectedSources();


### PR DESCRIPTION
The ConnectableAPIBehaviour is only available from USD 21.11 see https://github.com/PixarAnimationStudios/USD/blob/v21.11/pxr/usd/usdShade/plugInfo.json

The early out relies on this from apiSchemaBase.h (UsdAPISchemaBase):

/// \note When the bool-conversion operator is invoked on an applied API 
/// schema, it evaluates to true only if the application of the API schema has
/// been recorded on the prim via a call to the auto-generated Apply() method.

To work around this we can skip the early and if the connectable behaviour is not available we will still return an empty HdMaterialNetworkMap since there will be no outputs.

Fixes #994 