### PR TITLE
Allow to specify a given RenderSettings prim when kicking a usd file

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -342,6 +342,7 @@ ASTR(region_max_y);
 ASTR(region_min_x);
 ASTR(region_min_y);
 ASTR(render_device);
+ASTR(render_settings);
 ASTR(repeat);
 ASTR(rotation);
 ASTR(roughness);

--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -295,6 +295,10 @@ scene_load
         int mask = AI_NODE_ALL;
         if (AiParamValueMapGetInt(params, str::mask, &mask))
             reader->SetMask(mask);
+        AtString renderSettings;
+        if (AiParamValueMapGetStr(params, str::render_settings, &renderSettings) && renderSettings.length() > 0)
+            reader->SetRenderSettings(std::string(renderSettings.c_str()));
+        
     }
     reader->SetFrame(frame);
     reader->SetThreadCount(threadCount);

--- a/testsuite/test_0203/README
+++ b/testsuite/test_0203/README
@@ -1,0 +1,5 @@
+Read specific Render Settings
+
+see #1016
+
+author: sebastien ortega

--- a/testsuite/test_0203/data/scene.usda
+++ b/testsuite/test_0203/data/scene.usda
@@ -1,0 +1,154 @@
+#usda 1.0
+(
+    defaultPrim = "grid1"
+    endTimeCode = 1
+    framesPerSecond = 24
+    metersPerUnit = 1
+    startTimeCode = 1
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+
+def Xform "cameras"
+{
+    def Camera "camera1"
+    {
+        float2 clippingRange = (1, 1000000)
+        float focalLength = 50
+        float focusDistance = 5
+        float fStop = 0
+        float horizontalAperture = 20.955
+        float horizontalApertureOffset = 0
+        token projection = "perspective"
+        double shutter:close = 0.25
+        double shutter:open = -0.25
+        float verticalAperture = 15.2908
+        float verticalApertureOffset = 0
+        matrix4d xformOp:transform = ( (0.9514633454010166, 5.551115123125784e-17, -0.3077620872659687, 0), (-0.13241210016549554, 0.9027137050711844, -0.4093592583616711, 0), (0.2778210540763038, 0.43024175375787804, 0.8588990017663758, 0), (5.363992736785748, 8.47881619685509, 17.19747719054302, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+    def Camera "camera2"
+    {
+        float2 clippingRange = (1, 1000000)
+        float focalLength = 50
+        float focusDistance = 5
+        float fStop = 0
+        float horizontalAperture = 20.955
+        float horizontalApertureOffset = 0
+        token projection = "perspective"
+        double shutter:close = 0.25
+        double shutter:open = -0.25
+        float verticalAperture = 15.2908
+        float verticalApertureOffset = 0
+        matrix4d xformOp:transform = ( (0.9514633454010166, 5.551115123125784e-17, -0.3077620872659687, 0), (-0.13241210016549554, 0.9027137050711844, -0.4093592583616711, 0), (0.2778210540763038, 0.43024175375787804, 0.8588990017663758, 0), (5.363992736785748, 8.47881619685509, 17.19747719054302, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+    def Camera "camera3"
+    {
+        float2 clippingRange = (1, 1000000)
+        float focalLength = 50
+        float focusDistance = 5
+        float fStop = 0
+        float horizontalAperture = 20.955
+        float horizontalApertureOffset = 0
+        token projection = "perspective"
+        double shutter:close = 0.25
+        double shutter:open = -0.25
+        float verticalAperture = 15.2908
+        float verticalApertureOffset = 0
+        matrix4d xformOp:transform = ( (0.9514633454010166, 5.551115123125784e-17, -0.3077620872659687, 0), (-0.13241210016549554, 0.9027137050711844, -0.4093592583616711, 0), (0.2778210540763038, 0.43024175375787804, 0.8588990017663758, 0), (5.363992736785748, 8.47881619685509, 17.19747719054302, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+    def Camera "camera4"
+    {
+        float2 clippingRange = (1, 1000000)
+        float focalLength = 50
+        float focusDistance = 5
+        float fStop = 0
+        float horizontalAperture = 20.955
+        float horizontalApertureOffset = 0
+        token projection = "perspective"
+        double shutter:close = 0.25
+        double shutter:open = -0.25
+        float verticalAperture = 15.2908
+        float verticalApertureOffset = 0
+        matrix4d xformOp:transform = ( (0.9514633454010166, 5.551115123125784e-17, -0.3077620872659687, 0), (-0.13241210016549554, 0.9027137050711844, -0.4093592583616711, 0), (0.2778210540763038, 0.43024175375787804, 0.8588990017663758, 0), (5.363992736785748, 8.47881619685509, 17.19747719054302, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "rendersettings1"
+    {
+        custom int arnold:global:AA_samples = 1
+        custom int arnold:global:GI_diffuse_depth = 1
+        custom int arnold:global:GI_diffuse_samples = 1
+        custom int arnold:global:GI_specular_depth = 1
+        
+        token aspectRatioConformPolicy = "expandAperture"
+        rel camera = </cameras/camera1>
+        int2 resolution = (160, 120)
+        rel products = </Render/Products/renderproduct1>
+    }
+    def RenderSettings "rendersettings2"
+    {
+        custom int arnold:global:AA_samples = 2
+        custom int arnold:global:GI_diffuse_depth = 2
+        custom int arnold:global:GI_diffuse_samples = 2
+        custom int arnold:global:GI_specular_depth = 2
+        
+        token aspectRatioConformPolicy = "expandAperture"
+        rel camera = </cameras/camera2>
+        int2 resolution = (160, 120)
+        rel products = </Render/Products/renderproduct1>
+    }
+    def RenderSettings "rendersettings3"
+    {
+        custom int arnold:global:AA_samples = 3
+        custom int arnold:global:GI_diffuse_depth = 3
+        custom int arnold:global:GI_diffuse_samples = 3
+        custom int arnold:global:GI_specular_depth = 3
+        
+        token aspectRatioConformPolicy = "expandAperture"
+        rel camera = </cameras/camera3>
+        int2 resolution = (160, 120)
+        rel products = </Render/Products/renderproduct1>
+    }
+    def RenderSettings "rendersettings4"
+    {
+        custom int arnold:global:AA_samples = 4
+        custom int arnold:global:GI_diffuse_depth = 4
+        custom int arnold:global:GI_diffuse_samples = 4
+        custom int arnold:global:GI_specular_depth = 4
+        
+        token aspectRatioConformPolicy = "expandAperture"
+        rel camera = </cameras/camera4>
+        int2 resolution = (160, 120)
+        rel products = </Render/Products/renderproduct1>
+    }
+    def Scope "Products"
+    {
+        def RenderProduct "renderproduct1"
+        {
+            rel orderedVars = [
+                </Render/Products/Vars/rendervar1>,
+            ]
+            token productName = "testrender.tif"
+            token productType = "raster"
+        }
+        def Scope "Vars"
+        {
+            def RenderVar "rendervar1"
+            {
+                custom string arnold:filter = "gaussian_filter"
+                custom float arnold:width = 2
+                token dataType = "color4f"
+                string sourceName = "RGBA"
+                token sourceType = "raw"
+            }
+        }
+
+    }
+}

--- a/testsuite/test_0203/data/test.cpp
+++ b/testsuite/test_0203/data/test.cpp
@@ -1,0 +1,69 @@
+#include <ai.h>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    bool success = true;
+    AiMsgSetConsoleFlags(AI_LOG_ALL);
+    AiBegin();
+   
+
+    AtString renderSettingsParam("render_settings");
+    for (int i = 0; i <= 4; ++i) {
+        AtUniverse* universe = AiUniverse();
+        AtParamValueMap* params = AiParamValueMap();
+        int index = std::max(i, 1);
+        std::string indexStr = std::to_string(index);
+        std::string renderSettingsName = "/Render/rendersettings" + indexStr;
+        if (i > 0)
+            AiParamValueMapSetStr(params, renderSettingsParam, AtString(renderSettingsName.c_str()));
+        AiSceneLoad(universe, "scene.usda", params);    
+        AiParamValueMapDestroy(params);
+
+        AtNode *options = AiUniverseGetOptions(universe);
+        int AA_samples = AiNodeGetInt(options, AtString("AA_samples"));
+        int GI_diffuse_depth = AiNodeGetInt(options, AtString("GI_diffuse_depth"));
+        int GI_diffuse_samples = AiNodeGetInt(options, AtString("GI_diffuse_samples"));
+        int GI_specular_depth = AiNodeGetInt(options, AtString("GI_specular_depth"));
+        AtNode *camera = AiUniverseGetCamera(universe);
+        std::string cameraName;
+        if (camera) {
+            cameraName = AiNodeGetName(camera);
+        }
+        std::string expectedCameraName = std::string("/cameras/camera") + indexStr;
+
+        if (AA_samples != index) {
+            std::cerr<<"For "<<renderSettingsName<<", wrong attribute AA_samples = "<<AA_samples<<std::endl;
+            success = false;
+        }
+        if (GI_diffuse_depth != index) {
+            std::cerr<<"For "<<renderSettingsName<<", wrong attribute GI_diffuse_depth = "<<GI_diffuse_depth<<std::endl;
+            success = false;
+        }
+        if (GI_diffuse_samples != index) {
+            std::cerr<<"For "<<renderSettingsName<<", wrong attribute GI_diffuse_samples = "<<GI_diffuse_samples<<std::endl;
+            success = false;
+        }
+        if (GI_specular_depth != index) {
+            std::cerr<<"For "<<renderSettingsName<<", wrong attribute GI_specular_depth = "<<GI_specular_depth<<std::endl;
+            success = false;
+        }
+        if (cameraName != expectedCameraName) {
+            std::cerr<<"For "<<renderSettingsName<<", wrong camera = "<<cameraName<<std::endl;
+            success = false;
+        }
+        
+        
+
+
+
+        AiUniverseDestroy(universe);
+    }
+    return (success) ? 0 : 1;
+}

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -24,6 +24,7 @@
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 #include <pxr/usd/usdSkel/bakeSkinning.h>
 #include <pxr/usd/usdUtils/stageCache.h>
+#include <pxr/usd/usdRender/settings.h>
 
 #include <cstdio>
 #include <cstring>
@@ -580,6 +581,16 @@ void UsdArnoldReader::ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext 
     }        
 
     std::string objType = prim.GetTypeName().GetText();
+
+    // We want to ensure we only read a single RenderSettings prim. So we compare
+    // if the path provided to the reader. If nothing was set, we'll just look 
+    // for the first RenderSettings in the stage
+    if (prim.IsA<UsdRenderSettings>()) {
+        if (!_renderSettings.empty() && _renderSettings != objName)
+            return;
+        _renderSettings = objName;
+    }
+
     UsdArnoldPrimReader *primReader = _registry->GetPrimReader(objType);
     if (primReader && (_mask & primReader->GetType())) {
         if (_debug) {

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -74,6 +74,7 @@ public:
     void SetMask(int m) { _mask = m; }
     void SetPurpose(const std::string &p) { _purpose = TfToken(p.c_str()); }
     void SetId(unsigned int id) { _id = id; }
+    void SetRenderSettings(const std::string &renderSettings) {_renderSettings = renderSettings;}
 
     const UsdStageRefPtr &GetStage() const { return _stage; }
     const std::vector<AtNode *> &GetNodes() const { return _nodes; }
@@ -91,6 +92,7 @@ public:
     unsigned int GetId() const { return _id;}
     const TfToken &GetPurpose() const {return _purpose;}
     int GetCacheId() const {return _cacheId;}
+    const std::string &GetRenderSettings() const {return _renderSettings;}
 
     static unsigned int ReaderThread(void *data);
     static unsigned int ProcessConnectionsThread(void *data);
@@ -200,6 +202,7 @@ private:
     unsigned int _threadCount;
     int _mask;             // mask based on the arnold flags (AI_NODE_SHADER, etc...) to control
                            // what type of nodes are being read
+    std::string _renderSettings; // which RenderSettings prims to consider for the Arnold options
     UsdStageRefPtr _stage; // current stage being read. Will be cleared once
                            // finished reading
     std::vector<AtNode *> _nodes;


### PR DESCRIPTION
We add a possible paramMap "render_settings" when loading a usd file. If set, the reader will only pick a RenderSettings prim with this given name. If not set, only the first RenderSettings prim will be considered (currently all would end up being translated to the same arnold options node)

**Issues fixed in this pull request**
Fixes #1016
