### PR TITLE
Use velocity/acceleration primvars for mesh/curves in the render delegate

### DIFF
--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -73,7 +73,7 @@ void HdArnoldBasisCurves::Sync(
                                (*dirtyBits & HdChangeTracker::DirtyPrimvar);
     if (_primvars.count(HdTokens->points) == 0 && HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
         param.Interrupt();
-        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points, param());
+        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points, param(), GetDeformKeys(), &_primvars);
     }
 
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -195,7 +195,7 @@ void HdArnoldMesh::Sync(
         _numberOfPositionKeys = 1;
     } else if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
         param.Interrupt();
-        _numberOfPositionKeys = HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::vlist, param());
+        _numberOfPositionKeys = HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::vlist, param(), GetDeformKeys(), &_primvars);
     }
 
     const auto dirtyTopology = HdChangeTracker::IsTopologyDirty(*dirtyBits, id);

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -876,6 +876,7 @@ inline size_t _ExtrapolatePositions(
         deformKeys == 0) {
         return 0;
     }
+
     // Check if primvars or positions exists. These arrays are COW.
     VtVec3fArray velocities;
     VtVec3fArray accelerations;
@@ -898,7 +899,6 @@ inline size_t _ExtrapolatePositions(
             timeIndex = i;
             break;
         }
-
     }
     // If no proper time was found, let's pick the first sample that has the same
     // size as the velocities
@@ -922,15 +922,15 @@ inline size_t _ExtrapolatePositions(
             }
         }    
     }
+
     if (timeIndex < 0) 
-        return 0;
-    // We already checked for the value length outside.
-    const auto& positions = xf.values[timeIndex];
+        return 0; // We couldn't find a proper time sample to read positions
     
+    const auto& positions = xf.values[timeIndex];
     const auto numPositions = positions.size();
     const auto hasVelocity = !velocities.empty() && numPositions == velocities.size();
     const auto hasAcceleration = !accelerations.empty() && numPositions == accelerations.size();
-    // Only velocity at the moment.
+    
     if (!hasVelocity && !hasAcceleration) {
         // No velocity or acceleration, or incorrect sizes for both.
         return 0;


### PR DESCRIPTION
The render delegate already had some code to support velocity/accelerations when computing the positions (in `_ExtrapolatePositions` ), but a few things were missing :
- meshes and basis curves need to provide the primvars list to `HdArnoldSetPositionFromPrimvar` so that they can be used in `_ExtrapolatePositions`
- We were only considering velocities if positions were not animated. This isn't consistent with what the procedural is doing, and wuold still leads to issues. If the positions are animated and have varying topologies, then we wouldn't read the velocities, and this would still lead to errors. Instead, as soon as velocities/accelerations are provided, we should always consider them  instead of reading positions at different times.
- We were not necessarily considering the positions at the "current" frame, as we were just reading the first time sample. In case of varying topologies, this could lead to reading positions from the previous frame, where the amount of elements doesn't match the amount of velocities. So we need to find a time sample that can be used with velocities/accelerations

I verified that the test scene from test_0157 that exercises this with meshes & varying topologies. This change should also apply to curves, but I don't have a test scene yet. So it will need to be verified

**Issues fixed in this pull request**
Fixes #912
Fixes #911 

**Additional context**
Add any other context or screenshots about the pull request here.
