### PR TITLE
add ENABLE_HYDRA_TEST variable and fix missing script issue

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -81,6 +81,7 @@ vars.AddVariables(
     PathVariable('GOOGLETEST_INCLUDE', 'Where to find Google Test includes', os.path.join('$GOOGLETEST_PATH', 'include'), PathVariable.PathAccept),
     PathVariable('GOOGLETEST_LIB', 'Where to find Google Test libraries', os.path.join('$GOOGLETEST_PATH', 'lib64' if IS_LINUX else 'lib'), PathVariable.PathAccept),
     BoolVariable('ENABLE_UNIT_TESTS', 'Whether or not to enable C++ unit tests. This feature requires Google Test.', False),
+    BoolVariable('ENABLE_HYDRA_TEST', 'Whether or not to enable hydra_test', False),
     EnumVariable('TEST_ORDER', 'Set the execution order of tests to be run', 'reverse', allowed_values=('normal', 'reverse')),
     EnumVariable('SHOW_TEST_OUTPUT', 'Display the test log as it is being run', 'single', allowed_values=('always', 'never', 'single')),
     EnumVariable('USE_VALGRIND', 'Enable Valgrinding', 'False', allowed_values=('False', 'True', 'Full')),
@@ -452,7 +453,7 @@ usd_input_resource_folder = os.path.join(USD_LIB, 'usd')
 
 hydra_test_script = os.path.join('testsuite','hydra_test', 'SConscript')
 hydra_test_build = os.path.join(BUILD_BASE_DIR, 'hydra_test')
-if BUILD_RENDER_DELEGATE and BUILD_TESTSUITE:
+if BUILD_RENDER_DELEGATE and BUILD_TESTSUITE and env['ENABLE_HYDRA_TEST']:
     env['HYDRA_TEST_BUILD'] = os.path.join(env['ROOT_DIR'], hydra_test_build, 'hydra_test') 
     HYDRA_TEST = env.SConscript(hydra_test_script, variant_dir = hydra_test_build, duplicate = 0, exports = 'env')
     SConscriptChdir(0)

--- a/tools/utils/regression_test.py
+++ b/tools/utils/regression_test.py
@@ -105,9 +105,9 @@ class Test:
          forceexpand = '-forceexpand' if self.forceexpand else ''
          self.script = 'kick %s %s -resave test_resaved.%s\n' % (self.scene, forceexpand, resaved_extension) + ' '.join(['kick test_resaved.{}'.format(resaved_extension)] + params)
       else:
-         renderer = self.hydra_test if self.hydra_test else 'kick'
-         if any(self.scene.endswith(ext) for ext in ["usd", "usda"]):
-            self.script = ' '.join(['%s %s' % (renderer, self.scene)] + params)
+         want_hydra_test = self.hydra_test and any(self.scene.endswith(ext) for ext in ["usd", "usda"]) 
+         renderer = self.hydra_test if want_hydra_test else 'kick'
+         self.script = ' '.join(['%s %s' % (renderer, self.scene)] + params)
 
    def prepare_test(self, test_name, env):
       # Silence test preparation by globally overriding the paramater PRINT_CMD_LINE_FUNC


### PR DESCRIPTION
**Changes proposed in this pull request**
- This adds ENABLE_HYDRA_TEST to abuild, to enable the use of the hydra_test renderer. The value is False per default
- Fix a bug where the tests using ass scripts were failing.

**Issues fixed in this pull request**
Fixes #1324