### PR TITLE
Fix build issues in older versions of USD

### DIFF
--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -1569,15 +1569,21 @@ bool HdArnoldGetComputedPrimvars(
         const auto computedPrimvars = delegate->GetExtComputationPrimvarDescriptors(id, interpolation);
         for (const auto& primvar : computedPrimvars) {
             if (HdChangeTracker::IsPrimvarDirty(dirtyBits, id, primvar.name)) {
+#if PXR_VERSION >= 2105
                 if (primvar.name == HdTokens->points)
                     pointsPrimvars.emplace_back(primvar);
                 else
+#endif
+                {
+
                     dirtyPrimvars.emplace_back(primvar);
+                }
             }
         }
     }
     
     bool changed = false;
+#if PXR_VERSION >= 2105
     if (pointsSample && !pointsPrimvars.empty()) {
         HdExtComputationUtils::SampledValueStore<HD_ARNOLD_MAX_PRIMVAR_SAMPLES> valueStore;
         const size_t maxSamples = HD_ARNOLD_MAX_PRIMVAR_SAMPLES;
@@ -1592,6 +1598,7 @@ bool HdArnoldGetComputedPrimvars(
             *pointsSample = itComputed->second;
         }
     }
+#endif
 
     if (!dirtyPrimvars.empty()) {
 


### PR DESCRIPTION
**Changes proposed in this pull request**
HdExtComputationUtils::SampledValueStore was defined only from USD 21.05 and up. This PR ensures we can still compile (and roll back to the previous behaviour) in older versions