### PR TITLE
Support render products with no productName #1170 (#1172)

### DIFF
--- a/translator/reader/read_options.cpp
+++ b/translator/reader/read_options.cpp
@@ -299,14 +299,12 @@ void UsdArnoldReadRenderSettings::Read(const UsdPrim &prim, UsdArnoldReaderConte
         if (!renderProduct) // couldn't find the render product in the usd scene
             continue;
 
-        // The product name is supposed to return the output image filename
+        // The product name is supposed to return the output image filename.
+        // If none is provided, we'll use the primitive name
         VtValue productNameValue;
         std::string filename = renderProduct.GetProductNameAttr().Get(&productNameValue, time.frame) ?
-            VtValueGetString(productNameValue, &prim) : std::string();
+            VtValueGetString(productNameValue, &prim) : productPrim.GetName().GetText();
       
-        if (filename.empty()) // no filename is provided, we can skip this product
-            continue;
-
         // By default, we'll be saving out to exr
         std::string driverType = "driver_exr";
         std::string extension = TfGetExtension(filename);


### PR DESCRIPTION
(cherry picked from commit caa8bd79f8e3171607e0e6ae0bb9f68f09b5437c)

**Changes proposed in this pull request**
Re-introducing the change done in #1172 , that was accidentally reverted in #1173

**Issues fixed in this pull request**
Fixes #1170 
