### PR TITLE
Use cache_id for instance nested usd procedurals

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -341,6 +341,7 @@ ASTR(osl_includepath);
 ASTR(outputs);
 ASTR(overrides);
 ASTR(parallel_node_init);
+ASTR(parent_instance);
 ASTR(penumbra_angle);
 ASTR(periodic);
 ASTR(persp_camera);

--- a/procedural/main.cpp
+++ b/procedural/main.cpp
@@ -114,14 +114,18 @@ procedural_init
     int cache_id = AiNodeGetInt(node, AtString("cache_id"));
     if (cache_id != 0) {
         // We have an id to load the Usd Stage in memory, using UsdStageCache
-        data->Read(cache_id, objectPath);
-    } else {
-        // We load a usd file, with eventual serialized overrides
-        const std::string originalFilename(AiNodeGetStr(node, AtString("filename")));
-        std::string filename(AiResolveFilePath(originalFilename.c_str(), AtFileType::Procedural));
-        applyProceduralSearchPath(filename, nullptr);
-        data->Read(filename, AiNodeGetArray(node, AtString("overrides")), objectPath);
-    }
+        if (data->Read(cache_id, objectPath))
+            return 1;
+        // If the reader didn't manage to load this cache id, then we read the usd data 
+        // through a filename as usual
+
+    } 
+    // We load a usd file, with eventual serialized overrides
+    const std::string originalFilename(AiNodeGetStr(node, AtString("filename")));
+    std::string filename(AiResolveFilePath(originalFilename.c_str(), AtFileType::Procedural));
+    applyProceduralSearchPath(filename, nullptr);
+    data->Read(filename, AiNodeGetArray(node, AtString("overrides")), objectPath);
+    
     return 1;
 }
 

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -351,6 +351,39 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
         SdfPath sdfPath(path);
         _hasRootPrim = true;
         _rootPrim = _stage->GetPrimAtPath(sdfPath);
