### PR TITLE
Support render products with no productName

### DIFF
--- a/translator/reader/read_options.cpp
+++ b/translator/reader/read_options.cpp
@@ -257,14 +257,12 @@ void UsdArnoldReadRenderSettings::Read(const UsdPrim &prim, UsdArnoldReaderConte
         if (!renderProduct) // couldn't find the render product in the usd scene
             continue;
 
-        // The product name is supposed to return the output image filename
+        // The product name is supposed to return the output image filename.
+        // If none is provided, we'll use the primitive name
         VtValue productNameValue;
         std::string filename = renderProduct.GetProductNameAttr().Get(&productNameValue, time.frame) ?
-            VtValueGetString(productNameValue, &prim) : std::string();
+            VtValueGetString(productNameValue, &prim) : productPrim.GetName().GetText();
       
-        if (filename.empty()) // no filename is provided, we can skip this product
-            continue;
-
         // By default, we'll be saving out to exr
         std::string driverType = "driver_exr";
         std::string extension = TfGetExtension(filename);


### PR DESCRIPTION
**Changes proposed in this pull request**
We were previously skipping all `RenderProduct` primitives with an empty `productName`. This was skipping all AOVs where the product name wasn't explicitely set.
Now, in this case we just use the product primitive name, and default to a .exr file.
Thus, by default, each AOV will render to a .exr file named as the render product.

In the case of merged .exrs, when all AOVs (RenderVars) are part of the same render product, then rendering with `kick -o output.exr` will therefore override the filename for all AOVs.

**Issues fixed in this pull request**
Fixes #1170 
