### PR TITLE
Conform naming of aov_shaders attribute in the node graph

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -79,6 +79,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (deep)
     (raw)
     (instantaneousShutter)
+    ((aovShadersArray, "aov_shaders:i"))
     (GeometryLight)
 );
 // clang-format on
@@ -1408,7 +1409,7 @@ std::vector<AtNode*> HdArnoldRenderDelegate::GetAovShaders(HdRenderIndex* render
 {
     const HdArnoldNodeGraph *nodeGraph = HdArnoldNodeGraph::GetNodeGraph(renderIndex, _aov_shaders);
     if (nodeGraph)
-        return nodeGraph->GetTerminals(str::t_aov_shaders);
+        return nodeGraph->GetTerminals(_tokens->aovShadersArray);
     return std::vector<AtNode *>();
 }
 

--- a/translator/reader/read_options.cpp
+++ b/translator/reader/read_options.cpp
@@ -160,11 +160,18 @@ static inline void UsdArnoldNodeGraphAovConnection(AtNode *options, const UsdPri
                 // We can use a UsdShadeShader schema in order to read connections
                 UsdShadeShader ngShader(ngPrim);
                 for (unsigned i=1;; i++) {
-                    // the output terminal name will be aov_shader{1,...,n} as a contiguous array
-                    TfToken outputName(attrBase + std::to_string(i));
+                    // the output attribute name will be aov_shaders:i{1,...,n} as a contiguous array
+                    TfToken outputName(attrBase + std::string(":i") + std::to_string(i));
                     UsdShadeOutput outputAttr = ngShader.GetOutput(outputName);
-                    if (!outputAttr)
+                    if (!outputAttr) {
+                        // TEMP : testing with the older format aov_shaders1, aov_shaders2, etc...
+                        // to be removed
+                        outputName = TfToken(attrBase + std::to_string(i));
+                        outputAttr = ngShader.GetOutput(outputName);
+                    }
+                    if (!outputAttr) {
                         break;
+                    }
                     SdfPathVector sourcePaths;
                     // Check which shader is connected to this output
                     if (outputAttr.HasConnectedSource() && outputAttr.GetRawConnectedSourcePaths(&sourcePaths) &&


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR renames the attributes used for aov_shaders, so that they conform to the format used for other attributes in arnold-usd.
Insted of being called `aov_shaders1`, these attributes will be called `aov_shaders:i1` .

The change is done both in the render delegate and in the procedural. But in the procedural, we're still supporting the previous format temporarily.