### PR TITLE
Generalize support for render delegate products

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -695,10 +695,9 @@ void HdArnoldRenderDelegate::_ParseDelegateRenderProducts(const VtValue& value)
             renderProductType = str::t_driver_deepexr;
 
         // Let's check if a driver type exists as this render product type #1422
-        std::string driverPrefixedType = std::string("driver_") + renderProductType.GetString();
-        if (AiNodeEntryLookUp(AtString(renderProductType.GetText())) == nullptr &&
-                AiNodeEntryLookUp(AtString(driverPrefixedType.c_str())) == nullptr) {
+        if (AiNodeEntryLookUp(AtString(renderProductType.GetText())) == nullptr) {
             // Arnold doesn't know how to render with this driver, let's skip it
+            AiMsgWarning("Unknown Arnold Driver Type %s", renderProductType.GetText());
             continue; 
         }
 

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -75,6 +75,8 @@ struct HdArnoldDelegateRenderProduct {
     HdAovSettingsMap settings;
     /// Name of the product, this is equal to the output location.
     TfToken productName;
+    /// Type of the render product, set to the arnold driver entry type
+    TfToken productType;
 };
 
 /// Main class point for the Arnold Render Delegate.

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -352,6 +352,10 @@ public:
     ///
     /// @return Const Reference to the list of Delegate Render Products.
     const DelegateRenderProducts& GetDelegateRenderProducts() const { return _delegateRenderProducts; }
+
+    /// Clear the existing list of delegate render products. This is needed when the render pass
+    /// didn't manage to create any render product based on the delegate list
+    void ClearDelegateRenderProducts() {_delegateRenderProducts.clear();}
     /// Advertise whether this delegate supports pausing and resuming of
     /// background render threads. Default implementation returns false.
     ///

--- a/render_delegate/render_delegate.h
+++ b/render_delegate/render_delegate.h
@@ -503,6 +503,8 @@ public:
     virtual bool InvokeCommand(const TfToken& command, const HdCommandArgs& args = HdCommandArgs()) override;
 #endif
 
+    const std::string &GetOutputOverride() const {return _outputOverride;}
+
 private:    
     HdArnoldRenderDelegate(const HdArnoldRenderDelegate&) = delete;
     HdArnoldRenderDelegate& operator=(const HdArnoldRenderDelegate&) = delete;
@@ -602,6 +604,7 @@ private:
     bool _ignoreVerbosityLogFlags = false;
     bool _isArnoldActive = false;
     std::unordered_set<AtString, AtStringHash> _cryptomatteDrivers;
+    std::string _outputOverride;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/render_delegate/render_pass.h
+++ b/render_delegate/render_pass.h
@@ -109,7 +109,7 @@ private:
     AtNode* _primIdWriter = nullptr;         ///< Pointer to the Arnold prim ID writer shader.
     AtNode* _primIdReader = nullptr;         ///< Pointer to the Arnold prim ID reader shader.
 
-    struct DeepRenderVar {
+    struct CustomRenderVar {
         /// Definition for the output string.
         AtString output;
         /// Optional writer node for each AOV.
@@ -118,17 +118,17 @@ private:
         AtNode* reader = nullptr;
     };
 
-    // Each deep driver handles multiple AOVs.
-    struct DeepProduct {
+    // Each arnold driver can handle multiple AOVs.
+    struct CustomProduct {
         /// List of the RenderVars.
-        std::vector<DeepRenderVar> renderVars;
-        /// Deep EXR driver.
+        std::vector<CustomRenderVar> renderVars;
+        /// Custom driver.
         AtNode* driver = nullptr;
-        /// Filter for the Deep EXR driver.
+        /// Filter for the custom driver.
         AtNode* filter = nullptr;
     };
 
-    std::vector<DeepProduct> _deepProducts; ///< List of Deep Render Products.
+    std::vector<CustomProduct> _customProducts; ///< List of Custom Render Products.
 
 #ifndef USD_DO_NOT_BLIT
 #ifdef USD_HAS_FULLSCREEN_SHADER


### PR DESCRIPTION
**Changes proposed in this pull request**
Support for Render delegate products is now generalized, and no longer hardcoded for `deep` . If one sets the name of an arnold driver in the product type field, then the arnold render delegate will create such a driver instead of relying on Hydra drivers.

For example, if we set `driver_exr` in the render product in Solaris, and then render with husk, the render rely on a driver_exr and therefore render as if it was using kick-usd. 

Still missing : pass on the arnold render product parameters (i.e. the list of driver attributes) to the driver. At the moment they're ignored and only the deep exr params are supported.


**Issues fixed in this pull request**
Fixes #1422 
