### PR TITLE
Fix default render settings values set in the render delegate config

### DIFF
--- a/render_delegate/config.cpp
+++ b/render_delegate/config.cpp
@@ -52,17 +52,17 @@ TF_DEFINE_ENV_SETTING(HDARNOLD_log_flags_console, -1, "Override logging flags fo
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_log_flags_file, -1, "Override logging flags for file output, if non-negative.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_AA_samples, 10, "Number of AA samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_AA_samples, 3, "Number of AA samples by default.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_GI_diffuse_samples, 1, "Number of diffuse samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_diffuse_samples, 2, "Number of diffuse samples by default.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_GI_specular_samples, 1, "Number of specular samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_specular_samples, 2, "Number of specular samples by default.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_GI_transmission_samples, 1, "Number of transmission samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_transmission_samples, 2, "Number of transmission samples by default.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_GI_sss_samples, 1, "Number of sss samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_sss_samples, 2, "Number of sss samples by default.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_GI_volume_samples, 1, "Number of volume samples by default.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_volume_samples, 2, "Number of volume samples by default.");
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_threads, -1, "Number of Threads for CPU rendering by default.");
 


### PR DESCRIPTION
In the render delegate config.cpp, where environment variables can be set for some render settings, specific defaults are set for some attributes. For the samples attributes, the values don't match what we usually set as defaults.  These default values happen to be used when rendering in husk (not in interactive Solaris rendering, not when exporting to usd to kick the files).

So for example, if "Diffuse Samples" isn't explicitely set, in interactive rendering or kick, it will be left to the default value of 2. But in husk it will default to 1, as this is the value set in config.
Likewise, AA_samples is 10 by default in husk rendering, which seems too much.

This PR sets these sampling values in a way that matches what's done in other arnold plugins. AA_samples defaults to 3, and the other "samples" default to 2


