### PR TITLE
Add missing read_skinning.* in CMakeLists.txt - fix-7.1.4 branch

### DIFF
--- a/translator/CMakeLists.txt
+++ b/translator/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
     reader/read_geometry.cpp
     reader/read_light.cpp
     reader/read_shader.cpp
+    reader/read_skinning.cpp
     reader/read_options.cpp
     reader/reader.cpp
     reader/registry.cpp
@@ -26,6 +27,7 @@ set(HDR
     reader/read_geometry.h
     reader/read_light.h
     reader/read_shader.h
+    reader/read_skinning.h
     reader/read_options.h
     reader/reader.h
     reader/registry.h


### PR DESCRIPTION
**Changes proposed in this pull request**
- Add the missing read_skinning.* files in the CMake build. This is only for fix-7.4.1 as it is already done in the main branch.

**Issues fixed in this pull request**
Fixes #1414

