### PR TITLE
Add env variable in the delegate to save the arnold scene before rendering it

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -93,6 +93,7 @@ ASTR(AA_seed);
 ASTR(ArnoldUsd);
 ASTR(ArnoldNodeGraph);
 ASTR(ArnoldOptions);
+ASTR(binary);
 ASTR(BOOL);
 ASTR(BYTE);
 ASTR(CPU);

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -28,10 +28,12 @@
 #include "render_param.h"
 #include "render_delegate.h"
 #include <constant_strings.h>
-
+#include <pxr/base/tf/envSetting.h>
 #include <ai.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_ENV_SETTING(HDARNOLD_DEBUG_SCENE, "", "Optionally save out the arnold scene before rendering.");
 
 #ifdef ARNOLD_MULTIPLE_RENDER_SESSIONS
 HdArnoldRenderParam::HdArnoldRenderParam(HdArnoldRenderDelegate* delegate) : _delegate(delegate)
@@ -43,9 +45,7 @@ HdArnoldRenderParam::HdArnoldRenderParam()
     _aborted.store(false, std::memory_order::memory_order_release);
     // If the HDARNOLD_DEBUG_SCENE env variable is defined, we'll want to 
     // save out the scene every time it's about to be rendered
-    const char *HDARNOLD_DEBUG_SCENE = std::getenv("HDARNOLD_DEBUG_SCENE");
-    if (HDARNOLD_DEBUG_SCENE) 
-        _debugScene = std::string(HDARNOLD_DEBUG_SCENE);
+    _debugScene = TfGetEnvSetting(HDARNOLD_DEBUG_SCENE);
 }
 
 HdArnoldRenderParam::Status HdArnoldRenderParam::Render()

--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -121,6 +121,10 @@ public:
     /// @return True if FPS has changed.
     bool UpdateFPS(const float FPS);
 
+    /// For debugging purpose, allow to save out the 
+    /// Arnold scene to a file, just before it's rendered
+    void WriteDebugScene() const;
+
 private:
 #ifdef ARNOLD_MULTIPLE_RENDER_SESSIONS
     /// The render delegate
@@ -136,6 +140,8 @@ private:
     GfVec2f _shutter = {0.0f, 0.0f};
     /// FPS.
     float _fps = 24.0f;
+    /// optionally save out the arnold scene to a file, before it's rendered
+    std::string _debugScene;
 };
 
 class HdArnoldRenderParamInterrupt {


### PR DESCRIPTION
When the env variable `HDARNOLD_DEBUG_SCENE` is defined, the render delegate will save it out before each render iteration. 
This allows to debug how the delegate translates hydra data into arnold.

**Issues fixed in this pull request**
Fixes #1266 
