### PR TITLE
Fix builds for older versions of USD

### DIFF
--- a/usd_imaging/arnold_mesh_light_adapter.cpp
+++ b/usd_imaging/arnold_mesh_light_adapter.cpp
@@ -94,11 +94,14 @@ void ArnoldMeshLightAdapter::TrackVariability(
         }
     }
 
-#if PXR_VERSION >= 2105
+#if PXR_VERSION >= 2102
     // Establish a primvar desc cache entry.
     HdPrimvarDescriptorVector& vPrimvars = _GetPrimvarDescCache()->GetPrimvars(cachePath);
 #else
     UsdImagingValueCache* valueCache = _GetValueCache();
+#if PXR_VERSION >= 2011
+    HdPrimvarDescriptorVector& vPrimvars = valueCache->GetPrimvars(cachePath);
+#endif
 #endif
    
     // Compile a list of primvars to check.
@@ -113,7 +116,7 @@ void ArnoldMeshLightAdapter::TrackVariability(
     std::vector<UsdGeomPrimvar> local = primvarsAPI.GetPrimvarsWithValues();
     primvars.insert(primvars.end(), local.begin(), local.end());
     for (auto const &pv : primvars) {
-#if PXR_VERSION >= 2105
+#if PXR_VERSION >= 2011
         _ComputeAndMergePrimvar(prim, pv, UsdTimeCode(), &vPrimvars);
 #else
         _ComputeAndMergePrimvar(prim, cachePath, pv, UsdTimeCode(), valueCache);


### PR DESCRIPTION
**Changes proposed in this pull request**
More fixes on the mesh light adapter, but for older versions of USD (20.11, 21.02). Some APIs were different back at the time.