### PR TITLE
Build symbols on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else ()
     set(LIB_EXTENSION ".dll")
     add_compile_definitions(_WINDOWS _WIN32 WIN32)
     add_compile_definitions(_WIN64)
-    add_compile_definitions(/DEBUG)
+    add_link_option(/DEBUG)
 endif ()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ else ()
     set(LIB_EXTENSION ".dll")
     add_compile_definitions(_WINDOWS _WIN32 WIN32)
     add_compile_definitions(_WIN64)
+    add_compile_definitions(/DEBUG)
 endif ()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" 0)

--- a/SConstruct
+++ b/SConstruct
@@ -275,6 +275,7 @@ elif IS_LINUX:
 elif IS_WINDOWS:
     env.Append(CPPDEFINES = Split('_WINDOWS _WIN32 WIN32 _USE_MATH_DEFINES'))
     env.Append(CPPDEFINES = Split('_WIN64'))
+    env.Append(LINKFLAGS=Split('/DEBUG'))
     if env['TBB_LIB_NAME'] != '%s':
         env.Append(CPPDEFINES = Split('__TBB_NO_IMPLICIT_LINKAGE=1'))
     if env['BOOST_ALL_NO_LIB']:


### PR DESCRIPTION
**Changes proposed in this pull request**
Simply adding the `/DEBUG` compile flag on windows, both in Scons and Cmake

**Issues fixed in this pull request**
Fixes #1360
