### PR TITLE
Support motion blur on skinned instances in Hydra

### DIFF
--- a/render_delegate/CMakeLists.txt
+++ b/render_delegate/CMakeLists.txt
@@ -54,7 +54,7 @@ if (BUILD_HEADERS_AS_SOURCES)
     target_sources(hdArnold PRIVATE ${COMMON_HDR} ${HDR})
 endif ()
 
-set(_usd_deps arch plug tf vt gf work sdf hf hd usdImaging usdLux pxOsd cameraUtil)
+set(_usd_deps arch plug trace tf vt gf work sdf hf hd usdImaging usdLux pxOsd cameraUtil)
 if (${USD_VERSION} VERSION_LESS "0.20.5")
     set(_usd_deps ${_usd_deps} hdx)
 endif ()

--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -68,12 +68,13 @@ void HdArnoldBasisCurves::Sync(
     HdArnoldRenderParamInterrupt param(renderParam);
     const auto& id = GetId();
 
+    HdArnoldSampledPrimvarType pointsSample;
     // Points can either come through accessing HdTokens->points, or driven by UsdSkel.
-    const auto dirtyPrimvars = HdArnoldGetComputedPrimvars(sceneDelegate, id, *dirtyBits, _primvars) ||
+    const auto dirtyPrimvars = HdArnoldGetComputedPrimvars(sceneDelegate, id, *dirtyBits, _primvars, nullptr, &pointsSample) ||
                                (*dirtyBits & HdChangeTracker::DirtyPrimvar);
     if (_primvars.count(HdTokens->points) == 0 && HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
         param.Interrupt();
-        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points, param(), GetDeformKeys(), &_primvars);
+        HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::points, param(), GetDeformKeys(), &_primvars, &pointsSample);
     }
 
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {

--- a/render_delegate/mesh.cpp
+++ b/render_delegate/mesh.cpp
@@ -198,14 +198,15 @@ void HdArnoldMesh::Sync(
     HdArnoldRenderParamInterrupt param(renderParam);
     const auto& id = GetId();
 
-    const auto dirtyPrimvars = HdArnoldGetComputedPrimvars(sceneDelegate, id, *dirtyBits, _primvars) ||
+    HdArnoldSampledPrimvarType pointsSample;
+    const auto dirtyPrimvars = HdArnoldGetComputedPrimvars(sceneDelegate, id, *dirtyBits, _primvars, nullptr, &pointsSample) ||
                                (*dirtyBits & HdChangeTracker::DirtyPrimvar);
 
     if (_primvars.count(HdTokens->points) != 0) {
         _numberOfPositionKeys = 1;
     } else if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
         param.Interrupt();
-        _numberOfPositionKeys = HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::vlist, param(), GetDeformKeys(), &_primvars);
+        _numberOfPositionKeys = HdArnoldSetPositionFromPrimvar(GetArnoldNode(), id, sceneDelegate, str::vlist, param(), GetDeformKeys(), &_primvars, &pointsSample);
     }
 
     const auto dirtyTopology = HdChangeTracker::IsTopologyDirty(*dirtyBits, id);

