### PR TITLE
Fix build issue in procedural against USD 21.11

### DIFF
--- a/translator/reader/utils.cpp
+++ b/translator/reader/utils.cpp
@@ -336,13 +336,17 @@ bool IsPrimVisible(const UsdPrim &prim, UsdArnoldReader *reader, float frame)
         return true;
     
     bool parentVisibility = IsPrimVisible(parent, reader, frame);
+    if (!parentVisibility)
+        return false;
+    
     if (!imageable)
-        return parentVisibility;
+        return true;
 
-    return imageable.ComputeVisibility(
-        (parentVisibility ? 
-            UsdGeomTokens->inherited : UsdGeomTokens->invisible), frame) != UsdGeomTokens->invisible;
-
+    VtValue value;
+    if (imageable.GetVisibilityAttr().Get(&value, frame)) {
+        return value.Get<TfToken>() != UsdGeomTokens->invisible;
+    }
+    return true;
 }
 size_t ReadStringArray(UsdAttribute attr, AtNode *node, const char *attrName, const TimeSettings &time)
 {


### PR DESCRIPTION
**Changes proposed in this pull request**
Recent commits are not building in USD 21.11. It's because one of the versions of `UsdGeomImageable::ComputeVisibility` has been removed. I'm computing it manually now, with the simple rule that visibility can either be `inherited` or `invisible`, and that a primitive is hidden if any of its ancestors is imageable and has visiblity set to `invisible`