### PR TITLE
Fix issue with mtlx standard surface in the render delegate #1181

### DIFF
--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -594,7 +594,7 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNode(const HdMaterialNode& node)
     const auto* nodeTypeStr = node.identifier.GetText();
     bool isMaterialx = false;
     const AtString nodeType(strncmp(nodeTypeStr, "arnold:", 7) == 0 ? nodeTypeStr + 7 : nodeTypeStr);
-    if (node.identifier != str::ND_standard_surface_surfaceshader && strncmp(nodeTypeStr, "ND_", 3) == 0) {
+    if (node.identifier != str::t_ND_standard_surface_surfaceshader && strncmp(nodeTypeStr, "ND_", 3) == 0) {
         isMaterialx = true;
     }
 

--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -594,7 +594,7 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNode(const HdMaterialNode& node)
     const auto* nodeTypeStr = node.identifier.GetText();
     bool isMaterialx = false;
     const AtString nodeType(strncmp(nodeTypeStr, "arnold:", 7) == 0 ? nodeTypeStr + 7 : nodeTypeStr);
-    if (node.identifier != str::t_standard_surface && strncmp(nodeTypeStr, "ND_", 3) == 0) {
+    if (node.identifier != str::ND_standard_surface_surfaceshader && strncmp(nodeTypeStr, "ND_", 3) == 0) {
         isMaterialx = true;
     }
 


### PR DESCRIPTION
In the render delegate, we were not reading correctly standard_surface shaders coming from a materialx document, due an error in some string comparisons