### PR TITLE
Fix for element connection in arnold node graph

### DIFF
--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -827,12 +827,12 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNetwork(const HdMaterialNetwork& network)
         if (AiNodeEntryLookUpParameter(outputNodeEntry, AtString(outputAttr.c_str())) == nullptr) {
             // Attribute outputAttr wasn't found in outputNode. First we need to check if it's an array connection
             std::string baseOutputAttr;
-            size_t elemPos = outputAttr.find_last_of(':i');
+            size_t elemPos = outputAttr.rfind(":i");
             if (elemPos != std::string::npos && elemPos > 0) {
                 // We have an array connection, e.g. "color:i0".
                 // We want to replace this string by "color[0]" which Arnold understands
-                baseOutputAttr = outputAttr.substr(0, elemPos - 1);
-                outputAttr.replace(elemPos - 1, 2, std::string("["));
+                baseOutputAttr = outputAttr.substr(0, elemPos);
+                outputAttr.replace(elemPos, 2, std::string("["));
                 outputAttr += "]";
             }
             // if we didn't recognize an array connection, or if the 

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -378,7 +378,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(HdArnoldRenderContext context) : 
     _id = SdfPath(TfToken(TfStringPrintf("/HdArnoldRenderDelegate_%p", this)));
     // We first need to check if arnold has already been initialized.
     // If not, we need to call AiBegin, and the destructor on we'll call AiEnd
-    _isArnoldActive = AiUniverseIsActive();
+    _isArnoldActive = AiArnoldIsActive();
     if (!_isArnoldActive) {
         AiADPAddProductMetadata(AI_ADP_PLUGINNAME, AtString{"arnold-usd"});
         AiADPAddProductMetadata(AI_ADP_PLUGINVERSION, AtString{AI_VERSION});


### PR DESCRIPTION
Currently we have a warning in the render delegate code for connecting array elements

```
render_delegate/node_graph.cpp:830:54: warning: multi-character character constant [-Wmultichar]
            size_t elemPos = outputAttr.find_last_of(':i');
                                                     ^
render_delegate/node_graph.cpp:830:54: warning: implicit conversion from 'int' to 'std::basic_string<char>::value_type' (aka 'char') changes value from 14953 to 105 [-Wconstant-conversion]
            size_t elemPos = outputAttr.find_last_of(':i');
```
This doesn't amount to a bug in the render delegate, but is in fact only searching for the last :, not the last :i since we pass a char not a string. If we has used a string it would pick the last of : OR i which is not what we want either.

We can fix by using rfind("i0") and updating the indices.

Note we only get different behaviour for strings such as input[3].i which we would represent as input:i0:i, but we would never have such connections, only input[3].x or similar (i.e. components x,yz,r,g,b,a).

But this fix will make the code tighter and remove the compile warning.