### PR TITLE
Ensure CER is disabled during batch hydra renders

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -359,6 +359,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
 #if ARNOLD_VERSION_NUMBER >= 70104
         // Ensure that the ADP dialog box will not pop up and hang the application
         AiADPDisableDialogWindow();
+        AiErrorReportingSetEnabled(false);
 #endif
     }
     if (!_isArnoldActive) {


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR ensures that batch hydra renders disable CER, so that we don't get windows showing up during batch renders