+
+        // If this primitive is a prototype, then its name won't be consistent between sessions 
+        // (/__Prototype1 , /__Prototype2, etc...), it will therefore cause random results.
+        // In this case, we'll have stored a user data "parent_instance", with the name of a parent
+        // instanceable prim pointing to this prototype. It will allow us to find the expected prototype.
+        // Note that we don't want to do this if we have a cacheId, as in this case the prototype is 
+        // already the correct one
+        if (_cacheId == 0 && _procParent && _rootPrim &&
+#if PXR_VERSION >= 2011
+                _rootPrim.IsPrototype()
+#else
+                _rootPrim.IsMaster()
+#endif
+                && AiNodeLookUpUserParameter(_procParent, str::parent_instance)) {
+            
+            AtString parentInstance = AiNodeGetStr(_procParent, str::parent_instance); 
+            UsdPrim parentInstancePrim = _stage->GetPrimAtPath(SdfPath(parentInstance.c_str()));
+            if (parentInstancePrim) {
+                // our usd procedural has a uer-data "parent_instance" which returns the name of
+                // the instanceable prim. We want to check what is its prototype
+#if PXR_VERSION >= 2011
+                auto proto = parentInstancePrim.GetPrototype();
+#else
+                auto proto = parentInstancePrim.GetMaster();
+#endif
+                if (proto) {
+                    // We found a prototype, this is the primitive we want to use as a root prim
+                    _rootPrim = proto;
+                }
+
+            }            
+        }
+
         if (!_rootPrim) {
             AiMsgError(
                 "[usd] %s : Object Path %s is not valid", (_procParent) ? AiNodeGetName(_procParent) : "",
@@ -577,100 +610,6 @@ void UsdArnoldReader::ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext 
         if (proto) {
             
             AtArray *protoMatrix = nullptr;
-
-            /* The code below shouldn't be needed anymore, keeping it around in case we need it for
-                resaved .ass files
-
-            // If this instance is pointing to a reference file, we want to treat it in a special way 
-            // USD creates a prim e.g. /__Prototype1 that represents this referenced file. But if there 
-            // are multiple references in the scene, then their name is not always consistent. Therefore
-            // we need to ensure we're not giving such an object path in nested USD procedurals, otherwise
-            // we get random switches between the referenced files (see #1021). To prevent that we store
-            // every instance referenced files, along with their corresponding primitive name. This will be 
-            // used later in ProcessConnection, to set the proper filename in the nested procedural
-            if (prim.HasAuthoredReferences()) {
-                UsdPrimCompositionQuery compQuery = UsdPrimCompositionQuery::GetDirectReferences(prim);
-                std::vector<UsdPrimCompositionQueryArc> compArcs = compQuery.GetCompositionArcs();
-                if (compArcs.size() > 0) {
-                    PcpNodeRef nodeRef = compArcs[0].GetTargetNode();
-                    PcpLayerStackRefPtr stackRef = nodeRef.GetLayerStack();
-                    auto layers = stackRef->GetLayers();
-                    if (layers.size() > 0) {
-                        LockReader();
-                        // store the reference filename in a map, where the key is the prototype prim name
-                        
-                        auto &ref = _referencesMap[proto.GetPath().GetText()];
-                        // the map value is a pair of strings. The first element is the filename
-                        // and the second is the object path
-                        ref.filename = layers[0]->GetRealPath();
-                        // default to the current filename if no layer path is defined (#1093)
-                        if (ref.filename.empty())
-                            ref.filename = GetFilename();
-                        // objectPath is the name of the prototype primitive. Note that this is different from
-                        // the actual "proto" path name, which in practice will be e.g. __Prototype1, and that
-                        // will not be consistent.
-                        ref.objectPath = nodeRef.GetPath().GetText();
-
-                        // Get the variants map for the prototype prim
-                        bool hasVariants = prim.HasVariantSets();
-                        std::unordered_map<std::string, std::string> protoVariants;
-
-                        auto GetPrototypeData = [](const UsdPrim &prim, bool hasVariants, 
-                            const TimeSettings &time,
-                            std::unordered_map<std::string, std::string> &variants) 
-                        {
-                            if (!prim)
-                                return (AtArray*)nullptr;
-                            if (hasVariants) {
-                                // add the list of prototype's variant sets / variants to our map
-                                UsdVariantSets varSets = prim.GetVariantSets();
-                                std::vector<std::string> varSetNames = varSets.GetNames();
-                                for (auto &varSet : varSetNames) {
-                                    variants[varSet] = varSets.GetVariantSelection(varSet);
-                                }
-                            }
-                            // get the prototype's local matrix, as we need to "remove" it
-                            // from the instancable prim transform
-                            if (prim.IsA<UsdGeomXformable>()) {
-                                return ReadLocalMatrix(prim, time);
-                            }
-                            return (AtArray*)nullptr;
-                        };
-
-                        // We need to get informations about the actual primitive that is being instanced
-                        // (variants, transform). But the "proto" primitive that we have is just an intermediate primitive
-                        // so we need to load it from the stage, either the current one, or a new that loads a given
-                        // SdfLayer (when the reference is pointing to another file)
-                        UsdPrim protoPrim = _stage->GetPrimAtPath(nodeRef.GetPath());
-                        if (protoPrim) {
-                            protoMatrix = GetPrototypeData(protoPrim, hasVariants, time, protoVariants);
-                        } else {
-                            UsdStageRefPtr layerStage = UsdStage::Open(layers[0], UsdStage::LoadNone);
-                            protoPrim = layerStage->GetPrimAtPath(nodeRef.GetPath());
-                            protoMatrix = GetPrototypeData(protoPrim, hasVariants, time, protoVariants);
-                        }
-                        // Get all the variants for this instanceable primitive
-                        // and add them to a map. Note that we can associate this with the proto path, because
-                        // USD will create different prototypes when the same proto is instanciated with different
-                        // variants overrides (#1122)
-                        UsdVariantSets varSets = prim.GetVariantSets();
-                        std::vector<std::string> varSetNames = varSets.GetNames();
-                        for (const auto &varSet : varSetNames) {
-                            std::string variantValue = varSets.GetVariantSelection(varSet);
-                            const auto &it = protoVariants.find(varSet);
-                            // If the instanceable prim variant is the same as the prototype's one,
-                            // then there's no need to store the current variant
-                            if (it != protoVariants.end() && it->second == variantValue)
-                                continue;
-        
-                            ref.variants[varSet] = variantValue;
-                        }
-                        UnlockReader();
-                    }                
-                }
-            }
-            */
-
             AtNode *ginstance = context.CreateArnoldNode("ginstance", objName.c_str());
             if (prim.IsA<UsdGeomXformable>()) {
                 ReadMatrix(prim, ginstance, time, context);
@@ -1248,63 +1187,11 @@ bool UsdArnoldReaderThreadContext::ProcessConnection(const Connection &connectio
 
                         target = _reader->CreateNestedProc(connection.target.c_str(), context);
 
-                        /* this code shouldn't be needed anymore, keeping it around in case it 
-                           helps for resaved .ass files
-
-                           
-                        std::string childUsdEntry = "usd";
-                        const AtNode *parentProc = _reader->GetProceduralParent();
-                        if (parentProc)
-                            childUsdEntry = AiNodeEntryGetName(AiNodeGetNodeEntry(parentProc));
-
-                        target = CreateArnoldNode(childUsdEntry.c_str(), connection.target.c_str());
-
-                        std::string nestedFilename = _reader->GetFilename().c_str();
-                        std::string nestedObjectPath = connection.target;
-                        std::string nestedOverride;
-                        int cacheId = _reader->GetCacheId();
-
-                        // If this instance is pointing to a reference file, 
-                        // USD creates a prim e.g. /__Prototype1 that represents this referenced file. 
-                        // But if there multiple references in the scene, then their name is not always consistent. 
-                        // To prevent random results (see #1021), we set in this case the referenced filename
-                        // on the child usd procedural, instead of the "current" USD filename
-                        if (cacheId == 0)
-                            _reader->GetReferencePath(prim.GetPath().GetText(), nestedFilename, nestedObjectPath, nestedOverride);
-                        {
-                            // Now increment the ref count for this cache ID
-                            std::lock_guard<AtMutex> guard(s_globalReaderMutex);
-                            const auto &cacheIdIter = s_cacheRefCount.find(cacheId);
-                            if (cacheIdIter != s_cacheRefCount.end()) {
-                                cacheIdIter->second++;        
-                            }
-                        }
-
-                        AiNodeSetStr(target, str::filename, AtString(nestedFilename.c_str()));
-                        AiNodeSetStr(target, str::object_path, AtString(nestedObjectPath.c_str()));
-                        AiNodeSetInt(target, str::cache_id, cacheId);
-                        const TimeSettings &time = _reader->GetTimeSettings();
-                        AiNodeSetFlt(target, str::frame, time.frame); // give it the desired frame
-                        AiNodeSetFlt(target, str::motion_start, time.motionStart);
-                        AiNodeSetFlt(target, str::motion_end, time.motionEnd);
-                        const AtArray *readerOverrides = _reader->GetOverrides();
-                        AtArray *overrides = (readerOverrides != nullptr) ? AiArrayCopy(readerOverrides) : nullptr;
-
-                        if (!nestedOverride.empty()) {
-                            if (overrides) {
-                                AiArrayResize(overrides, AiArrayGetNumElements(overrides) + 1, 1);
-                            }
-                            else  {
-                                overrides = AiArrayAllocate(1, 1, AI_TYPE_STRING);
-                            }
-                            AiArraySetStr(overrides, AiArrayGetNumElements(overrides) - 1, nestedOverride.c_str());
-                        }
-                        if (overrides)
-                            AiNodeSetArray(target, str::overrides, overrides);
-                        // Hide the prototype, we'll only want the instance to be visible
-                        AiNodeSetByte(target, str::visibility, 0);
-                        AiNodeSetInt(target, str::threads, _reader->GetThreadCount());
-                        */
+                        // First time we create the nested proc, we want to add a user data with the first 
+                        // instanceable prim pointing to it
+                        // Declare the user data
+                        AiNodeDeclare(target, str::parent_instance, "constant STRING");
+                        AiNodeSetStr(target, str::parent_instance, AiNodeGetName(connection.sourceNode));
                     }
                 }
             }
@@ -1420,62 +1307,6 @@ bool UsdArnoldReaderContext::GetPrimVisibility(const UsdPrim &prim, float frame)
     }
     
     return true;
-}
-
-bool UsdArnoldReader::GetReferencePath(const std::string &primName, std::string &filename, 
-                                        std::string &objectPath, std::string &override)
-{
-    bool success = false;
-    std::unordered_map<std::string, std::string> variantsMap;
-    LockReader();
-    auto referencePath = _referencesMap.find(primName);
-    if (referencePath != _referencesMap.end()) {
-        filename = referencePath->second.filename;
-        objectPath = referencePath->second.objectPath;
-        // copy the variants map while we're locked. We'll
-        // serialize it after we unlock
-        variantsMap = referencePath->second.variants;
-        success = true;
-    }
-    UnlockReader();
-
-    if (!variantsMap.empty() && !objectPath.empty()) {
-        // Some variants were assigned to this prototype, 
-        // we want to check first if they're already part of the 
-        // actual prototype. If that's not the case, it means that 
-        // we need to override the variant here. The way we can do this
-        // is by adding an "overrides" statement in the nested usd procedural,
-        // that will modify the variant for this prim.
-        std::istringstream primsPath(objectPath.c_str());
-        std::string primPath;
-        override = "#usda 1.0\n";
-        int pathCount = 0;
-        while (std::getline(primsPath, primPath, '/')) {
-            if (primPath.empty())
-                continue;
-
-            if (pathCount > 0)
-                override += "{ ";
-            override += "over \"";
-            override += primPath;
-            override += "\"";
-            pathCount++;
-        }
-
-        override += "(variants = {\n";
-        for (auto &variant : variantsMap) {
-            // At this point we know the variant is different from the prototype
-            override += "string ";
-            override += variant.first;
-            override += " = \"";
-            override += variant.second;
-            override += "\"\n";
-        }
-        override += "}){";
-        for (int i = 0; i < pathCount; ++i)
-            override += "\n}";
-    }
-    return success;
 }
 
 void UsdArnoldReader::ComputeMotionRange(const UsdPrim &options)

