### PR TITLE
Disable animation for instancer user primvars

### DIFF
--- a/translator/reader/read_geometry.cpp
+++ b/translator/reader/read_geometry.cpp
@@ -882,6 +882,9 @@ void UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderConte
     const TimeSettings &time = context.GetTimeSettings();
     float frame = time.frame;
 
+    TimeSettings staticTime(time);
+    staticTime.motionBlur = false;
+
     UsdGeomPointInstancer pointInstancer(prim);
 
     // this will be used later to contruct the name of the instances
@@ -1034,7 +1037,8 @@ void UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderConte
 
     ReadMatrix(prim, node, time, context);
     InstancerPrimvarsRemapper primvarsRemapper;
-    ReadPrimvars(prim, node, time, context, &primvarsRemapper);
+    // For instancer primvars, we want to remove motion blur as it's causing errors #1298
+    ReadPrimvars(prim, node, staticTime, context, &primvarsRemapper);
     ReadMaterialBinding(prim, node, context, false); // don't assign the default shader
 
     ReadArnoldParameters(prim, context, node, time, "primvars:arnold");


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR, when we evaluate user primvars for an instancer, we evaluate them at a single time and disable animation for now.
Animated user datas aren't supported in instancers at the moment, so this is a workaround until it's properly addressed in arnold core.


**Issues fixed in this pull request**
Fixes #1298 
