### PR TITLE
Provide Role and Help metadatas at the shader level 

### DIFF
--- a/ndr/parser.cpp
+++ b/ndr/parser.cpp
@@ -274,6 +274,18 @@ NdrNodeUniquePtr NdrArnoldParserPlugin::Parse(const NdrNodeDiscoveryResult& disc
         _ReadShaderAttribute(attr, properties, "");
 
     }
+    // Now handle the metadatas at the node level
+    NdrTokenMap metadata;
+    static const auto supportedMetadatas = {
+        SdrPropertyMetadata->Role,
+        SdrPropertyMetadata->Help
+    };
+
+    for (const auto &m : supportedMetadatas) {
+        const auto it = primCustomData.find(m);
+        if (it != primCustomData.end())
+            metadata.insert({m, TfStringify(it->second)});
+    }
     
     return NdrNodeUniquePtr(new SdrShaderNode(
         discoveryResult.identifier,    // identifier
@@ -286,7 +298,8 @@ NdrNodeUniquePtr NdrArnoldParserPlugin::Parse(const NdrNodeDiscoveryResult& disc
 #ifdef USD_HAS_NEW_SDR_NODE_CONSTRUCTOR
         discoveryResult.uri, // resolvedUri
 #endif
-        std::move(properties)));
+        std::move(properties),
+        metadata));
 }
 
 const NdrTokenVec& NdrArnoldParserPlugin::GetDiscoveryTypes() const

--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -406,6 +406,8 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
             AtString dcc = metadata->value.STR();
             if (!dcc.empty() && dcc != str::usd)
                 continue;
+        } else if (metadata->name == str::desc) {
+            usdPrimMetadata = SdrPropertyMetadata->Help;
         }
         primCustomData[usdPrimMetadata] = _ReadArnoldMetadata(metadata);
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
We were computing the node entry metadatas in `_ReadArnoldShaderDef` (utils.cpp), but we were just using "ui.groups` to create the attributes in a given order and grouping. 
In this PR we also provide the Role and Help metadatas at the shader node level. 

**Issues fixed in this pull request**
Fixes #1368 
