### PR TITLE
Revert to SdrShaderNodes for discovery plugin

### DIFF
--- a/ndr/parser.cpp
+++ b/ndr/parser.cpp
@@ -60,14 +60,16 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 
 namespace {
 
-// We have to subclass NdrProperty, because SdrShaderProperty ignores certain shader
-// parameter types that Arnold supports, like 4 component colors.
-class ArnoldShaderProperty : public NdrProperty {
+// We have to subclass SdrShaderProperty, because it tries to read the SdfType
+// from a token, and it doesn't support all the parameter types arnold does,
+// like the 4 component color. Besides this, we also guarantee that the default
+// value will match the SdfType, as the SdfType comes from the default value.
+class ArnoldShaderProperty : public SdrShaderProperty {
 public:
     ArnoldShaderProperty(
         const TfToken& name, const SdfValueTypeName& typeName, const VtValue& defaultValue, bool isOutput,
-        size_t arraySize, const NdrTokenMap& metadata)
-        : NdrProperty(name, typeName.GetAsToken(), defaultValue, isOutput, arraySize, false, metadata),
+        size_t arraySize, const NdrTokenMap& metadata, const NdrTokenMap& hints, const NdrOptionVec& options)
+        : SdrShaderProperty(name, typeName.GetAsToken(), defaultValue, isOutput, arraySize, metadata, hints, options),
           _typeName(typeName)
     {
     }
@@ -132,16 +134,18 @@ NdrNodeUniquePtr NdrArnoldParserPlugin::Parse(const NdrNodeDiscoveryResult& disc
         // parameter types, so we just have to blindly pass all required
         // parameters.
         // TODO(pal): Read metadata and hints.
-        properties.emplace_back(NdrPropertyUniquePtr(new ArnoldShaderProperty{
+        properties.emplace_back(SdrShaderPropertyUniquePtr(new ArnoldShaderProperty{
             propertyName,       // name
             attr.GetTypeName(), // typeName
             v,                  // defaultValue
             false,              // isOutput
             0,                  // arraySize
-            NdrTokenMap()       // metadata
+            NdrTokenMap(),       // metadata
+            NdrTokenMap(),                       // hints
+            NdrOptionVec()                       // options
         }));
     }
-    return NdrNodeUniquePtr(new NdrNode(
+    return NdrNodeUniquePtr(new SdrShaderNode(
         discoveryResult.identifier,    // identifier
         discoveryResult.version,       // version
         discoveryResult.name,          // name


### PR DESCRIPTION
**Changes proposed in this pull request**
Rolling back the changes in #974 that changed `SdrShaderNode` and `SdrShaderProperty` by `NdrNode` / `NdrProperty`.
This isn't causing regressions in my tests, but might need more verifications

**Issues fixed in this pull request**
Fixes #1131 
