### PR TITLE
Ignore distant lights normalize attribute in the delegate

### DIFF
--- a/render_delegate/light.cpp
+++ b/render_delegate/light.cpp
@@ -305,6 +305,9 @@ auto distantLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* ne
                            HdSceneDelegate* sceneDelegate, HdArnoldRenderDelegate* renderDelegate) {
     TF_UNUSED(filter);
     iterateParams(light, nentry, id, sceneDelegate, distantParams);
+    // For distant lights, we want to ignore the normalize attribute, as it's not behaving
+    // as expected in arnold (see #1191)
+    AiNodeResetParameter(light, str::normalize);
 };
 
 auto diskLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* nentry, const SdfPath& id,


### PR DESCRIPTION
When distant lights have normalize disabled, they don't behave as expected. Until this is fixed, we're ignoring this parameter in the render delegate, just like we do for the procedural 
**Issues fixed in this pull request**
Fixes #1191 

**Additional context**
Add any other context or screenshots about the pull request here.
