### PR TITLE
Ensure empty product names don't render as ".exr" 

### DIFF
--- a/translator/reader/read_options.cpp
+++ b/translator/reader/read_options.cpp
@@ -294,8 +294,13 @@ void UsdArnoldReadRenderSettings::Read(const UsdPrim &prim, UsdArnoldReaderConte
         // The product name is supposed to return the output image filename.
         // If none is provided, we'll use the primitive name
         VtValue productNameValue;
-        std::string filename = renderProduct.GetProductNameAttr().Get(&productNameValue, time.frame) ?
-            VtValueGetString(productNameValue, nullptr) : productPrim.GetName().GetText();
+        std::string filename = productPrim.GetName().GetText();
+        if (renderProduct.GetProductNameAttr().Get(&productNameValue, time.frame)) {
+            std::string valStr = VtValueGetString(productNameValue, nullptr);
+            // only set the filename is the product name is a non-empty string #1336
+            if (!valStr.empty())
+                filename = valStr;
+        }
       
         // By default, we'll be saving out to exr
         std::string driverType = "driver_exr";


### PR DESCRIPTION
**Changes proposed in this pull request**
When product name isn't set at all, we're using the render product prim name as an output filename.
This PR checks if the product name is set to an empty value, and does the same in that case

**Issues fixed in this pull request**
Fixes #1336 
