### PR TITLE
Set the defaultPrim in the usd writer

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -194,6 +194,7 @@ ASTR(crease_idxs);
 ASTR(crease_sharpness);
 ASTR(curves);
 ASTR(cylinder_light);
+ASTR(defaultPrim);
 ASTR(depth_pointer);
 ASTR(diffuse);
 ASTR(diffuseColor);

--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -373,6 +373,10 @@ scene_write
         if (AiParamValueMapGetStr(params, str::scope, &scope))
             writer->SetScope(std::string(scope.c_str()));
 
+        AtString defaultPrim;
+        if (AiParamValueMapGetStr(params, str::defaultPrim, &defaultPrim))
+            writer->SetDefaultPrim(std::string(defaultPrim.c_str()));
+
         bool allAttributes;
         if (AiParamValueMapGetBool(params, str::all_attributes, &allAttributes))
             writer->SetWriteAllAttributes(allAttributes);

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -61,7 +61,7 @@ void UsdArnoldWriter::Write(const AtUniverse *universe)
     _exportedNodes.clear();
 
     // If we've explicitely set a scope, we want to use it as a defaultPrim
-    if (!_scope.empty())
+    if (_defaultPrim.empty() && !_scope.empty())
         _defaultPrim = _scope;
     
     AtNode *camera = AiUniverseGetCamera(universe);
@@ -197,8 +197,12 @@ void UsdArnoldWriter::CreateHierarchy(const SdfPath &path, bool leaf)
         // If this primitive was already written, let's early out.
         // No need to test this for the leaf node that is about 
         // to be created
-        if (_stage->GetPrimAtPath(path))
+        if (_stage->GetPrimAtPath(path)) {
+            if (_defaultPrim.empty())
+                _defaultPrim = path.GetText();
+
             return;
+        }
     }
 
     // Ensure the parents xform are created first, otherwise they'll

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -94,7 +94,7 @@ public:
     bool GetWriteMaterialBindings() const {return _writeMaterialBindings;}
     void SetWriteMaterialBindings(bool b) {_writeMaterialBindings = b;}
 
-    void CreateHierarchy(const SdfPath &path, bool leaf = true) const;
+    void CreateHierarchy(const SdfPath &path, bool leaf = true);
 
     const std::vector<float> &GetAuthoredFrames() const {return _authoredFrames;}
 
@@ -183,4 +183,5 @@ private:
     UsdTimeCode _time;                 // current time required by client code
     std::vector<float> _authoredFrames;// list of frames that were previously authored in this usd stage
     std::vector<float> _nearestFrames; // based on the _authoredFrames list, we store the 1 or 2 nearest frames
+    std::string _defaultPrim;          // usd files have a defaultPrim that can be used for file references
 };

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -90,6 +90,8 @@ public:
         }
         
     }
+    const std::string &GetDefaultPrim() const {return _defaultPrim;}
+    void SetDefaultPrim(const std::string &defaultPrim) {_defaultPrim = defaultPrim;}
 
     bool GetWriteMaterialBindings() const {return _writeMaterialBindings;}
     void SetWriteMaterialBindings(bool b) {_writeMaterialBindings = b;}


### PR DESCRIPTION
**Changes proposed in this pull request**
It's been requesting several times that we should set a defaultPrim when authoring usd files, as this can be required for file referencing. This PR sets one value for that. If an explicit value is provided we use it, otherwise if a scope is set we use it as the defaultPrim. If none of the params is set, then we use the top parent primitive, created by `UsdArnoldWriter::CreateHierarchy`

**Issues fixed in this pull request**
Fixes #1063 
