### PR TITLE
Ensure the lights normalize attribute is authored in usd files

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -66,6 +66,7 @@ ASTR2(houdiniFps, "houdini:fps");
 ASTR2(hydraPrimId, "hydra_primId");
 ASTR2(inputs_code, "inputs:code");
 ASTR2(primvars_arnold_subdiv_type, "primvars:arnold:subdiv_type");
+ASTR2(primvars_arnold_normalize, "primvars:arnold:normalize");
 ASTR2(renderPassAOVDriver, "HdArnoldRenderPass_aov_driver");
 ASTR2(renderPassCamera, "HdArnoldRenderPass_camera");
 ASTR2(renderPassClosestFilter, "HdArnoldRenderPass_closestFilter");

--- a/translator/writer/write_light.cpp
+++ b/translator/writer/write_light.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "write_light.h"
+#include <constant_strings.h>
 
 #include <ai.h>
 #include <cstdio>
@@ -63,6 +64,10 @@ void UsdArnoldWriteDistantLight::Write(const AtNode *node, UsdArnoldWriter &writ
     WriteAttribute(node, "angle", prim, light.GetAngleAttr(), writer);
     writeLightCommon(node, prim, *this, writer);
     _WriteMatrix(light, node, writer);
+
+    UsdAttribute normalizeAttr = prim.CreateAttribute(TfToken("primvars:arnold:normalize"), SdfValueTypeNames->Bool, false);
+    WriteAttribute(node, "normalize", prim, normalizeAttr, writer);
+
     _WriteArnoldParameters(node, writer, prim, "primvars:arnold");
 }
 
@@ -102,6 +107,9 @@ void UsdArnoldWriteDomeLight::Write(const AtNode *node, UsdArnoldWriter &writer)
         writer.SetAttribute(light.GetTextureFormatAttr(), UsdLuxTokens->angular);
 
     _exportedAttrs.insert("format");
+
+    UsdAttribute normalizeAttr = prim.CreateAttribute(str::t_primvars_arnold_normalize, SdfValueTypeNames->Bool, false);
+    WriteAttribute(node, "normalize", prim, normalizeAttr, writer);
 
     _WriteArnoldParameters(node, writer, prim, "primvars:arnold");
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
When we write distant or skydome lights, we were not authoring the normalize attribute. This is causing issues, since the default is different between usd and arnold. With this PR, we're now ensuring we're always dump it for these "non-boundable" lights


**Issues fixed in this pull request**
Fixes #1024


**Additional context**
Add any other context or screenshots about the pull request here.
