### PR TITLE
Remove harmless warnings when declaring a user data  #1014

### DIFF
--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -597,7 +597,9 @@ void UsdArnoldPrimReader::ReadPrimvars(
         declaration += AiParamGetTypeName(primvarType);
 
         // Declare the user data
-        AiNodeDeclare(node, name.GetText(), declaration.c_str());    
+        AtString nameStr(name.GetText());
+        if (AiNodeLookUpUserParameter(node, nameStr) == NULL)
+            AiNodeDeclare(node, nameStr, declaration.c_str());    
             
         bool hasIdxs = false;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
As we do in other arnold plugins, we need to check if a user data already exists before calling `AiNodeDeclare` in order to avoid eventual arnold warnings

**Issues fixed in this pull request**
Fixes #1014 
