### PR TITLE
Imagers only updates in the render delegate 

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -389,6 +389,7 @@ ASTR(region_min_y);
 ASTR(render_device);
 ASTR(render_settings);
 ASTR(repeat);
+ASTR(request_imager_update);
 ASTR(rotation);
 ASTR(roughness);
 ASTR(scale);

--- a/render_delegate/node_graph.h
+++ b/render_delegate/node_graph.h
@@ -121,6 +121,13 @@ public:
     /// @return Pointer to the requested HdArnoldNodeGraph 
     HDARNOLD_API
     static const HdArnoldNodeGraph* GetNodeGraph(HdRenderIndex* renderIndex, const SdfPath& id);
+
+    /// Notify this node graph that it's meant to be used as an imager graph.
+    /// In this case, when an interactive change happens, we don't want to restart
+    /// a full render, but instead we directly update the arnold imagers and then 
+    /// notify Arnold that the imagers were updated (#1320)
+    HDARNOLD_API
+    void SetImagerGraph();
     
 protected:
     /// Utility struct to store translated nodes.
@@ -281,6 +288,7 @@ protected:
     ArnoldNodeGraph _nodeGraph;              ///< Storing arnold shaders for terminals.
     HdArnoldRenderDelegate* _renderDelegate; ///< Pointer to the Render Delegate.
     bool _wasSyncedOnce = false;             ///< Whether or not the material has been synced at least once.
+    bool _isImagerGraph = false;             ///< Whether or not this is an imager graph
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -1483,9 +1483,12 @@ std::vector<AtNode*> HdArnoldRenderDelegate::GetAovShaders(HdRenderIndex* render
 
 AtNode* HdArnoldRenderDelegate::GetImager(HdRenderIndex* renderIndex)
 {
-    const HdArnoldNodeGraph *nodeGraph = HdArnoldNodeGraph::GetNodeGraph(renderIndex, _imager);
-    if (nodeGraph)
+    HdArnoldNodeGraph *nodeGraph = (HdArnoldNodeGraph *)HdArnoldNodeGraph::GetNodeGraph(renderIndex, _imager);
+    if (nodeGraph) {
+        // Notify this nodeGraph that it's being used as an imager graph
+        nodeGraph->SetImagerGraph();
         return nodeGraph->GetTerminal(str::t_input);
+    }
     return nullptr;
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
We're adding a flag to the HdArnoldNodeGraph class to specify if this is an imager graph. 
When it's modified interactively, instead of pausing and restarting the render, we update directly the arnold scene, and then notify arnold that the imagers were update (through the AiRenderHints APIs).

This allows the imagers to be updated without necessarily restarting the render

**Issues fixed in this pull request**
Fixes #1320 
