### PR TITLE
Write shading trees under their material's scope

### DIFF
--- a/testsuite/test_0138/data/test.cpp
+++ b/testsuite/test_0138/data/test.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
         AiMsgError("/beautiful/scope/my/cone/name doesn't exist");
         success = false;
     }
-    if (!AiNodeLookUpByName("/beautiful/scope/lambert1")) {
+    if (!AiNodeLookUpByName("/beautiful/scope/lambert1/lambert1")) {
         AiMsgError("/beautiful/scope/lambert1 doesn't exist");
         success = false;
     }

--- a/testsuite/test_0208/README
+++ b/testsuite/test_0208/README
@@ -1,0 +1,6 @@
+Write shaders under materials
+See #1067
+
+author: sebastien ortega
+
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0208/data/scene.ass
+++ b/testsuite/test_0208/data/scene.ass
@@ -1,0 +1,353 @@
+
+options
+{
+ AA_samples 3
+ outputs "RGBA RGBA myfilter mydriver"
+ xres 160
+ yres 120
+ camera "/persp/perspShape"
+ frame 1
+ GI_diffuse_depth 1
+ GI_specular_depth 1
+ GI_transmission_depth 8
+ declare render_layer constant STRING
+ render_layer "defaultRenderLayer"
+}
+
+gaussian_filter
+{
+ name myfilter
+}
+
+driver_tiff
+{
+ name mydriver
+ filename "testrender.tif"
+ color_space ""
+}
+
+persp_camera
+{
+ name /persp/perspShape
+ matrix
+ 0.676875949 -2.77555756e-17 -0.736097097 0
+ -0.454585969 0.786521792 -0.418013215 0
+ 0.578956425 0.617562473 0.53237772 0
+ 4.59069586 4.97445917 4.89203739 1
+ near_clip 0.100000001
+ far_clip 10000
+ shutter_start 0
+ shutter_end 0
+ shutter_type "box"
+ rolling_shutter "off"
+ rolling_shutter_duration 0
+ motion_start 0
+ motion_end 0
+ exposure 0
+ fov 54.4322243
+ uv_remap 0 0 0 1
+ declare dcc_name constant STRING
+ dcc_name "perspShape"
+}
+
+distant_light
+{
+ name /directionalLight1/directionalLightShape1
+ matrix
+ 0.769123435 -0.397355825 -0.500557184 0
+ -0.072987996 0.723485172 -0.686470687 0
+ 0.634918809 0.564515352 0.527447164 0
+ 0 0 9.15674019 1
+ intensity 3
+ exposure 0
+ cast_shadows on
+ cast_volumetric_shadows on
+ shadow_density 1
+ samples 1
+ normalize on
+ diffuse 1
+ specular 1
+ sss 1
+ indirect 1
+ max_bounces 999
+ volume_samples 2
+ volume 1
+ aov "default"
+ angle 0
+ declare dcc_name constant STRING
+ dcc_name "directionalLightShape1"
+}
+
+distant_light
+{
+ name /directionalLight2/directionalLightShape2
+ matrix
+ -0.375051379 -0.194117576 0.906451762 0
+ -0.503000438 0.863977432 -0.0230986327 0
+ -0.778670013 -0.464608818 -0.421677142 0
+ 0 0 0 1
+ exposure 0
+ cast_shadows on
+ cast_volumetric_shadows on
+ shadow_density 1
+ samples 1
+ normalize on
+ diffuse 1
+ specular 1
+ sss 1
+ indirect 1
+ max_bounces 999
+ volume_samples 2
+ volume 1
+ aov "default"
+ angle 0
+ declare dcc_name constant STRING
+ dcc_name "directionalLightShape2"
+}
+
+persp_camera
+{
+ name /Camera_Root/Camera/CameraShape
+ matrix
+ 0.0237747245 0.0651279762 -0.997593641 0
+ -0.965841591 0.259061337 -0.00610516639 0
+ 0.258040339 0.963662565 0.0690624192 0
+ 9.64240074 33.2830162 2.6994009 1
+ near_clip 0.100000001
+ far_clip 32768
+ shutter_start 0
+ shutter_end 0
+ shutter_type "box"
+ rolling_shutter "off"
+ rolling_shutter_duration 0
+ motion_start 0
+ motion_end 0
+ exposure 0
+ fov 41.183075
+ uv_remap 0 0 0 1
+ declare dcc_name constant STRING
+ dcc_name "CameraShape"
+}
+
+polymesh
+{
+ name /pCube1/pCubeShape1
+ visibility 255
+ sidedness 255
+ matrix
+ 1 0 0 0
+ 0 1 0 0
+ 0 0 1 0
+ 5 0 0 1
+ shader 3 1 NODE
+"aiStandard3" "aiStandard3" "aiStandard5"
+ use_light_group off
+ id 528272281
+ nsides 6 1 UINT
+4 4 4 4 4 4
+ vidxs 24 1 UINT
+  0 1 3 2 2 3 5 4 4 5 7 6 6 7 1 0 1 7 5 3 6 0 2 4
+ uvidxs 24 1 UINT
+  0 1 3 2 2 3 5 4 4 5 7 6 6 7 9 8 1 10 11 3 12 0 2 13
+ shidxs 6 1 BYTE
+1 0 0 0 2 0
+ vlist 8 1 VECTOR
+-0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5
+  0.5 -0.5 -0.5
+ uvlist 14 1 VECTOR2
+  0.375 0 0.625 0 0.375 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1
+  0.625 1 0.875 0 0.875 0.25 0.125 0 0.125 0.25
+ smoothing on
+ subdiv_type "catclark"
+ subdiv_iterations 6
+ subdiv_adaptive_error 0
+ subdiv_adaptive_metric "auto"
+ subdiv_adaptive_space "raster"
+ subdiv_frustum_ignore off
+ subdiv_uv_smoothing "pin_corners"
+ subdiv_smooth_derivs off
+ disp_padding 1
+ disp_height 1
+ disp_zero_value 0
+ disp_autobump off
+ autobump_visibility 1
+ step_size 0
+ volume_padding 0
+ declare dcc_name constant STRING
+ dcc_name "pCubeShape1"
+}
+
+
+polymesh
+{
+ name /pCube2/pCubeShape2
+ visibility 255
+ sidedness 255
+ matrix
+ 5.36313248 0 0 0
+ 0 5.36313248 0 0
+ 0 0 5.36313248 0
+ 0 0 0 1
+ shader 3 1 NODE
+"aiStandard3" "aiStandard3" "aiStandard5"
+ use_light_group off
+ id 528272281
+ nsides 6 1 UINT
+4 4 4 4 4 4
+ vidxs 24 1 UINT
+  0 1 3 2 2 3 5 4 4 5 7 6 6 7 1 0 1 7 5 3 6 0 2 4
+ uvidxs 24 1 UINT
+  0 1 3 2 2 3 5 4 4 5 7 6 6 7 9 8 1 10 11 3 12 0 2 13
+ shidxs 6 1 BYTE
+1 0 0 0 2 0
+ vlist 8 1 VECTOR
+-0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5
+  0.5 -0.5 -0.5
+ uvlist 14 1 VECTOR2
+  0.375 0 0.625 0 0.375 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1
+  0.625 1 0.875 0 0.875 0.25 0.125 0 0.125 0.25
+ smoothing on
+ subdiv_uv_smoothing "pin_corners"
+ subdiv_smooth_derivs off
+ disp_map 3 1 NODE
+"displacementShader1" "displacementShader2" "displacementShader3"
+ disp_padding 1
+ disp_height 1
+ disp_zero_value 0
+ disp_autobump off
+ autobump_visibility 1
+ step_size 0
+ volume_padding 0
+ declare dcc_name constant STRING
+ dcc_name "pCubeShape1"
+}
+
+
+
+standard_surface
+{
+ name aiStandard3
+ base_color checker
+}
+checkerboard
+{
+	name checker
+}
+
+range
+{
+ name displacementShader1
+ input bulge1
+ output_min 0
+ output_max 0.1
+ contrast_pivot 0
+}
+
+cell_noise
+{
+ name bulge1
+ scale 10 10 10
+}
+
+state_float
+{
+ name place2dTexture1@u
+ variable "u"
+}
+
+state_float
+{
+ name place2dTexture1@v
+ variable "v"
+}
+
+uv_transform
+{
+ name place2dTexture1
+ passthrough 0 0 0 1
+ passthrough.r place2dTexture1@u
+ passthrough.g place2dTexture1@v
+ uvset ""
+ rotate_frame 0
+ wrap_frame_u "none"
+ wrap_frame_v "none"
+ repeat 10 10
+ rotate 0
+}
+
+
+range
+{
+ name displacementShader2
+ input noise1
+ output_min 0
+ output_max 0.2
+ contrast_pivot 0
+}
+
+noise
+{
+ name noise1
+ scale 10 10 10
+}
+
+state_float
+{
+ name place2dTexture2@u
+ variable "u"
+}
+
+state_float
+{
+ name place2dTexture2@v
+ variable "v"
+}
+
+uv_transform
+{
+ name place2dTexture2
+ passthrough 0 0 0 1
+ passthrough.r place2dTexture2@u
+ passthrough.g place2dTexture2@v
+ uvset ""
+ rotate_frame 0
+ wrap_frame_u "none"
+ wrap_frame_v "none"
+ rotate 0
+}
+
+standard
+{
+ name aiStandard5
+ Kd_color 0 0 1
+}
+
+range
+{
+ name displacementShader3
+ input checker1@cc
+ output_min 0
+ output_max 0.2
+ contrast_pivot 0
+}
+
+checkerboard
+{
+ name checker1
+ color1 0 0 0
+ color2 1 1 1
+ u_frequency 20
+ v_frequency 20
+ u_offset 0
+ v_offset 0
+ uvset ""
+}
+
+color_correct
+{
+ name checker1@cc
+ input checker1
+ alpha_is_luminance on
+ alpha_multiply 0.100000001
+}
+

--- a/testsuite/test_0208/data/test.cpp
+++ b/testsuite/test_0208/data/test.cpp
@@ -1,0 +1,83 @@
+#include <ai.h>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+int main(int argc, char **argv)
+{
+    AiMsgSetConsoleFlags(AI_LOG_ALL);
+    AiBegin();
+    AiASSLoad("scene.ass");
+    AtParamValueMap* params = AiParamValueMap();
+    AiParamValueMapSetStr(params, AtString("scope"), AtString("beautiful/scope"));
+    AiSceneWrite(nullptr, "scene.usda", params);
+    AiParamValueMapDestroy(params);
+    AiEnd();
+
+    std::vector<std::string> includeList = {"/aiStandard3/aiStandard3", 
+                                            "/aiStandard3/checker",
+                                            "/aiStandard3displacementShader1/aiStandard3",
+                                            "/aiStandard3displacementShader1/checker",
+                                            "/aiStandard3displacementShader1/displacementShader1",
+                                            "/aiStandard3displacementShader1/bulge1",
+                                            "/aiStandard3displacementShader2/aiStandard3",
+                                            "/aiStandard3displacementShader2/checker",
+                                            "/aiStandard3displacementShader2/displacementShader2",
+                                            "/aiStandard3displacementShader2/noise1",
+                                            "/aiStandard5displacementShader3/aiStandard5",
+                                            "/aiStandard5displacementShader3/displacementShader3",
+                                            "/aiStandard5displacementShader3/checker1_cc",
+                                            "/aiStandard5displacementShader3/checker1",
+                                            "/place2dTexture1_u",
+                                            "/place2dTexture1_v",
+                                            "/place2dTexture1",
+                                            "/place2dTexture1_passthrough",
+                                            "/place2dTexture2_u",
+                                            "/place2dTexture2_v",
+                                            "/place2dTexture2",
+                                            "/place2dTexture2_passthrough",
+                                        };
+
+    AiBegin();
+    bool success = true;
+    AiSceneLoad(nullptr, "scene.usda", nullptr);
+
+    for (auto &testName : includeList) {
+        std::string name = "/beautiful/scope" + testName;
+        if (!AiNodeLookUpByName(name.c_str())) {
+            success = false;
+            AiMsgError("%s doesn't exist", name.c_str());
+        }
+    }
+    std::vector<std::string> excludeList = {"/checker",
+                                            "/checker1",
+                                            "/bulge1",
+                                            "/displacementShader1",
+                                            "/displacementShader2",
+                                            "/displacementShader3",
+                                            "/noise1",
+                                            "/checker1_cc" };
+    for (auto &testName : excludeList) {
+        if (AiNodeLookUpByName(testName.c_str())) {
+            success = false;
+            AiMsgError("%s shouldn't exist", testName.c_str());
+        }
+        std::string name = "/beautiful/scope" + testName;
+        if (AiNodeLookUpByName(name.c_str())) {
+            success = false;
+            AiMsgError("%s shouldn't exist", name.c_str());
+        }
+    }
+
+    AiEnd();
+    return (success) ? 0 : 1;
+}
+
+
+
+
+
+
+

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -127,12 +127,32 @@ void UsdArnoldWriter::Write(const AtUniverse *universe)
         _stage->SetMetadata(_tokens->endFrame, (double)endFrame);        
     }
 
