### PR TITLE
adds plugin resources when INSTALL_USD_PLUGIN_RESOURCES is set

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -617,7 +617,6 @@ if PROCEDURAL:
     INSTALL_PROC += env.Install(os.path.join(PREFIX_HEADERS, 'arnold_usd'), ARNOLDUSD_HEADER)
     if env['USD_BUILD_MODE'] == 'static':
         INSTALL_PROC += env.Install(PREFIX_PROCEDURAL, usd_input_resource_folder)
-        INSTALL_PROC += env.Install(PREFIX_PROCEDURAL, usd_input_resource_folder)
     env.Alias('procedural-install', INSTALL_PROC)
 
 if ARNOLD_TO_USD:


### PR DESCRIPTION
**Changes proposed in this pull request**
- Setting INSTALL_USD_PLUGIN_RESOURCES will trigger the copy of the plugin/usd folder onto the install destination 

**Issues fixed in this pull request**
Fixes #1302 
