### PR TITLE
Restore asset attributes as string in the registry, with the proper metadata

### DIFF
--- a/ndr/parser.cpp
+++ b/ndr/parser.cpp
@@ -146,7 +146,8 @@ void _ReadShaderAttribute(const UsdAttribute &attr, NdrPropertyUniquePtrVec &pro
         SdrPropertyMetadata->Connectable,
         SdrPropertyMetadata->Label,
         SdrPropertyMetadata->Role,
-        SdrPropertyMetadata->Help
+        SdrPropertyMetadata->Help,
+        SdrPropertyMetadata->IsAssetIdentifier
     };
 
     if (!folder.empty()) {

--- a/ndr/utils.cpp
+++ b/ndr/utils.cpp
@@ -466,28 +466,15 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
             }
         } else {
 
-            // Some arnold string attributes can actually represent USD asset attributes.
-            // In order to identify them, we check for a specific metadata "path" set on this attribute
-            AtString pathMetadata;
-            if (paramType == AI_TYPE_STRING && 
-                  AiMetaDataGetStr(nodeEntry, paramName, str::path, &pathMetadata) && 
-                  pathMetadata == str::file) {
-
-                attr = prim.CreateAttribute(TfToken(paramName.c_str()), SdfValueTypeNames->Asset, false);
-                SdfAssetPath assetPath(AiParamGetDefault(pentry)->STR().c_str());
-                attr.Set(VtValue(assetPath));
-            } else {
-                // Regular attribute conversion
-                const auto* conversion = _GetDefaultValueConversion(paramType);
-                if (conversion == nullptr) {
-                    continue;
-                }
-                attr = prim.CreateAttribute(TfToken(paramName.c_str()), conversion->type, false);
-
-                if (conversion->f != nullptr) {
-                    attr.Set(conversion->f(*AiParamGetDefault(pentry), pentry));
-                }
+            const auto* conversion = _GetDefaultValueConversion(paramType);
+            if (conversion == nullptr) {
+                continue;
             }
+            attr = prim.CreateAttribute(TfToken(paramName.c_str()), conversion->type, false);
+
+            if (conversion->f != nullptr) {
+                attr.Set(conversion->f(*AiParamGetDefault(pentry), pentry));
+            }          
         }
 
 
@@ -514,7 +501,6 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
                 continue;
 
             TfToken usdMetadata;
-            // For now we only support a hardcoded list of metadatas
             if (metadata->name == str::linkable)
                 usdMetadata = SdrPropertyMetadata->Connectable;
             else if (metadata->name == str::_min)
@@ -530,6 +516,15 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
                 foundLabel = true;
             } else if (metadata->name == str::desc)
                 usdMetadata = SdrPropertyMetadata->Help;
+            else if (metadata->name == str::path && 
+                    metadata->value.STR() == str::file) {
+                // In arnold some string attributes should actually represent
+                // an asset attribute in USD. They have a metadata "path" set to "file".
+                // USD expects such attributes to be declared as strings in the 
+                // with a metadata IsAssetIdentifier set to true
+                customData[SdrPropertyMetadata->IsAssetIdentifier] = VtValue(true);
+                continue;                
+            }
             else
                 usdMetadata = TfToken(metadata->name.c_str());
 


### PR DESCRIPTION
The fix done in #1418 wasn't doing the right thing. For "asset" attributes, we need to declare them as string attributes, with a metadata IsAssetIdentifier set to true.
This is actually simpler and cleaner than the first PR

**Issues fixed in this pull request**
Fixes #1163 