-    // Loop over the universe nodes, and write each of them
-    AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, _mask);
+    // Loop over the universe nodes, and write each of them. We first want to write all node
+    // except shaders. Those assigned to geometries will be exported during the process, 
+    // with a given material's scope (#1067)
+    AtNodeIterator *iter = AiUniverseGetNodeIterator(_universe, _mask  & ~AI_NODE_SHADER );
     while (!AiNodeIteratorFinished(iter)) {
         WritePrimitive(AiNodeIteratorGetNext(iter));
     }
     AiNodeIteratorDestroy(iter);
+
+    // Then, do a second loop only through shaders in the arnold universe.
+    // Those that weren't exported yet in the previous step, and that aren't 
+    // therefore assigned to any geometry, will be exported here 
+    if (_mask & AI_NODE_SHADER) {
+        iter = AiUniverseGetNodeIterator(_universe, AI_NODE_SHADER );
+        while (!AiNodeIteratorFinished(iter)) {
+            AtNode *node = AiNodeIteratorGetNext(iter);
+            // check if the shader was previously exported, i.e if it's
+            // part of a shading tree assigned to a geometry
+            if (_exportedShaders.find(node) != _exportedShaders.end())
+                continue;
+            WritePrimitive(node);
+        }
+        AiNodeIteratorDestroy(iter);
+            
+    }
+    
     _universe = nullptr;
 }
 
