### PR TITLE
Fix build issue with older versions of Arnold 

### DIFF
--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -733,7 +733,7 @@ AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const At
 {
 #if ARNOLD_VERSION_NUMBER < 70103
     return nullptr;
-#endif
+#else
     const char *nodeTypeChar = nodeType.c_str();
     if (nodeType == str::ND_standard_surface_surfaceshader) {
         AtNode *node = AiNode(_renderDelegate->GetUniverse(), str::standard_surface, nodeName);
@@ -755,6 +755,7 @@ AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const At
     }
 
     return nullptr;
+#endif
 }
 bool HdArnoldNodeGraph::ClearUnusedNodes()
 {


### PR DESCRIPTION
**Changes proposed in this pull request**
As described in #1217, the ifdefs weren't correctly placed. Fixing it so that we don't try to call APIs that don't exist for a given version of arnold

**Issues fixed in this pull request**
Fixes #1217 
