### PR TITLE
Add point_light to the list of schemas to be generated #1081

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -406,6 +406,7 @@ nativeUsdList = {
     'cylinder' : ignoreShapeAttributes + ['radius', 'shader'],
     'cone' : ignoreShapeAttributes + ['bottom_radius', 'shader'],
     'light' : ignoreLightAttributes,
+    'point_light' : ignoreLightAttributes + ['position', 'radius'],
     'distant_light' : ignoreLightAttributes + ['angle'],
     'skydome_light' : ignoreLightAttributes + ['filename', 'format'],
     'disk_light' : ignoreLightAttributes + ['radius'],


### PR DESCRIPTION
**Changes proposed in this pull request**
We just need to add `point_light`  to the `nativeUsdList` so that generate the API schema for it (this ended up causing problems in mayaUSD as it relies on the API schemas)
**Issues fixed in this pull request**
Fixes #1081 
