### PR TITLE
Fix uninitialized UV coords with leftHanded meshes

### DIFF
--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -228,6 +228,7 @@ void HdArnoldMesh::Sync(
             for (auto i = decltype(numFaces){0}; i < numFaces; ++i) {
                 const auto vertexCount = _vertexCounts[i];
                 if (Ai_unlikely(_vertexCounts[i] <= 0)) {
+                    nsides[i] = 0;
                     continue;
                 }
                 nsides[i] = vertexCount;

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -1509,7 +1509,7 @@ AtArray* HdArnoldGenerateIdxs(const VtIntArray& indices, const VtIntArray* verte
     if (vertexCounts != nullptr && !vertexCounts->empty()) {
         unsigned int vertexId = 0;
         for (auto vertexCount : *vertexCounts) {
-            if (Ai_unlikely(vertexCount <= 0) || Ai_unlikely(vertexId + vertexCount >= numIdxs)) {
+            if (Ai_unlikely(vertexCount <= 0) || Ai_unlikely(vertexId + vertexCount > numIdxs)) {
                 continue;
             }
             for (auto vertex = decltype(vertexCount){0}; vertex < vertexCount; vertex += 1) {


### PR DESCRIPTION
**Changes proposed in this pull request**
For recent versions of USD where we use indexed primvars differently, there was a typo in the code that reorders primvars indices for left-handed meshes.
When checking for out-of-bound indices in the primvar index arrays (in this case for `uvidxs` ), we were not comparing the indices correctly and skipping the values from the last polygon (there was a `>=` instead of a `>`).
Because of that, we were leaving the last few indices uninitialized, and that would randomly cause errors.

In the same vein, I'm also ensuring that we're not leaving uninitialized values in `nsides` when faces have no vertices, even though this is not what caused the original issue.

**Issues fixed in this pull request**
Fixes #1136 
