### PR TITLE
Read primitives with empty purpose

### DIFF
--- a/translator/reader/reader.cpp
+++ b/translator/reader/reader.cpp
@@ -250,13 +250,16 @@ void UsdArnoldReader::TraverseStage(UsdPrim *rootPrim, UsdArnoldReaderContext &c
             UsdGeomImageable imageable(prim);
             bool pruneChildren = false;
             attr = imageable.GetVisibilityAttr();
-            if (attr && attr.HasAuthoredValue())
+            if (attr && attr.HasAuthoredValue()) {
+
                 pruneChildren |= (attr.Get(&visibility, frame) && 
                         visibility == UsdGeomTokens->invisible);
+            }
 
             attr = imageable.GetPurposeAttr();
             if (attr && attr.HasAuthoredValue()) {
                 pruneChildren |= ((attr.Get(&purpose, frame) && 
+                        !purpose.IsEmpty() && 
                         purpose != UsdGeomTokens->default_ && 
                         purpose != reader->GetPurpose()));
             }


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR, when we find a primitive with `purpose` set to an empty string, we consider this to be equivalent to the default value `default` .

**Issues fixed in this pull request**
Fixes #1372 
