### PR TITLE
Use custom metadata to store authored frames

### DIFF
--- a/translator/writer/write_arnold_type.cpp
+++ b/translator/writer/write_arnold_type.cpp
@@ -113,14 +113,6 @@ void UsdArnoldWriteArnoldType::Write(const AtNode *node, UsdArnoldWriter &writer
             }
         }
     }
-    // Special case for the options node. We want to save the parameter "frame" in a special way if a
-    // frame was specified. In that case, we always add a time sample with a value corresponding to this frame
-    if (isOptions && !writer.GetTime().IsDefault()) {
-        UsdAttribute frameAttr = prim.CreateAttribute(_tokens->frame, SdfValueTypeNames->Float, false);
-        frameAttr.Set((float)writer.GetTime().GetValue(), writer.GetTime());
-        _exportedAttrs.insert("frame"); // ensure this attribute is not handled by _WriteArnoldParameters
-    }
-
     _WriteArnoldParameters(node, writer, prim, "arnold");
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of relying on the ArnoldOptions prim to store the list of frames, we now use the stage custom metadata, through a value called `timeCodeArray` (I used the same name as in one of the usd unit tests that stores such a list).

We no longer need to force the export of the options anymore, and we no longer need to force the export of the "frame" options attribute
 
**Issues fixed in this pull request**
Fixes #963 
