### PR TITLE
Default mesh smoothing to true in the delegate

### DIFF
--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -168,18 +168,17 @@ inline void _ConvertFaceVaryingPrimvarToBuiltin(
 #if PXR_VERSION >= 2102
 HdArnoldMesh::HdArnoldMesh(HdArnoldRenderDelegate* renderDelegate, const SdfPath& id)
     : HdArnoldRprim<HdMesh>(str::polymesh, renderDelegate, id)
-{
-    // The default value is 1, which won't work well in a Hydra context.
-    AiNodeSetByte(GetArnoldNode(), str::subdiv_iterations, 0);
-}
 #else
 HdArnoldMesh::HdArnoldMesh(HdArnoldRenderDelegate* renderDelegate, const SdfPath& id, const SdfPath& instancerId)
     : HdArnoldRprim<HdMesh>(str::polymesh, renderDelegate, id, instancerId)
+#endif
 {
     // The default value is 1, which won't work well in a Hydra context.
     AiNodeSetByte(GetArnoldNode(), str::subdiv_iterations, 0);
+    // polymesh smoothing is disabled by default in arnold core, 
+    // but we actually want it to default to true as in the arnold plugins
+    AiNodeSetBool(GetArnoldNode(), str::smoothing, true);
 }
-#endif
 
 void HdArnoldMesh::Sync(
     HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits, const TfToken& reprToken)


### PR DESCRIPTION
**Changes proposed in this pull request**
Just like it's done in the procedural, we're now setting the polymesh smoothing to be enabled by default in the delegate.
We were already doing similar in `HdArnoldMesh` for the `subdiv_iterations` that needed to be set to 0 by default.

Note that the `HdArnoldRprim`  constructor is different for usd versions older than 21.02. We had ifdefs for it, but they were containing the whole contructor function. I'm changing them to just change the function signature, which is enough and avoids code duplication on ech ifdef case.

**Issues fixed in this pull request**
Fixes #24