--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -575,7 +575,12 @@ void UsdArnoldReader::ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext 
         auto proto = prim.GetMaster();
 #endif
         if (proto) {
+            
             AtArray *protoMatrix = nullptr;
+
+            /* The code below shouldn't be needed anymore, keeping it around in case we need it for
+                resaved .ass files
+
             // If this instance is pointing to a reference file, we want to treat it in a special way 
             // USD creates a prim e.g. /__Prototype1 that represents this referenced file. But if there 
             // are multiple references in the scene, then their name is not always consistent. Therefore
@@ -664,6 +669,7 @@ void UsdArnoldReader::ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext 
                     }                
                 }
             }
+            */
 
             AtNode *ginstance = context.CreateArnoldNode("ginstance", objName.c_str());
             if (prim.IsA<UsdGeomXformable>()) {
@@ -1240,6 +1246,12 @@ bool UsdArnoldReaderThreadContext::ProcessConnection(const Connection &connectio
                         // usd procedural that will only read this specific prim. Note that this 
                         // is similar to what is done by the point instancer reader
 
+                        target = _reader->CreateNestedProc(connection.target.c_str(), context);
+
+                        /* this code shouldn't be needed anymore, keeping it around in case it 
+                           helps for resaved .ass files
+
+                           
                         std::string childUsdEntry = "usd";
                         const AtNode *parentProc = _reader->GetProceduralParent();
                         if (parentProc)
@@ -1292,6 +1304,7 @@ bool UsdArnoldReaderThreadContext::ProcessConnection(const Connection &connectio
                         // Hide the prototype, we'll only want the instance to be visible
                         AiNodeSetByte(target, str::visibility, 0);
                         AiNodeSetInt(target, str::threads, _reader->GetThreadCount());
+                        */
                     }
                 }
             }

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -55,12 +55,14 @@ public:
 
     void Read(const std::string &filename, AtArray *overrides,
               const std::string &path = ""); // read a USD file
