### PR TITLE
Declare filename attributes as asset Paths

### DIFF
--- a/common/constant_strings.h
+++ b/common/constant_strings.h
@@ -362,6 +362,7 @@ ASTR(overrides);
 ASTR(parallel_node_init);
 ASTR(param_shader_file);
 ASTR(parent_instance);
+ASTR(path);
 ASTR(penumbra_angle);
 ASTR(periodic);
 ASTR(persp_camera);

--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -465,6 +465,20 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
                 attr.Set(conversion->f(array));
             }
         } else {
+
+            // Some arnold string attributes can actually represent USD asset attributes.
+            // In order to identify them, we check for a specific metadata "path" set on this attribute
+            if (paramType == AI_TYPE_STRING) {
+                AtString pathMetadata;
+                if (AiMetaDataGetStr(nodeEntry, paramName, str::path, &pathMetadata) && 
+                        pathMetadata == str::file) {
+
+                    attr = prim.CreateAttribute(TfToken(paramName.c_str()), SdfValueTypeNames->Asset, false);
+                    SdfAssetPath assetPath(AiParamGetDefault(pentry)->STR().c_str());
+                    attr.Set(VtValue(assetPath));
+                    continue;
+                }
+            }
             const auto* conversion = _GetDefaultValueConversion(paramType);
             if (conversion == nullptr) {
                 continue;

--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -468,25 +468,25 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
 
             // Some arnold string attributes can actually represent USD asset attributes.
             // In order to identify them, we check for a specific metadata "path" set on this attribute
-            if (paramType == AI_TYPE_STRING) {
-                AtString pathMetadata;
-                if (AiMetaDataGetStr(nodeEntry, paramName, str::path, &pathMetadata) && 
-                        pathMetadata == str::file) {
+            AtString pathMetadata;
+            if (paramType == AI_TYPE_STRING && 
+                  AiMetaDataGetStr(nodeEntry, paramName, str::path, &pathMetadata) && 
+                  pathMetadata == str::file) {
 
-                    attr = prim.CreateAttribute(TfToken(paramName.c_str()), SdfValueTypeNames->Asset, false);
-                    SdfAssetPath assetPath(AiParamGetDefault(pentry)->STR().c_str());
-                    attr.Set(VtValue(assetPath));
+                attr = prim.CreateAttribute(TfToken(paramName.c_str()), SdfValueTypeNames->Asset, false);
+                SdfAssetPath assetPath(AiParamGetDefault(pentry)->STR().c_str());
+                attr.Set(VtValue(assetPath));
+            } else {
+                // Regular attribute conversion
+                const auto* conversion = _GetDefaultValueConversion(paramType);
+                if (conversion == nullptr) {
                     continue;
                 }
-            }
-            const auto* conversion = _GetDefaultValueConversion(paramType);
-            if (conversion == nullptr) {
-                continue;
-            }
-            attr = prim.CreateAttribute(TfToken(paramName.c_str()), conversion->type, false);
+                attr = prim.CreateAttribute(TfToken(paramName.c_str()), conversion->type, false);
 
-            if (conversion->f != nullptr) {
-                attr.Set(conversion->f(*AiParamGetDefault(pentry), pentry));
+                if (conversion->f != nullptr) {
+                    attr.Set(conversion->f(*AiParamGetDefault(pentry), pentry));
+                }
             }
         }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR, we're authoring "filename" arnold attributes as SdfAssetPath in USD. This no longer requires changes in the usd reader, since we now handle the conversion at read-time, and support not resolving the usd paths.

In order to find out if an attribute is a filename, we look for its metadata `file` and check if it's set to `path`
The change also needs to be done in the Sdr registry, since we should now declare these attributes as being SdfAssetPath

**Issues fixed in this pull request**
Fixes #1163
