### PR TITLE
Curve pinning for the render delegate, reader and writer

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -446,6 +446,7 @@ ASTR(visibility);
 ASTR(vlist);
 ASTR(volume);
 ASTR(width);
+ASTR(wrap_mode);
 ASTR(wrapS);
 ASTR(wrapT);
 ASTR(xres);

--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -81,6 +81,7 @@ void HdArnoldBasisCurves::Sync(
         const auto topology = GetBasisCurvesTopology(sceneDelegate);
         const auto curveBasis = topology.GetCurveBasis();
         const auto curveType = topology.GetCurveType();
+        const auto curveWrap = topology.GetCurveWrap();
         if (curveType == HdTokens->linear) {
             AiNodeSetStr(GetArnoldNode(), str::basis, str::linear);
             _interpolation = HdTokens->linear;
@@ -98,6 +99,10 @@ void HdArnoldBasisCurves::Sync(
                 AiNodeSetStr(GetArnoldNode(), str::basis, str::linear);
                 _interpolation = HdTokens->linear;
             }
+#if ARNOLD_VERSION_NUMBER >= 70103
+            if (curveBasis == HdTokens->bSpline || curveBasis == HdTokens->catmullRom)
+                AiNodeSetStr(GetArnoldNode(), str::wrap_mode, AtString{curveWrap.GetText()});
+#endif
         }
         const auto& vertexCounts = topology.GetCurveVertexCounts();
         // When interpolation is linear, we clear out stored vertex counts, because we don't need them anymore.

--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -408,18 +408,22 @@ void UsdArnoldReadCurves::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
     if (prim.IsA<UsdGeomBasisCurves>()) {
         // TODO: use a scope_pointer for curves and basisCurves.
         UsdGeomBasisCurves basisCurves(prim);
-        TfToken curveType;
+        TfToken curveType, wrapMode;
         basisCurves.GetTypeAttr().Get(&curveType, frame);
+        basisCurves.GetWrapAttr().Get(&curveWrap, frame);
         if (curveType == UsdGeomTokens->cubic) {
             TfToken basisType;
             basisCurves.GetBasisAttr().Get(&basisType, frame);
-
             if (basisType == UsdGeomTokens->bezier)
                 basis = str::bezier;
             else if (basisType == UsdGeomTokens->bspline)
                 basis = str::b_spline;
             else if (basisType == UsdGeomTokens->catmullRom)
                 basis = str::catmull_rom;
+#if ARNOLD_VERSION_NUMBER >= 70103
+            if (basisType == UsdGeomTokens->bspline || basisType == UsdGeomTokens->catmullRom)
+                AiNodeSetStr(GetArnoldNode(), str::wrap_mode, AtString{curveWrap.GetText()});
+#endif
         }
     }
     AiNodeSetStr(node, str::basis, basis);

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -200,9 +200,15 @@ void UsdArnoldWriteCurves::Write(const AtNode *node, UsdArnoldWriter &writer)
             break;
         case 1:
             writer.SetAttribute(curves.GetBasisAttr(), TfToken(UsdGeomTokens->bspline));
+#if ARNOLD_VERSION_NUMBER >= 70103
+            writer.SetAttribute(curves.GetWrapAttr(), TfToken(AiNodeGetStr(node, AtString("wrap_mode"))));
+#endif
             break;
         case 2:
             writer.SetAttribute(curves.GetBasisAttr(), TfToken(UsdGeomTokens->catmullRom));
+#if ARNOLD_VERSION_NUMBER >= 70103
+            writer.SetAttribute(curves.GetWrapAttr(), TfToken(AiNodeGetStr(node, AtString("wrap_mode"))));
+#endif
             break;
         default:
         case 3:


### PR DESCRIPTION
Fixes #800.

Pass the wrap_mode through to the arnold shape from the usd primitive and hydra, conversely set wrap attribute from arnold in the writer.