-    void Read(int cacheId, const std::string &path = ""); // read a USdStage from memory
+    bool Read(int cacheId, const std::string &path = ""); // read a USdStage from memory
     void ReadStage(UsdStageRefPtr stage,
                    const std::string &path = ""); // read a specific UsdStage
     void ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext &context, bool isInstance = false);
 
     void ClearNodes();
+    AtNode *CreateNestedProc(const char *objectPath, UsdArnoldReaderContext &context);
+    void InitCacheId();
 
     void SetProceduralParent(const AtNode *node);
     void SetUniverse(AtUniverse *universe);

--- a/translator/reader/reader.h
+++ b/translator/reader/reader.h
@@ -98,8 +98,6 @@ public:
     static unsigned int ReaderThread(void *data);
     static unsigned int ProcessConnectionsThread(void *data);
 
-    bool GetReferencePath(const std::string &primName, std::string &filename, std::string &objectPath, std::string &override);
-
     bool HasRootPrim() const {return _hasRootPrim;}
     const UsdPrim &GetRootPrim() const {return _rootPrim;}
 
@@ -197,12 +195,7 @@ public:
         }
     }
     void ComputeMotionRange(const UsdPrim &renderSettings);
-    
-    struct ReferenceData {
-        std::string filename;
-        std::string objectPath;
-        std::unordered_map<std::string, std::string> variants;
-    };
+        
 private:
     const AtNode *_procParent;          // the created nodes are children of a procedural parent
     AtUniverse *_universe;              // only set if a specific universe is being used
