### PR TITLE
Don't remap vertex primvars for pinned curves #1240

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -357,6 +357,7 @@ ASTR(periodic);
 ASTR(persp_camera);
 ASTR(photometric_light);
 ASTR(pin_threads);
+ASTR(pinned);
 ASTR(pixel_aspect_ratio);
 ASTR(plugin_searchpath);
 ASTR(point_light);


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR ports the same changes done in #1216 to the render delegate.
For pinned curves, primvars with vertex interpolation should *not* me remapped as we usually do.
I verified in the test_0239 scene, it now renders as in the procedural

**Issues fixed in this pull request**
Fixes #1240 
