### PR TITLE
Fix attribute calls in camera reader that were causing random crashes

### DIFF
--- a/translator/reader/read_camera.cpp
+++ b/translator/reader/read_camera.cpp
@@ -61,12 +61,12 @@ void UsdArnoldReadCamera::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AiNodeSetFlt(node, str::fov, fov);
 
         VtValue focusDistanceValue;
-        if (cam.CreateFocusDistanceAttr().Get(&focusDistanceValue, time.frame)) {
+        if (cam.GetFocusDistanceAttr().Get(&focusDistanceValue, time.frame)) {
             AiNodeSetFlt(node, str::focus_distance, VtValueGetFloat(focusDistanceValue));
         }
     }
     GfVec2f clippingRange;
-    cam.CreateClippingRangeAttr().Get(&clippingRange, time.frame);
+    cam.GetClippingRangeAttr().Get(&clippingRange, time.frame);
     AiNodeSetFlt(node, str::near_clip, clippingRange[0]);
     AiNodeSetFlt(node, str::far_clip, clippingRange[1]);
 


### PR DESCRIPTION
For some reason, in the camera reader we were using wrong functions by mistake to get the values for attributes "clippingRange" and "focusDistance". Instead of calling the usual "Get" functions, we were the "Create" functions that eventually create the attribute if it's not defined. 
Modifying the usd stage while traversing it in parallel was definitely not something to do, and this ended up causing crashes in specific scenarios

**Issues fixed in this pull request**
Fixes #1087 
