### PR TITLE
re-export core usd libraries symbols on macOS

### DIFF
--- a/procedural/macos_export_list
+++ b/procedural/macos_export_list
@@ -1,2 +1,5 @@
 _NodeLoader
 _SceneFormatLoader
+*pxrInternal_*Gf*
+*pxrInternal_*Vt*
+*pxrInternal_*Tf*

--- a/procedural/macos_export_list_no_scene
+++ b/procedural/macos_export_list_no_scene
@@ -1,1 +1,4 @@
 _NodeLoader
+*pxrInternal_*Gf*
+*pxrInternal_*Vt*
+*pxrInternal_*Tf*


### PR DESCRIPTION
**Changes proposed in this pull request**
- on macOS it allows to export only the symbols belonging to USD. Most of them are weak external symbols.

**Issues fixed in this pull request**
Fixes #1226