@@ -146,26 +166,28 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
         return;
     }
 
-    AtString nodeName = AtString(AiNodeGetName(node));
-
-    static const AtString rootStr("root");
-    static const AtString ai_default_reflection_shaderStr("ai_default_reflection_shader");
-    static const AtString ai_default_color_managerStr("ai_default_color_manager_ocio");
+    std::string nodeName(AiNodeGetName(node));
+    
+    static const std::string rootStr("root");
+    static const std::string ai_default_reflection_shaderStr("ai_default_reflection_shader");
+    static const std::string ai_default_color_managerStr("ai_default_color_manager_ocio");
 
     // some Arnold nodes shouldn't be saved
     if (nodeName == rootStr || nodeName == ai_default_reflection_shaderStr || nodeName == ai_default_color_managerStr) {
         return;
     }
+    if (!_scope.empty())
+        nodeName = _scope + nodeName;
 
     // Check if this arnold node has already been exported, and early out if it was.
     // Note that we're storing the name of the arnold node, which might be slightly
     // different from the USD prim name, since UsdArnoldPrimWriter::GetArnoldNodeName
     // replaces some forbidden characters by underscores.
-    if (!nodeName.empty() && IsNodeExported(nodeName))
-        return;
-
-    if (!nodeName.empty())
+    if (!nodeName.empty()) {
+        if (IsNodeExported(nodeName))
+            return;
         _exportedNodes.insert(nodeName); // remember that we already exported this node
+    }
 
     std::string objType = AiNodeEntryGetName(AiNodeGetNodeEntry(node));
     UsdArnoldPrimWriter *primWriter = _registry->GetPrimWriter(objType);

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -74,7 +74,7 @@ public:
     UsdTimeCode GetTime(float delta) const { return _time.IsDefault() ? UsdTimeCode(delta) : UsdTimeCode(_time.GetValue() + delta);}
     void SetFrame(float frame) {_time = UsdTimeCode(frame);}
     
