### PR TITLE
avoid creating a fallback dummy geometry light by returning nullptr

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -1041,7 +1041,7 @@ HdSprim* HdArnoldRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
         return HdArnoldLight::CreateDomeLight(this, SdfPath::EmptyPath());
     }
     if (typeId == _tokens->GeometryLight) {
-        return HdArnoldLight::CreateGeometryLight(this, SdfPath::EmptyPath());
+        return nullptr;
     }
     if (typeId == HdPrimTypeTokens->simpleLight) {
         return nullptr;


### PR DESCRIPTION
**Changes proposed in this pull request**
- We don't return a dummy GeometryLight without path to the geo to avoid the warning. This is a fallback geo and we are not using it, so we shouldn't need to create one in the first place.

**Issues fixed in this pull request**
Fixes #1275

More infos on fallback prims in the usd forum : https://groups.google.com/g/usd-interest/c/O4llDTmnc7k/m/Hd9fbjFwDgAJ