@@ -222,10 +215,7 @@ private:
 
     std::unordered_map<std::string, UsdCollectionAPI> _lightLinksMap;
     std::unordered_map<std::string, UsdCollectionAPI> _shadowLinksMap;
-    // store path to prototypes filenames & object paths
-    std::unordered_map<std::string, ReferenceData> _referencesMap; 
-    std::unordered_map<std::string, std::string> _overridesMap; 
-
+    
     AtNode *_defaultShader;
     std::string _filename; // usd filename that is currently being read
     AtArray *_overrides;   // usd overrides that are currently being applied on top of the usd file


### PR DESCRIPTION
**Changes proposed in this pull request**
When we need to create nested usd procedurals for instances, we were relying on a usd filename, which caused lots of randomness issues (prototype names aren't consistent). 
We also had to do complex setups for variants overrides, transforms on the instanceable prim, etc... 
In this PR, we switch to using a UsdStageCache and a cacheId in the nested procedurals. When the usd reader needs to create a nested usd proc, it now stores its stage in the stage cache, and passes it to the child procs. This way, the child procs will share the same stage, and there won't be any randomness.

We use a reference counting system, so that once all the procedurals finished reading the data, we release the memory from the stage.

We have a special case when we resave the usd scenes to ass files, because then the cache id no longer makes sense. In this case, to avoid the original random issues with prototypes, we author a user data `parent_instance` in the nested usd procedural, with the name of a parent instance (which is consistent). This way, we can easily find back the correct prototype name and render as expected.

**Issues fixed in this pull request**
Fixes #1187 
