### PR TITLE
Propagate thread count to nested procedurals for instancing 

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -863,6 +863,7 @@ void UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderConte
             // so we always want it to be hidden to avoid duplicated geometries. 
             // We just want the instances to be visible eventually
             AiNodeSetByte(proto, str::visibility, 0);
+            AiNodeSetInt(proto, str::threads, reader->GetThreadCount());
             nodesVec[i] = proto;
 
             // we keep track that this prototype relies on a child usd procedural

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -1138,6 +1138,7 @@ bool UsdArnoldReaderThreadContext::ProcessConnection(const Connection &connectio
                             AiNodeSetArray(target, str::overrides, AiArrayCopy(overrides));
                         // Hide the prototype, we'll only want the instance to be visible
                         AiNodeSetByte(target, str::visibility, 0);
+                        AiNodeSetInt(target, str::threads, _reader->GetThreadCount());
                     }
                 }
             }


### PR DESCRIPTION
**Changes proposed in this pull request**
When we need to create a nested usd procedural for instancing purpose, we now also propagate the thread count to this procedural, so that we can properly debug scenes with a single thread

**Issues fixed in this pull request**
Fixes #1034 
