### PR TITLE
Remove attributes reset in the lights delegate

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -629,9 +629,6 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
 
         AtNode *color = nullptr;
         std::vector<AtNode *> lightFilters;
-        AiNodeResetParameter(_light, str::color);
-        AiNodeResetParameter(_light, str::shader);
-        AiNodeResetParameter(_light, str::filters);
         HdArnoldRenderDelegate::PathSet pathSet;
 
         if (!lightShaderPath.IsEmpty()) {


### PR DESCRIPTION
**Changes proposed in this pull request**
Before checking the shaders connections to lights, we call `AiNodeResetParameter` on the light color to ensure IPR updates behave properly. But this is now overriding the code setting the light color attribute.
After looking more in depth at the code, there is already a `AiNodeReset(_light)` that resets the whole light before any attribute is set, so we don't actually need to reset any attribute in particular.
This PR removes the 3 attribute resets from this code, which fixes the issue with the lights colors

**Issues fixed in this pull request**
Fixes #1168
