### PR TITLE
Fix PRX_PLUGIN_PATH_NAME path for testsuite

### DIFF
--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -133,7 +133,7 @@ def run_test(target, source, env):
 
    test_env = env.Clone()
    test_env.AppendENVPath('ARNOLD_PLUGIN_PATH', os.path.dirname(test_env['USD_PROCEDURAL_PATH']))
-   test_env.AppendENVPath('PXR_PLUGINPATH_NAME', os.path.dirname(test_env['PREFIX_RENDER_DELEGATE']))
+   test_env.AppendENVPath('PXR_PLUGINPATH_NAME', test_env['PREFIX_RENDER_DELEGATE'])
 
    show_test_output = (test_env['SHOW_TEST_OUTPUT'] == 'always') or (test_env['SHOW_TEST_OUTPUT'] == 'single' and (len(TEST_TARGETS) == 1))
 


### PR DESCRIPTION
The previous PR wasn't setting PRX_PLUGIN_PATH_NAME  to the right folder, for the testsuite