### PR TITLE
Add env variable for autoTX 

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -432,6 +432,7 @@ ASTR(surface);
 ASTR(swrap);
 ASTR(texture_accept_unmipped);
 ASTR(texture_accept_untiled);
+ASTR(texture_auto_generate_tx);
 ASTR(texture_automip);
 ASTR(texture_autotile);
 ASTR(texture_conservative_lookups);

--- a/render_delegate/config.cpp
+++ b/render_delegate/config.cpp
@@ -100,6 +100,8 @@ TF_DEFINE_ENV_SETTING(HDARNOLD_procedural_searchpath, "", "Procedural search pat
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_osl_includepath, "", "OSL include path.");
 
+TF_DEFINE_ENV_SETTING(HDARNOLD_auto_generate_tx, true, "Auto-generate Textures to TX");
+
 HdArnoldConfig::HdArnoldConfig()
 {
     bucket_size = std::max(1, TfGetEnvSetting(HDARNOLD_bucket_size));
@@ -134,6 +136,7 @@ HdArnoldConfig::HdArnoldConfig()
     plugin_searchpath = TfGetEnvSetting(HDARNOLD_plugin_searchpath);
     procedural_searchpath = TfGetEnvSetting(HDARNOLD_procedural_searchpath);
     osl_includepath = TfGetEnvSetting(HDARNOLD_osl_includepath);
+    auto_generate_tx = TfGetEnvSetting(HDARNOLD_auto_generate_tx);
 }
 
 const HdArnoldConfig& HdArnoldConfig::GetInstance() { return TfSingleton<HdArnoldConfig>::GetInstance(); }

--- a/render_delegate/config.h
+++ b/render_delegate/config.h
@@ -173,6 +173,11 @@ struct HdArnoldConfig {
     ///
     bool flush_textures;
 
+    /// Use HDARNOLD_auto_generate_tx to set the value.
+    ///
+    bool auto_generate_tx;
+
+
 private:
     /// Constructor for reading the values from the environment variables.
     HDARNOLD_API

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -263,6 +263,7 @@ const SupportedRenderSettings& _GetSupportedRenderSettings()
         {str::t_atmosphere, {"Path to the atmosphere node graph.", std::string{}}},
         {str::t_aov_shaders, {"Path to the aov_shaders node graph.", std::string{}}},
         {str::t_imager, {"Path to the imagers node graph.", std::string{}}},
+        {str::t_texture_auto_generate_tx, {"Auto-generate Textures to TX", config.auto_generate_tx}},
     };
     return data;
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR declares a new env variable `HDARNOLD_auto_generate_tx` that can be used to override the default value of autoTX

**Issues fixed in this pull request**
Fixes #1353 
