### PR TITLE
Updated test_0173 to use Arnold Spheres

### DIFF
--- a/testsuite/test_0173/data/test.usda
+++ b/testsuite/test_0173/data/test.usda
@@ -18,9 +18,9 @@ def Xform "testgeometry_rubbertoy1" (
     matrix4d xformOp:transform:xform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
     uniform token[] xformOpOrder = ["xformOp:transform:xform"]
 
-    def Sphere "sphere_0"
+    def ArnoldSphere "sphere_0"
     {
-        float radius = 1
+        float[] radius = [1]
         rel material:binding = </materials/materiallibrary1>
     }
 }


### PR DESCRIPTION
Updated test_0173 as using Arnold Spheres will account for UVs for this test. Related to changed introduced in #1318.