### PR TITLE
Disable MaterialX shaders unless variable is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif ()
 endif ()
 
+if (ENABLE_MATERIALX)
+    add_compile_options(-D_ARNOLD_MATERIALX=1)
+endif ()
+
 # Common directory includes.
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/common")
 set(COMMON_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif ()
 
 if (ENABLE_MATERIALX)
-    add_compile_options(-D_ARNOLD_MATERIALX=1)
+    add_compile_options(-DARNOLD_MATERIALX=1)
 endif ()
 
 # Common directory includes.

--- a/SConstruct
+++ b/SConstruct
@@ -105,6 +105,7 @@ vars.AddVariables(
     BoolVariable('BUILD_DOCS', 'Whether or not to build the documentation.', True),
     BoolVariable('PROC_SCENE_FORMAT', 'Whether or not to build the procedural with a scene format plugin.', True),
     BoolVariable('DISABLE_CXX11_ABI', 'Disable the use of the CXX11 abi for gcc/clang', False),
+    BoolVariable('ENABLE_MATERIALX', 'Support reading MaterialX shaders', False),
     StringVariable('BOOST_LIB_NAME', 'Boost library name pattern', 'boost_%s'),
     StringVariable('TBB_LIB_NAME', 'TBB library name pattern', '%s'),
     StringVariable('USD_MONOLITHIC_LIBRARY', 'Name of the USD monolithic library', 'usd_ms'),
@@ -372,6 +373,9 @@ env.Append(LIBPATH = [p for p in [BOOST_LIB, PYTHON_LIB, TBB_LIB, GOOGLETEST_LIB
 
 env['ROOT_DIR'] = os.getcwd()
 
+if env['ENABLE_MATERIALX']:
+    env.Append(CPPDEFINES = Split('ARNOLD_MATERIALX'))
+    
 # including common headers
 env.Append(CPPPATH = [os.path.join(env['ROOT_DIR'], 'common')])
 env['COMMON_SRC'] = [os.path.join(env['ROOT_DIR'], 'common', src) for src in find_files_recursive(os.path.join(env['ROOT_DIR'], 'common'), ['.cpp'])]

--- a/cmake/utils/options.cmake
+++ b/cmake/utils/options.cmake
@@ -34,7 +34,8 @@ option(BUILD_DOCS "Builds the Documentation" ON)
 option(BUILD_TESTSUITE "Builds the testsuite" ON)
 option(BUILD_UNIT_TESTS "Build the unit tests" OFF)
 option(BUILD_USE_PYTHON3 "Use python 3." OFF)
-option(BUILD_ENABLE_MATERIALX_SUPPORT "Enables MaterialX support for USD 21.08 and later." OFF)
+
+option(ENABLE_MATERIALX "Support reading MaterialX shaders." OFF)
 
 set(PREFIX_PROCEDURAL "procedural" CACHE STRING "Directory to install the procedural under.")
 set(PREFIX_PLUGINS "plugin" CACHE STRING "Directory to install the plugins (Hydra and Ndr) under.")

--- a/render_delegate/CMakeLists.txt
+++ b/render_delegate/CMakeLists.txt
@@ -58,16 +58,6 @@ set(_usd_deps arch plug tf vt gf work sdf hf hd usdImaging usdLux pxOsd cameraUt
 if (${USD_VERSION} VERSION_LESS "0.20.5")
     set(_usd_deps ${_usd_deps} hdx)
 endif ()
-# Enable materialx support in the render delegate.
-if (${USD_VERSION} VERSION_GREATER_EQUAL "0.21.8" AND BUILD_ENABLE_MATERIALX_SUPPORT)
-    find_package(MaterialX REQUIRED)
-    target_include_directories(hdArnold PUBLIC ${MATERIALX_INCLUDE_DIRS})
-    set(_usd_deps ${_usd_deps} hdMtlx ndr sdr)
-    target_link_libraries(hdArnold PUBLIC ${MATERIALX_LIBRARIES})
-    # TODO(pal): We need a new API to get this info from Arnold at runtime.
-    target_compile_definitions(hdArnold PUBLIC "ARNOLD_MATERIALX_STDLIB_DIR=\"${ARNOLD_MATERIALX_DIR}\"")
-    target_compile_definitions(hdArnold PUBLIC "ARNOLD_MATERIALX_BASE_DIR=\"${ARNOLD_LOCATION}\"")
-endif ()
 
 add_common_dependencies(
     TARGET_NAME hdArnold

--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -594,9 +594,11 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNode(const HdMaterialNode& node)
     const auto* nodeTypeStr = node.identifier.GetText();
     bool isMaterialx = false;
     const AtString nodeType(strncmp(nodeTypeStr, "arnold:", 7) == 0 ? nodeTypeStr + 7 : nodeTypeStr);
+#ifdef ARNOLD_MATERIALX
     if (node.identifier != str::t_ND_standard_surface_surfaceshader && strncmp(nodeTypeStr, "ND_", 3) == 0) {
         isMaterialx = true;
     }
+#endif
 
     TF_DEBUG(HDARNOLD_MATERIAL)
         .Msg("HdArnoldNodeGraph::ReadMaterial - node %s - type %s\n", node.path.GetText(), nodeType.c_str());
@@ -731,9 +733,12 @@ HdArnoldNodeGraph::NodeDataPtr HdArnoldNodeGraph::GetNode(const SdfPath& path, c
 
 AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const AtString &nodeName)
 {
-#if ARNOLD_VERSION_NUMBER < 70103
-    return nullptr;
-#else
+    // Disable materialx support until it's included in the USD libs
+    // that are shipped with Arnold
+#ifdef ARNOLD_MATERIALX
+    
+//#if ARNOLD_VERSION_NUMBER < 70103
+//    return nullptr;
     const char *nodeTypeChar = nodeType.c_str();
     if (nodeType == str::ND_standard_surface_surfaceshader) {
         AtNode *node = AiNode(_renderDelegate->GetUniverse(), str::standard_surface, nodeName);
@@ -754,6 +759,8 @@ AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const At
         return AiNode(_renderDelegate->GetUniverse(), AtString(nodeTypeChar + 10), nodeName);
     }
 
+    return nullptr;
+#else
     return nullptr;
 #endif
 }

--- a/translator/reader/read_shader.cpp
+++ b/translator/reader/read_shader.cpp
@@ -71,6 +71,7 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         return;
     }
 
+#ifdef ARNOLD_MATERIALX
     // MaterialX shader representing standard surface. In this case we just want to create an arnold standard_surface
     // shader and translate it as is
     if (shaderId == "ND_standard_surface_surfaceshader") {
@@ -94,7 +95,7 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
 
     // Materialx shaders will start with "ND_" in USD
     // We cannot read this for arnold versions up to 7.1.2.x, as the API to get OSL code didn't exist
-#if ARNOLD_VERSION_NUMBER >= 70103
+// #if ARNOLD_VERSION_NUMBER >= 70103
     if (strncmp(shaderId.c_str(), "ND_", 3) == 0) {
         // Create an OSL inline shader
         node = context.CreateArnoldNode("osl", nodeName.c_str());       
@@ -176,8 +177,8 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         
         return;
     }
-#endif
 
+#endif
     if (shaderId == "UsdPreviewSurface") {
         node = context.CreateArnoldNode("standard_surface", nodeName.c_str());
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR temporarily comments out the code needed to read materialx shaders, both in the procedural and in the delegate, as the USD static libs currently shipped with Arnold don't include the materialx plugin. An environment variable can restore it.

In the Cmake files, I'm removing the previous materialx build variables that are no longer relevant.

I'm commenting out the tests based on the arnold version since they're not needed with the new build variable. But I'm keeping them as comments so that we don't forget to restore them when the build variable is no longer needed