### PR TITLE
IPR improvements the arnold node graph adapter (#1057)

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -82,6 +82,7 @@ ASTR(AA_samples);
 ASTR(AA_samples_max);
 ASTR(AA_seed);
 ASTR(ArnoldUsd);
+ASTR(ArnoldNodeGraph);
 ASTR(BOOL);
 ASTR(BYTE);
 ASTR(CPU);

--- a/usd_imaging/node_graph_adapter.h
+++ b/usd_imaging/node_graph_adapter.h
@@ -77,6 +77,15 @@ public:
     void MarkDirty(
         const UsdPrim& prim, const SdfPath& cachePath, HdDirtyBits dirty, UsdImagingIndexProxy* index) override;
 
+    USDIMAGING_API
+    void MarkMaterialDirty(UsdPrim const& prim,
+                           SdfPath const& cachePath,
+                           UsdImagingIndexProxy* index) override;
+
+    USDIMAGING_API
+    void ProcessPrimResync(SdfPath const& cachePath,
+                           UsdImagingIndexProxy* index) override;
+
     /// Tells if the primitive is supported by an UsdImagingIndex.
     ///
     /// @param index Pointer to the UsdImagingIndex.


### PR DESCRIPTION
Implement callbacks from the UsdImagingMaterialAdapter in materialAdapter.cpp to improve the IPR in the ArnoldNodeGraph adapter

Fixes #1057

