### PR TITLE
Fix crashes with invalid indexed primvars

### DIFF
--- a/translator/reader/prim_reader.cpp
+++ b/translator/reader/prim_reader.cpp
@@ -598,8 +598,10 @@ void UsdArnoldPrimReader::ReadPrimvars(
 
         // Declare the user data
         AtString nameStr(name.GetText());
-        if (AiNodeLookUpUserParameter(node, nameStr) == NULL)
+        if (AiNodeLookUpUserParameter(node, nameStr) == nullptr && 
+            AiNodeEntryLookUpParameter(nodeEntry, nameStr) == nullptr) {
             AiNodeDeclare(node, nameStr, declaration.c_str());    
+        }
             
         bool hasIdxs = false;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR verifies that we're not setting out-of-bounds vector elements in case primvars have invalid indices. 
I'm also verifying we're not trying to declare a user data for an attribute that already exists to prevent warnings that I've seen while debugging this.
I'm not managing to reproduce the crash with a simpler scene than the one provided by the customer, so I couldn't add a test  


**Issues fixed in this pull request**
Fixes #1045 
