### PR TITLE
Write enum attributes as tokens instead of strings

### DIFF
--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -163,18 +163,18 @@ const ParamConversionMap& _ParamConversionMap()
               return AiM4IsIdentity(AiNodeGetMatrix(no, na));
           }}},
         {AI_TYPE_ENUM,
-         {SdfValueTypeNames->String,
+         {SdfValueTypeNames->Token,
           [](const AtNode* no, const char* na) -> VtValue {
               const auto* nentry = AiNodeGetNodeEntry(no);
               if (nentry == nullptr) {
-                  return VtValue("");
+                  return VtValue(TfToken(""));
               }
               const auto* pentry = AiNodeEntryLookUpParameter(nentry, na);
               if (pentry == nullptr) {
-                  return VtValue("");
+                  return VtValue(TfToken(""));
               }
               const auto enums = AiParamGetEnum(pentry);
-              return VtValue(_GetEnum(enums, AiNodeGetInt(no, na)));
+              return VtValue(TfToken(_GetEnum(enums, AiNodeGetInt(no, na))));
           },
           [](const AtNode* no, const char* na, const AtParamValue* pentry) -> bool {
               return (pentry->INT() == AiNodeGetInt(no, na));


### PR DESCRIPTION
**Changes proposed in this pull request**
We now author enum attributes as token attrs instead of strings. This fixes the errors we were facing, and these attributes are now authored properly

**Issues fixed in this pull request**
Fixes #1071 
