### PR TITLE
Avoid crashes when invalid primitive path is set for a volume's field

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -1037,8 +1037,10 @@ void UsdArnoldReadVolume::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
     // So we can only use the first .vdb that is found, and we'll dump a warning if needed.
     for (UsdVolVolume::FieldMap::iterator it = fields.begin(); it != fields.end(); ++it) {
         UsdPrim fieldPrim = reader->GetStage()->GetPrimAtPath(it->second);
-        if (!fieldPrim.IsA<UsdVolOpenVDBAsset>())
+        if (!fieldPrim || !fieldPrim.IsA<UsdVolOpenVDBAsset>()) {
+            AiMsgWarning("[usd] Volume field primitive is invalid %s", it->second.GetText());
             continue;
+        }
         UsdVolOpenVDBAsset vdbAsset(fieldPrim);
 
         VtValue vdbFilePathValue;


### PR DESCRIPTION
In the volume reader, we were testing if the field density primitive had the proper type (UsdVolOpenVDBAsset) but we were simply not testing if the primitive existed.  So if the path was invalid we were crashing. 

Fixes #1281 