--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -1376,10 +1376,14 @@ void HdArnoldSetInstancePrimvar(
 
 size_t HdArnoldSetPositionFromPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const AtString& paramName,
-    const HdArnoldRenderParam* param, int deformKeys, const HdArnoldPrimvarMap* primvars)
+    const HdArnoldRenderParam* param, int deformKeys, const HdArnoldPrimvarMap* primvars, HdArnoldSampledPrimvarType *pointsSample)
 {
     HdArnoldSampledPrimvarType sample;
-    sceneDelegate->SamplePrimvar(id, HdTokens->points, &sample);
+    if (pointsSample != nullptr && pointsSample->count > 0)
+        sample = *pointsSample;
+    else
+        sceneDelegate->SamplePrimvar(id, HdTokens->points, &sample);
+
     HdArnoldSampledType<VtVec3fArray> xf;
     HdArnoldUnboxSample(sample, xf);
     if (xf.count == 0) {
@@ -1555,38 +1559,57 @@ void HdArnoldInsertPrimvar(
 
 bool HdArnoldGetComputedPrimvars(
     HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, HdArnoldPrimvarMap& primvars,
-    const std::vector<HdInterpolation>* interpolations)
+    const std::vector<HdInterpolation>* interpolations, HdArnoldSampledPrimvarType *pointsSample)
 {
     // First we are querying which primvars need to be computed, and storing them in a list to rely on
     // the batched computation function in HdExtComputationUtils.
     HdExtComputationPrimvarDescriptorVector dirtyPrimvars;
+    HdExtComputationPrimvarDescriptorVector pointsPrimvars;
     for (auto interpolation : (interpolations == nullptr ? primvarInterpolations : *interpolations)) {
         const auto computedPrimvars = delegate->GetExtComputationPrimvarDescriptors(id, interpolation);
         for (const auto& primvar : computedPrimvars) {
             if (HdChangeTracker::IsPrimvarDirty(dirtyBits, id, primvar.name)) {
-                dirtyPrimvars.emplace_back(primvar);
+                if (primvar.name == HdTokens->points)
+                    pointsPrimvars.emplace_back(primvar);
+                else
+                    dirtyPrimvars.emplace_back(primvar);
             }
         }
     }
-
-    // Early exit.
-    if (dirtyPrimvars.empty()) {
-        return false;
+    
+    bool changed = false;
+    if (pointsSample && !pointsPrimvars.empty()) {
+        HdExtComputationUtils::SampledValueStore<HD_ARNOLD_MAX_PRIMVAR_SAMPLES> valueStore;
+        const size_t maxSamples = HD_ARNOLD_MAX_PRIMVAR_SAMPLES;
+        HdExtComputationUtils::SampleComputedPrimvarValues(
+            pointsPrimvars, delegate, maxSamples, &valueStore);
+        
+        const auto itComputed = valueStore.find(pointsPrimvars[0].name);
+            
+        if (itComputed != valueStore.end() && itComputed->second.count > 0) {
+            changed = true;
+            // Store points separately, with sampled results
+            *pointsSample = itComputed->second;
+        }
     }
 
-    auto changed = false;
-    auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues(dirtyPrimvars, delegate);
-    for (const auto& primvar : dirtyPrimvars) {
-        const auto itComputed = valueStore.find(primvar.name);
-        if (itComputed == valueStore.end()) {
-            continue;
-        }
-        changed = true;
+    if (!dirtyPrimvars.empty()) {
+
+        auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues(dirtyPrimvars, delegate);
+
+        for (const auto& primvar : dirtyPrimvars) {
+            const auto itComputed = valueStore.find(primvar.name);
+            if (itComputed == valueStore.end()) {
+                continue;
+            }
+            changed = true;
+            
 #ifdef USD_HAS_SAMPLE_INDEXED_PRIMVAR
-        HdArnoldInsertPrimvar(primvars, primvar.name, primvar.role, primvar.interpolation, itComputed->second, {});
+            HdArnoldInsertPrimvar(primvars, primvar.name, primvar.role, primvar.interpolation, itComputed->second, {});
 #else
-        HdArnoldInsertPrimvar(primvars, primvar.name, primvar.role, primvar.interpolation, itComputed->second);
+            HdArnoldInsertPrimvar(primvars, primvar.name, primvar.role, primvar.interpolation, itComputed->second);
 #endif
+        }
     }
 
     return changed;

--- a/render_delegate/utils.h
+++ b/render_delegate/utils.h
@@ -410,7 +410,7 @@ HDARNOLD_API
 size_t HdArnoldSetPositionFromPrimvar(
     AtNode* node, const SdfPath& id, HdSceneDelegate* sceneDelegate, const AtString& paramName,
     const HdArnoldRenderParam* param, int deformKeys = HD_ARNOLD_MAX_PRIMVAR_SAMPLES,
-    const HdArnoldPrimvarMap* primvars = nullptr);
+    const HdArnoldPrimvarMap* primvars = nullptr,  HdArnoldSampledPrimvarType *pointsSample = nullptr);
 /// Sets positions attribute on an Arnold shape from a VtValue holding VtVec3fArray.
 ///
 /// @param node Pointer to an Arnold node.
@@ -479,7 +479,7 @@ void HdArnoldInsertPrimvar(
 HDARNOLD_API
 bool HdArnoldGetComputedPrimvars(
     HdSceneDelegate* delegate, const SdfPath& id, HdDirtyBits dirtyBits, HdArnoldPrimvarMap& primvars,
-    const std::vector<HdInterpolation>* interpolations = nullptr);
+    const std::vector<HdInterpolation>* interpolations = nullptr, HdArnoldSampledPrimvarType *pointsSample = nullptr);
 
 /// Get the non-computed primvars and ignoring the points primvar. If multiple position keys are used, the function
 /// does not query the value of the normals.

--- a/tools/utils/dependencies.py
+++ b/tools/utils/dependencies.py
@@ -50,6 +50,7 @@ def render_delegate(env, sources):
     usd_libs = [
         'arch',
         'plug',
+        'trace',
         'tf',
         'vt',
         'gf',


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we had support for motion blur in skinned geometries. For the "points" primvar, we need to call `HdExtComputationUtils::SampleComputedPrimvarValues` instead of `HdExtComputationUtils::GetComputedPrimvarValues` which will return different values for each time sample. For now we're only doing this for the points primvar, since some primvars shouldn't be animated in Arnold.

**Issues fixed in this pull request**
Fixes #738 
