### PR TITLE
Light shaders

### DIFF
--- a/common/common_utils.h
+++ b/common/common_utils.h
@@ -21,6 +21,8 @@
 #include <pxr/base/arch/export.h>
 
 #include <pxr/base/gf/matrix4d.h>
+#include <pxr/imaging/hd/types.h>
+#include <pxr/usd/sdf/path.h>
 
 #include <ai.h>
 
@@ -39,5 +41,19 @@ std::string ArnoldUsdMakeCamelCase(const std::string &in);
 /// @return GfMatrix converted from the AtMatrix.
 ARCH_HIDDEN
 GfMatrix4d ArnoldUsdConvertMatrix(const AtMatrix& in);
+
+template <typename F>
+ARCH_HIDDEN
+void ArnoldUsdCheckForSdfPathValue(const VtValue& value, F&& f)
+{
+    if (value.IsHolding<SdfPath>()) {
+        f(value.UncheckedGet<SdfPath>());
+    } else if (value.IsHolding<std::string>()) {
+        const auto s = value.UncheckedGet<std::string>();
+        if (!s.empty() && *s.begin() == '/') {
+            f(SdfPath{value.UncheckedGet<std::string>()});
+        }
+    }
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/common/common_utils.h
+++ b/common/common_utils.h
@@ -21,7 +21,7 @@
 #include <pxr/base/arch/export.h>
 
 #include <pxr/base/gf/matrix4d.h>
-#include <pxr/imaging/hd/types.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/usd/sdf/path.h>
 
 #include <ai.h>

--- a/render_delegate/node_graph.h
+++ b/render_delegate/node_graph.h
@@ -114,6 +114,24 @@ public:
     HDARNOLD_API
     std::vector<AtNode*> GetTerminals(const TfToken& terminalBase) const;
 
+    /// Utility function to return a shader graph for a given terminal.
+    ///
+    /// @param renderIndex
+    /// @param id Path to ArnoldNodeGraph
+    /// @param terminal Terminal token
+    /// @return Vector of pointers to the terminal, nullptr if not found.
+    HDARNOLD_API
+    static AtNode* GetNodeGraphTerminal(HdRenderIndex* renderIndex, const SdfPath& id, const TfToken& terminal);
+
+    /// Utility function to return multiple shader graphs for a given terminal base token.
+    ///
+    /// @param renderIndex
+    /// @param id Path to ArnoldNodeGraph
+    /// @param terminalBase Terminal base token
+    /// @return Vector of pointers to the terminal, nullptr if not found.
+    HDARNOLD_API
+    static std::vector<AtNode*> GetNodeGraphTerminals(HdRenderIndex* renderIndex, const SdfPath& id, const TfToken& terminalBase);
+
 protected:
     /// Utility struct to store translated nodes.
     struct NodeData {

--- a/render_delegate/node_graph_tracker.cpp
+++ b/render_delegate/node_graph_tracker.cpp
@@ -68,6 +68,24 @@ void HdArnoldNodeGraphTracker::TrackSingleNodeGraph(
     }
 }
 
+void HdArnoldNodeGraphTracker::TrackLightNodeGraph(
+        HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const SdfPath& nodeGraphId)
+{
+    // Initial assignment.
+    if (_nodeGraphs.empty()) {
+        _nodeGraphs.assign(1, nodeGraphId);
+        renderDelegate->TrackLightNodeGraphs(shapeId, _nodeGraphs);
+        // We already have a single material stored, check if it has changed.
+    } else {
+        if (_nodeGraphs.cdata()[0] != nodeGraphId) {
+            renderDelegate->UntrackLightNodeGraphs(shapeId, _nodeGraphs);
+            _nodeGraphs[0] = nodeGraphId;
+            renderDelegate->TrackLightNodeGraphs(shapeId, _nodeGraphs);
+        }
+    }
+}
+
+
 void HdArnoldNodeGraphTracker::UntrackNodeGraphs(HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId)
 {
     if (!_nodeGraphs.empty()) {

--- a/render_delegate/node_graph_tracker.h
+++ b/render_delegate/node_graph_tracker.h
@@ -63,6 +63,10 @@ public:
     void TrackSingleNodeGraph(
         HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const SdfPath& nodeGraphId);
 
+    HDARNOLD_API
+    void TrackLightNodeGraph(
+            HdArnoldRenderDelegate* renderDelegate, const SdfPath& shapeId, const SdfPath& nodeGraphId);
+
     /// Untrack all materials assigned to the shape. Typically used when deleting the shape.
     ///
     /// @param renderDelegate Pointer to the Arnold Render Delegate.


### PR DESCRIPTION
Fixes #1141

Looks for color, shader and light_filter# connections in the ArnoldNodeGraph referenced from the light primitive in the _primvars:arnold:shaders_ property.