### PR TITLE
Fix build issues with usd 21.02 

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -543,7 +543,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
         
 
         // Check if light temperature is enabled, and eventually set the light color properly
-#if PXR_VERSION >= 2105
+#if PXR_VERSION >= 2102
         const TfToken enableColorTemperatureToken(UsdLuxTokens->inputsEnableColorTemperature);
         const TfToken colorTemperatureToken(UsdLuxTokens->inputsColorTemperature);
 #else


### PR DESCRIPTION
**Changes proposed in this pull request**
The light attribute tokens for temperature were changed in 21.02 and not in 21.05, we need to change the ifdef to build against 21.02

**Issues fixed in this pull request**
Fixes #1075

**Additional context**
Add any other context or screenshots about the pull request here.
