### PR TITLE
Optimize nested instances in the render delegate

### DIFF
--- a/render_delegate/instancer.h
+++ b/render_delegate/instancer.h
@@ -73,7 +73,8 @@ public:
     /// @param prototypeId ID of the instanced shape.
     /// @param sampleArray Output struct to hold time sampled matrices.
     HDARNOLD_API
-    void CalculateInstanceMatrices(const SdfPath& prototypeId, HdArnoldSampledMatrixArrayType& sampleArray);
+    void CalculateInstanceMatrices(HdArnoldRenderDelegate* renderDelegate, 
+        const SdfPath& prototypeId, std::vector<AtNode *> &instancers);
 
     /// Sets the primvars on the instancer node.
     ///
@@ -86,8 +87,7 @@ public:
     /// @param childInstanceCount Number of child instances (for nested instancers)
     /// @param parentInstanceCount Returns the number of parent instances (for nested instancers)
     HDARNOLD_API
-    void SetPrimvars(AtNode* node, const SdfPath& prototypeId, size_t totalInstanceCount,
-                    size_t childInstanceCount, size_t &parentInstanceCount);
+    void SetPrimvars(AtNode* node, const SdfPath& prototypeId, size_t totalInstanceCount);
 
 protected:
     /// Syncs the primvars for the instancer.

--- a/render_delegate/shape.h
+++ b/render_delegate/shape.h
@@ -123,7 +123,7 @@ protected:
     void _UpdateInstanceVisibility(HdArnoldRenderParamInterrupt& param);
 
     HdArnoldRenderDelegate* _renderDelegate; ///< Pointer to the Arnold render delegate.
-    AtNode* _instancer = nullptr;            ///< Pointer to the Arnold Instancer.
+    std::vector<AtNode*> _instancers;        ///< Pointer to the Arnold Instancer.
     AtNode* _shape;                          ///< Pointer to the Arnold Shape.
     uint8_t _visibility = AI_RAY_ALL;        ///< Visibility of the mesh.
 };

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -392,7 +392,7 @@ void HdArnoldSetFaceVaryingPrimvar(
 HDARNOLD_API
 void HdArnoldSetInstancePrimvar(
     AtNode* node, const TfToken& name, const TfToken& role, const VtIntArray& indices, 
-    const VtValue& value, size_t parentInstanceCount = 1, size_t childInstanceCount = 1);
+    const VtValue& value);
 /// Sets positions attribute on an Arnold shape from a VtVec3fArray primvar.
 ///
 /// If velocities or accelerations are non-zero, the shutter range is non-instantaneous and the scene delegate only


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we're now creating nested arnold instancers when we find nested instancers in the delegate.
Instead of storing a single instancer node for each shape, we're storing a list of instancers (from child to parent).

Since we no longer need to flatten the full list of instances for each shape, a lot of code could be removed about the "parent" and "child" instance counts. The code that handles the creation and translation of the arnold instancer was now moved from shape.cpp to instancer.cpp, so that it also can be done for nested instancers.

Since things are done quite differently now, we need to ensure it didn't cause any regression. There are several test scenes in our testsuite to verify this (183, 186, 188, 194, 196, etc...). So far all my tests seem to be working properly

**Issues fixed in this pull request**
Fixes #1124 
