### PR TITLE
add GeometryLight in CreateFallbackSprim

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -1039,6 +1039,9 @@ HdSprim* HdArnoldRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
     if (typeId == HdPrimTypeTokens->domeLight) {
         return HdArnoldLight::CreateDomeLight(this, SdfPath::EmptyPath());
     }
+    if (typeId == _tokens->GeometryLight) {
+        return HdArnoldLight::CreateGeometryLight(this, SdfPath::EmptyPath());
+    }
     if (typeId == HdPrimTypeTokens->simpleLight) {
         return nullptr;
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Handle GeometryLight in CreateFallbackSprim, this avoids to have warnings when there is a Geometry light in the scene

**Issues fixed in this pull request**
Fixes #1251
