### PR TITLE
Ensure arnold_usd.h is included when needed

### DIFF
--- a/translator/reader/registry.cpp
+++ b/translator/reader/registry.cpp
@@ -26,7 +26,7 @@
 #include "read_options.h"
 #include "read_shader.h"
 #include "utils.h"
-
+#include "../arnold_usd.h"
 #include <common_utils.h>
 //-*************************************************************************
 

--- a/translator/writer/registry.cpp
+++ b/translator/writer/registry.cpp
@@ -25,7 +25,7 @@
 #include "write_geometry.h"
 #include "write_light.h"
 #include "write_shader.h"
-
+#include "../arnold_usd.h"
 #include <common_utils.h>
 
 //-*************************************************************************

--- a/translator/writer/write_geometry.cpp
+++ b/translator/writer/write_geometry.cpp
@@ -25,6 +25,7 @@
 #include <pxr/usd/usdGeom/points.h>
 #include <pxr/usd/usdGeom/primvarsAPI.h>
 
+#include "../arnold_usd.h"
 //-*************************************************************************
 
 PXR_NAMESPACE_USING_DIRECTIVE


### PR DESCRIPTION
We were testing ARNOLD_VERSION_NUMBER to use `AiArnoldIsActive` instead of `AiUniverseIsActive` , but without including `../arnold_usd.h` that properly defines this variable

Fixes #1387 