-    bool IsNodeExported(const AtString &name) { return _exportedNodes.count(name) == 1; }
+    bool IsNodeExported(const std::string &name) { return _exportedNodes.count(name) == 1; }
 
     const std::string &GetScope() const {return _scope;}
     void SetScope(const std::string &scope) {
@@ -166,6 +166,14 @@ public:
         SetAttribute(attr, value, subFrame);
     }
 
+    // Remember that this shader was already exported, possibly under a material's scope.
+    // We won't want to author it again in the last shader loop (#1067)
+    void SetExportedShader(const AtNode *shader)
+    {
+        if (shader)
+            _exportedShaders.insert(shader);
+    }
+
 private:
     const AtUniverse *_universe;        // Arnold universe to be converted
     UsdArnoldWriterRegistry *_registry; // custom registry used for this writer. If null, a global
@@ -177,7 +185,9 @@ private:
                                         // determining what arnold nodes must be saved out
     float _shutterStart;
     float _shutterEnd;
-    std::unordered_set<AtString, AtStringHash> _exportedNodes; // list of arnold attributes that were exported
+
+    std::unordered_set<std::string> _exportedNodes; // List of node names that were exported (including material scope)
+    std::unordered_set<const AtNode *> _exportedShaders; // list of shader nodes that were exported
     std::string _scope;                // scope in which the primitives must be written
     bool _allAttributes;               // write all attributes to usd prims, even if they're left to default
     UsdTimeCode _time;                 // current time required by client code


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we're now authoring shaders under their respective material's scope. For that we've needed to do the following changes :
- we split the loop through arnold nodes to be written in 2. First for all nodes except shaders, and a second one with only shaders
- in `processMaterialBinding` we create a material based on the surface (and eventually displacement) shader. And we then set the material's path as the new writer scope while we trigger the export of surface/displacement shaders. This way the shaders will be written under the material's hierarchy, and it will propagate to the whole shading tree
- when we check if a node was already written (to avoid doing it multiple times), we ensure the scope is taken into account. Therefore the same shader can now be authored multiple times, once for every different material it's assigned to
- in the second loop to write all shaders, we only consider those that weren't exported in the previous step, i.e. which aren't part of any shading tree assigned to a geometry. Only those will be authored with a regular naming (not under any material)
- Fixed an issue when testing if a shape was assigned to arnold's default shader. The previous code would have failed when a scope was being used
- Fixed test_0138 , as the shader names are now different
- Added test_0208 that exercises this

Fixes #1067 
