### PR TITLE
Fix usdPreviewSurface attribute useSpecularWorkflow in the procedural

### DIFF
--- a/translator/reader/read_shader.cpp
+++ b/translator/reader/read_shader.cpp
@@ -195,7 +195,7 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
             paramInput.Get(&specularWorkflow, time.frame);
         }
 
-        if (specularWorkflow == 1) {
+        if (specularWorkflow == 0) {
             // metallic workflow, set the specular color to white and use the
             // metalness
             AiNodeSetRGB(node, str::specular_color, 1.f, 1.f, 1.f);


### PR DESCRIPTION
In the procedural, the attribute usdSpecularWorkflow was not interpreted correctly. This PR fixes it

**Issues fixed in this pull request**
Fixes #1183 
