### PR TITLE
Don't hide any usd symbols on Mac for shared usd libs

### DIFF
--- a/procedural/SConscript
+++ b/procedural/SConscript
@@ -121,14 +121,14 @@ if system.IS_LINUX:
     local_env.Append(LINKFLAGS = [ '-Wl,--exclude-libs=ALL' ])
     local_env.Append(CXXFLAGS = [ '-fvisibility=hidden' ])
 elif system.IS_DARWIN:
-    if local_env['ARNOLD_HAS_SCENE_FORMAT_API']:
-        if local_env['USD_BUILD_MODE'] == 'static':
+    # On Mac, we only hide symbols if we're linking against a static usd.
+    # Otherwise we get crashes e.g. with mayaUSD (see #1226)
+    if local_env['USD_BUILD_MODE'] == 'static':
+        if local_env['ARNOLD_HAS_SCENE_FORMAT_API']:
             export_list = os.path.join(src_proc_dir, 'macos_export_list')
         else:
-            export_list = os.path.join(src_proc_dir, 'macos_export_list_shared')
-    else:
-        export_list = os.path.join(src_proc_dir, 'macos_export_list_no_scene')
-    local_env.Append(LINKFLAGS = Split('-Xlinker -S -Xlinker -x -Xlinker -exported_symbols_list -Xlinker {} '.format(export_list)))
+            export_list = os.path.join(src_proc_dir, 'macos_export_list_no_scene')
+        local_env.Append(LINKFLAGS = Split('-Xlinker -S -Xlinker -x -Xlinker -exported_symbols_list -Xlinker {} '.format(export_list)))
 
 # Build shared library for the Alembic procedural
 USD = local_env.SharedLibrary('%s_proc' % local_env['USD_PROCEDURAL_NAME'], source_files, SHLIBPREFIX='')

--- a/procedural/macos_export_list_shared
+++ b/procedural/macos_export_list_shared
@@ -1,5 +1,0 @@
-_NodeLoader
-_SceneFormatLoader
-*pxrInternal_*Gf*
-*pxrInternal_*Vt*
-*pxrInternal_*Tf*


### PR DESCRIPTION
**Changes proposed in this pull request**
The fix done in #1227 wasn't actually enough, and we were still getting crashes with some scenes.
For now, when we build against shared usd libs on Mac, we should *not* try to hide the usd symbols.

**Issues fixed in this pull request**
Fixes #1226 
