### PR TITLE
Add aov_shaders after primvar AOVs.

### DIFF
--- a/render_delegate/render_pass.cpp
+++ b/render_delegate/render_pass.cpp
@@ -620,8 +620,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             std::vector<AtString> outputs;
             outputs.reserve(numBindings);
             std::vector<AtString> lightPathExpressions;
-            // first add the user aov_shaders
-            std::vector<AtNode*> aovShaders = _aovShaders;
+            std::vector<AtNode*> aovShaders;
             // When creating the outputs array we follow this logic:
             // - color -> RGBA RGBA for the beauty box filter by default
             // - depth -> P VECTOR for remapping point to depth using the projection matrices closest filter by default
@@ -809,6 +808,9 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                     }
                 }
             }
+            // finally add the user aov_shaders at the end so they can access all the AOVs
+            aovShaders.insert(aovShaders.end(), _aovShaders.begin(), _aovShaders.end());
+
             if (!outputs.empty()) {
                 AiNodeSetArray(
                     _renderDelegate->GetOptions(), str::outputs,

--- a/translator/reader/read_options.cpp
+++ b/translator/reader/read_options.cpp
@@ -148,6 +148,8 @@ static inline void UsdArnoldNodeGraphAovConnection(AtNode *options, const UsdAtt
             UsdPrim ngPrim = context.GetReader()->GetStage()->GetPrimAtPath(SdfPath(valStr));
             // We verify if the primitive is indeed a ArnoldNodeGraph
             if (ngPrim && ngPrim.GetTypeName() == _tokens->ArnoldNodeGraph) {
+                AtArray* array = AiNodeGetArray(options, str::aov_shaders);
+                unsigned numElements = AiArrayGetNumElements(array);
                 // We can use a UsdShadeShader schema in order to read connections
                 UsdShadeShader ngShader(ngPrim);
                 for (unsigned i=1;; i++) {
@@ -163,8 +165,9 @@ static inline void UsdArnoldNodeGraphAovConnection(AtNode *options, const UsdAtt
                         SdfPath outPath(sourcePaths[0].GetPrimPath());
                         UsdPrim outPrim = context.GetReader()->GetStage()->GetPrimAtPath(outPath);
                         if (outPrim) {
-                            // we connect to aov_shaders{0,...,n-1} parameters i.e. 0 indexed
-                            std::string outputElement = attrBase + "[" + std::to_string(i-1) + "]";
+                            // we connect to aov_shaders{0,...,n-1} parameters i.e. 0 indexed, offset from any previous connections
+                            unsigned index = numElements + i-1;
+                            std::string outputElement = attrBase + "[" + std::to_string(index) + "]";
                             context.AddConnection(options, outputElement, outPath.GetText(),
                                                   UsdArnoldReader::CONNECTION_PTR);
                         }


### PR DESCRIPTION
Fixes #1107

In the procedural we need to make sure we add the global aov_shaders after the primvar AOVs, currently they may overwrite them. Let's also change the ordering to match this in the render delegate.