### PR TITLE
Add version checks for older versions of Arnold

### DIFF
--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -393,7 +393,11 @@ UsdStageRefPtr NdrArnoldGetShaderDefs()
         auto stage = UsdStage::CreateInMemory("__ndrArnoldShaderDefs.usda");
 
         // We expect the existing arnold universe to load the plugins.
+#if ARNOLD_VERSION_NUMBER >= 70100
         const auto hasActiveUniverse = AiArnoldIsActive();
+#else
+        const auto hasActiveUniverse = AiUniverseIsActive();   
+#endif
         if (!hasActiveUniverse) {
             AiBegin(AI_SESSION_BATCH);
 #if ARNOLD_VERSION_NUMBER >= 70100

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -378,7 +378,11 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(HdArnoldRenderContext context) : 
     _id = SdfPath(TfToken(TfStringPrintf("/HdArnoldRenderDelegate_%p", this)));
     // We first need to check if arnold has already been initialized.
     // If not, we need to call AiBegin, and the destructor on we'll call AiEnd
+#if ARNOLD_VERSION_NUMBER >= 70100
     _isArnoldActive = AiArnoldIsActive();
+#else
+    _isArnoldActive = AiUniverseIsActive();
+#endif
     if (!_isArnoldActive) {
         AiADPAddProductMetadata(AI_ADP_PLUGINNAME, AtString{"arnold-usd"});
         AiADPAddProductMetadata(AI_ADP_PLUGINVERSION, AtString{AI_VERSION});

--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -75,7 +75,11 @@ void UsdArnoldReaderRegistry::RegisterPrimitiveReaders()
     // If a universe is already active, we can just use it, otherwise we need to
     // call AiBegin.
     //  But if we do so, we'll have to call AiEnd() when we finish
+#if ARNOLD_VERSION_NUMBER >= 70100
     if (!AiArnoldIsActive()) {
+#else
+    if (!AiUniverseIsActive()) {
+#endif
         AiBegin();
         universeCreated = true;
     }

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -60,7 +60,11 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
     // If a universe is already active, we can just use it, otherwise we need to
     // call AiBegin.
     //  But if we do so, we'll have to call AiEnd() when we finish
+#if ARNOLD_VERSION_NUMBER >= 70100
     if (!AiArnoldIsActive()) {
+#else
+    if (!AiUniverseIsActive()) {
+#endif
         AiBegin();
         universeCreated = true;
     }


### PR DESCRIPTION
Adding version checks, so that we only call `AiArnoldIsActive` for Arnold 7.x versions

**Issues fixed in this pull request**
Fixes #1043 
