### PR TITLE
Ensure shader scope doesn't appear twice in the hierarchy

### DIFF
--- a/testsuite/test_1457/README
+++ b/testsuite/test_1457/README
@@ -1,0 +1,6 @@
+Ensure naming of surface shaders doesn't duplicate the hierarchy
+
+see #1457
+
+author: sebastien.ortega
+

--- a/testsuite/test_1457/data/scene.ass
+++ b/testsuite/test_1457/data/scene.ass
@@ -1,0 +1,163 @@
+### exported: Mon Mar 20 14:34:23 2023
+### from:     Arnold 7.2.1.0 [f200296d] windows x86_64 clang-15.0.7 oiio-2.4.1 osl-1.12.9 vdb-7.1.1 adlsdk-7.4.2.47 clmhub-3.1.1.43 rlm-14.2.5 optix-6.6.0 2023/03/17 10:39:17
+### host app: MtoA 5.3.1 8b55705d (MTOA-1365) Maya 2024
+### bounds: -1 -1 -1 1 1 1
+### render_layer: defaultRenderLayer
+### user: blaines
+### scene: C:/Users/blaines.ADS/Documents/maya/projects/default/scenes/sphere.mb
+### meters_per_unit: 0.010000
+
+
+
+options
+{
+ AA_samples 3
+ outputs "RGBA RGBA test/defaultArnoldFilter/gaussian_filter test/defaultArnoldDriver/driver_exr.RGBA"
+ xres 960
+ yres 540
+ texture_per_file_stats on
+ texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
+ texture_automip off
+ camera "test/persp/perspShape"
+ color_manager "test/defaultColorMgtGlobals"
+ meters_per_unit 0.00999999978
+ frame 1
+ procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
+ GI_diffuse_depth 1
+ GI_specular_depth 1
+ GI_transmission_depth 8
+ declare dcc_name constant STRING
+ dcc_name "defaultArnoldRenderOptions"
+ declare render_layer constant STRING
+ render_layer "defaultRenderLayer"
+}
+
+gaussian_filter
+{
+ name test/defaultArnoldFilter/gaussian_filter
+ declare dcc_name constant STRING
+ dcc_name "defaultArnoldFilter"
+}
+
+driver_exr
+{
+ name test/defaultArnoldDriver/driver_exr.RGBA
+ filename "C:/Users/blaines.ADS/Documents/maya/projects/default/images/sphere.exr"
+ color_space ""
+ declare dcc_name constant STRING
+ dcc_name "defaultArnoldDriver"
+}
+
+color_manager_ocio
+{
+ name test/defaultColorMgtGlobals
+ config "C:/Program Files/Autodesk/Maya2024/resources/OCIO-configs/Maya2022-default/config.ocio"
+ color_space_linear "ACEScg"
+ declare dcc_name constant STRING
+ dcc_name "defaultColorMgtGlobals"
+}
+
+persp_camera
+{
+ name test/persp/perspShape
+ matrix
+ 0.707106769 0 -0.707106769 0
+ -0.331294566 0.883452237 -0.331294566 0
+ 0.624695063 0.468521297 0.624695063 0
+ 2.4422133 1.83165991 2.4422133 1
+ near_clip 0.100000001
+ far_clip 10000
+ shutter_start 0
+ shutter_end 0
+ shutter_type "box"
+ rolling_shutter "off"
+ rolling_shutter_duration 0
+ motion_start 0
+ motion_end 0
+ exposure 0
+ fov 54.4322243
+ uv_remap 0 0 0 1
+ declare dcc_name constant STRING
+ dcc_name "perspShape"
+ declare maya_full_name constant STRING
+ maya_full_name "|persp|perspShape"
+}
+
+skydome_light
+{
+ name test/aiSkyDomeLight1/aiSkyDomeLightShape1
+ exposure 0
+ cast_shadows on
+ cast_volumetric_shadows on
+ shadow_density 1
+ shadow_color 0 0 0
+ samples 1
+ normalize on
+ camera 1
+ transmission 1
+ diffuse 1
+ specular 1
+ sss 1
+ indirect 1
+ max_bounces 999
+ volume_samples 2
+ volume 1
+ aov "default"
+ resolution 1000
+ format "latlong"
+ portal_mode "interior_only"
+ aov_indirect off
+ declare dcc_name constant STRING
+ dcc_name "aiSkyDomeLightShape1"
+ declare maya_full_name constant STRING
+ maya_full_name "|aiSkyDomeLight1|aiSkyDomeLightShape1"
+}
+
+polymesh
+{
+ name test/pSphere1/pSphereShape1
+ visibility 255
+ sidedness 255
+ matrix
+ 1 0 0 0
+ 0 1 0 0
+ 0 0 1 0
+ 0 0 0 1
+ shader "test/aiStandardSurface1"
+ use_light_group off
+ id 4263086747
+ nsides 400 1 b85UINT
+B!%<_l4$$$%)!$v;Z0$$$$.
+ vidxs 1560 1 b85UINT
+F$Glq$$'GF\$'J8Y$IW1:$Lwac$,R7F$,U)C$Naw$$R-RM$1](0$1_o-$Slgc$W8C7$6gmo$6j_l$XwXM$\C3v$;r^Y$;uPV$^-I7$aN$`$A(OC$A+A@$c89v$fXjJ$$&_A$F61k$hC*`$kc[4$K>0l$K@wi$mMpJ$pnKs$PHvV$PKhS$rXa4$v$<]$USg@$UVY=$wcQs%&/-G$Z^X*$ZaJ'%'nB]%+9s1$_iHi$_l:f%-$3G%0Dcp$dt9S$dw+P%2/$1$h@,s$j**=$j,q:%79ip%:ZED$o4p'$o7b$%<DZZ%?e6.$t?`f$tBRc%AOKD%Dp&m%$JQP%$MCM%FZ<.%J%lW%)UB:%)X47%Ke,m%O0]A%.`3$%.c$v%PorW%T;N+%3jxc%3mj`%Uwq2%YF>j%8uiM%8x[J%[0T+%^Q/T%>+Z7%>.L4%`;Dj%c[u>%C6Jv%C9<s%eF5T%hff(%HA;`%HD-]%jQ&>%mqVg%ML,J%MNsG%o[l(%s'GQ%RVr4%RYd1%tf\g%x28;%5U-2%WdT\&$qMQ&(=)%%\lS]%\oEZ&*'>;&-Gnd%awDG%b%6D&/2/%&2R_N%g-51%g0'.&4<td&7]P8%l8%p%l:lm&9GeN&<h@w%qBkZ%qE]W&>RV8&As1a%vM\D%vPNA&C]Fw&$nOd&&XM.&&[?+&Hh7a&L3h5&+c=m&+f/j&Ms(K&Q>Xt&0n.W&0puT&S(n5&VII^&5xtA&6&f>&X3^t&[T:H&;.e+&;1W(&]>O^&`_+2&@9Uj&@<Gg&bI@H&eipq&EDFT&EG8Q&gQ>x&jta[&JO7>&JR);&l^vq&p*RE&OZ((&O\o%&qig[&u5C/&Tdmg&Tg_d&vtXE'%@3n&Yo^Q&YrPN''*I/'*K$X&_%O;&_(A8',59n'/UjB&d0@%&d31w'1@*X'4`[,&G.Ox&i=wM'6JpB'9kKk&nEvN&nHhK';Ua,'>v<U&sPg8&sSY5'@`Qk'D,-?&x[Ww&x^It'EkBU'I6s)'(fHa'(i:^'Jv3?'NAch'-q9K'-t+H'P,$)'SLTR'3'*5'3)q2'U6ih'6GrU'81ot'84aq'ZAZR']b6&'=<`^'=?R['_LK<'bm&e'BGQH'BJCE'dW<&'gwlO'GRB2'GU4/'ib,e'm-]9'L]2q'L`$n'nlrO'r8Mx'Qgx['QjjX'swc9'wC>b'VriE'Vu[B($*ai('N/L'\(Z/'\+L,()8Db(,Xu6'a3Jn'a6<k(.C5L(1ceu'f>;X'fA-U(3N&6(6nV_'kI,B'kKs?(8Xku(<$GI'pSr,'pVd)(=c\_(A/83'u^bk'uaTh(BnMI(F:(r'X\ri(%lE>(H$>3(KDn\(*tD?(*w6<(M/.r(PO_F(0*5)(0-'&(R9t\(UZP0(55%h(57le(WDeF(Ze@o(:?kR(:B]O(\OV0(_p1Y(?J\<(?MN9(aZFo(e%wC(DUM&(DX>x(fe7Y(Gv@F(I`=e(Ic/b(kp(C(o;Xl(Nk.O(NmuL(q%n-(tFIV(Sut9(Sxf6(v0^l)$Q:@(Y+dx(Y.Vu)&;OV))\+*(^6Ub(^9G_)+F@@).fpi(cAFL(cD8I)0Q1*)3qaS(hL76(hO)3)5Y/Z)9'R=(mW'u(mYnr):fgS)>2C'(ram_(rd_\)?qX=)C=3f(wl^I(woPF)E'I')HH$P)'wO3)(%A0)J29f)MRj:)--?r)-01o)O=*P)R][$)280\)2:wY)TGp:)WhKc(j6@Z)7Eh/)YRa$)\s<M)<Mg0)<PY-)^]Qc)b)-7)AXWo)A[Il)chBM)g3rv)FcHY)Ff:V)hs37)l>c`)Kn9C)Kq+@)n(xv)qITJ)Q$*-)Q&q*)s3i`)vTE4)V.ol)V1ai)x>ZJ)YOc7)[9`V)[<RS*(IK4*+j&])`DQ@)`GC=*-T;s*0tlG)eOB*)eR4'*2_,]*6*]1)jZ2i)j]$f*7irG*;5Mp)odxS)ogjP*<tc1*@@>Z)toi=)tr[:*B*Sp*EK/D*%%Z'*%(L$*G2RK*JUu.**0Jf**3<c*L@5D*O`em*/;;P*/>-M*QK&.*TkVW*4F,:*4Hs7*VUkm*YvGA*9Pr$*9Scv*[`\W*_,8+*>[bc*>^T`*`kMA*d7(j*CfSM*CiEJ*ev>+*iAnT*&dcK*Ht5u*k,.j*nL_>*N'4v*N*&s*p6tT*sWP(*S2%`*S4l]*uAe>*xb@g*X<kJ*X?]G+%LV(+(m1Q*]G\4*]JN1+*WFg+-ww;*bRLs*bU>p+/b7Q+3-h%*g]=]*g`/Z+4m(;*k)1(*lh.G*ljuD+9wn%+=CIN*qrt1*quf.+?-^d+BN:8*w(dp*w+Vm+D8ON+GY*w+'3UZ+'6GW+IC@8+Lcpa+,>FD+,A8A+NN0w+QnaK+1I7.+1L)++SXva+W$R5+6T'm+6Vnj+X`u<+Yj%R+Yj1W+Yj=\+YjIa+YjUf+Yjak+Yjmp+Yk$u+Yk1%+Yk=*+YkI/+YkU4+Yka9+Ykm>+Yl$C+Yl0H+Yl<M+YlHR+YlTW+Yl`H+\/Bt+\/O$+\/[)+\/g.+\/s3+\0*8+\06=+\0BB+\0NG+\0ZL+\0fQ+\0rV+\1)[+\15`+\1Ae+\1Mj+\1Yo+\1et+\1r$+\/7.
+ nidxs 1560 1 b85UINT
+F$'GFH$*j\k$*jhq$,R[A$3D?0$5+JA$5+VI$6h<j$=YuY$?A+j$?A7r$A(s>$GoW-$IVb>$IVnF$K>Tg$R08V$SlCg$SlOo$UT6;$\Eo*$^-%;$^-1C$_ild$f[PS$$)E7$)3rI$j*)Y$ka82$/uZ&$0%nh$mMp;$plM,$:6;M$:;,-$rXa($uwb%$DKqs$DP>G$wcQj%&-vs$NaSD$NePa%'nBW%+96l$Xw4j$Y%c&%-$3D%0DKe$c7k;$c:u@%2/$1$j$j?$hC+1$hEr-%5R^`%:ZED$o4p'$o7b$%<DZZ%?e6.$t?`f$tBRc%AOKD%Dp&m%$JQP%$MCM%FZ<.%J%lW%)UB:%)X47%Ke,m%O0]A%.`3$%.c$v%PorW%T;N+%3jxc%3mj`%Ux(7%W_'W%8u]J%8xOF%[0T+%^Q/T%>+Z7%>.L4%`;Dj%c[u>%C6Jv%C9<s%eF5T%hff(%HA;`%HD-]%jQ&>%mqVg%ML,J%MNsG%o[l(%s'GQ%RVr4%RYd1%tf\g%x28;%7<8B%YK_m&&XL\&(=)$%\lS\%\oEZ&*'>;&-Gnd%awDG%b%6D&/2/%&2R_N%g-51%g0'.&4<td&7]P8%l8%p%l:lm&9GeN&<h@w%qBkZ%qE]W&>RV8&As1a%vM\D%vPNA&C]Fw&&Ufx&$qMw&$t?s&G,,Q&L3h5&+c=m&+f/j&Ms(K&Q>Xt&0n.W&0puT&S(n5&VII^&5xtA&6&f>&X3^t&[T:H&;.e+&;1W(&]>O^&`_+2&@9Uj&@<Gg&bI@H&eipq&EDFT&EG8Q&gQK(&i8JH&JO+;&JQr7&l^vq&p*RE&OZ((&O\o%&qig[&u5C/&Tdmg&Tg_d&vtXE'%@3n&Yo^Q&YrPN''*I/'*K$X&_%O;&_(A8',59n'/UjB&d0@%&d31w'1@*X'4`[,&Hj[3&k%-^'81oM'9kKj&nEvM&nHhK';Ua,'>v<U&sPg8&sSY5'@`Qk'D,-?&x[Ww&x^It'EkBU'I6s)'(fHa'(i:^'Jv3?'NAch'-q9K'-t+H'P,$)'SLTR'3'*5'3)q2'U6ih'8/4i'6Jph'6Mbd'XZOB']b6&'=<`^'=?R['_LK<'bm&e'BGQH'BJCE'dW<&'gwlO'GRB2'GU4/'ib,e'm-]9'L]2q'L`$n'nlrO'r8Mx'Qgx['QjjX'swc9'wC>b'VriE'Vu[B($*mn(%fm9'\(N,'\+@(()8Db(,Xu6'a3Jn'a6<k(.C5L(1ceu'f>;X'fA-U(3N&6(6nV_'kI,B'kKs?(8Xku(<$GI'pSr,'pVd)(=c\_(A/83'u^bk'uaTh(BnMI(F:(r'ZD)$('SPO(I`=>(KDn[(*tD>(*w6<(M/.r(PO_F(0*5)(0-'&(R9t\(UZP0(55%h(57le(WDeF(Ze@o(:?kR(:B]O(\OV0(_p1Y(?J\<(?MN9(aZFo(e%wC(DUM&(DX>x(fe7Y(I]WZ(H$>Y(H'0U(j3r3(o;Xl(Nk.O(NmuL(q%n-(tFIV(Sut9(Sxf6(v0^l)$Q:@(Y+dx(Y.Vu)&;OV))\+*(^6Ub(^9G_)+F@@).fpi(cAFL(cD8I)0Q1*)3qaS(hL76(hO)3)5Y;_)7@;*(mVpr(mYbn):fgS)>2C'(ram_(rd_\)?qX=)C=3f(wl^I(woPF)E'I')HH$P)'wO3)(%A0)J29f)MRj:)--?r)-01o)O=*P)R][$)280\)2:wY)TGp:)WhKc(krKj)9,s@)[9`/)\s<L)<Mg/)<PY-)^]Qc)b)-7)AXWo)A[Il)chBM)g3rv)FcHY)Ff:V)hs37)l>c`)Kn9C)Kq+@)n(xv)qITJ)Q$*-)Q&q*)s3i`)vTE4)V.ol)V1ai)x>ZJ)[7%K)YRaJ)YUSF*&b@$*+j&])`DQ@)`GC=*-T;s*0tlG)eOB*)eR4'*2_,]*6*]1)jZ2i)j]$f*7irG*;5Mp)odxS)ogjP*<tc1*@@>Z)toi=)tr[:*B*Sp*EK/D*%%Z'*%(L$*G2^P*Hn]p**0>c**30_*L@5D*O`em*/;;P*/>-M*QK&.*TkVW*4F,:*4Hs7*VUkm*YvGA*9Pr$*9Scv*[`\W*_,8+*>[bc*>^T`*`kMA*d7(j*CfSM*CiEJ*ev>+*iAnT*(Kn[*J[A1*lh-u*nL_=*N'4u*N*&s*p6tT*sWP(*S2%`*S4l]*uAe>*xb@g*X<kJ*X?]G+%LV(+(m1Q*]G\4*]JN1+*WFg+-ww;*bRLs*bU>p+/b7Q+3-h%*g]=]*g`/Z+4m(;*leH<*k,/;*k.v7+8;bj+=CIN*qrt1*quf.+?-^d+BN:8*w(dp*w+Vm+D8ON+GY*w+'3UZ+'6GW+IC@8+Lcpa+,>FD+,A8A+NN0w+QnaK+1I7.+1L)++SXva+W$R5+6T'm+6Vnj+Xa,A+Yj%R+Yj1Y+YjUg+Yjmq+Yk1&+YkI0+Yka:+Yl$D+Yl<N+YlTX+Yllb+Ym/l+YmGv+Ym`++Ymx5+Yn;?+YnSI+YnkS+Yo.]+YoF?+\/6q+\/Nx+\/[)+\/g.+\/s3+\0*8+\06=+\0BB+\0NG+\0ZL+\0fQ+\0rV+\1)[+\15`+\1Ae+\1Mj+\1Yo+\1et+\1r$+\/C2
+ uvidxs 1560 1 b85UINT
+F$IT'4$'GF]$'JD^$K>HN$N^ls$,R7G$,U5H$PI98$Si]]$1](1$1`&2$UT)w$XtNG$6gmp$6jkq$Z^oa$^*?1$;r^Z$;u\[$_i`K$c5/p$A(OD$A+ME$dtQ5$h?uZ$F3@.$GrI?$kfY4$o2(Y$M%H-$M(F.$pqIs$t<nC$R08l$R36m$v':]%$G_-$W;)V$W>'W%&2+G%)ROl$\Eo@$\HmA%+<q1%.]@V$aP`*$aS^+%0Gap%3h1@$f[Pi$f^Nj%5RRZ%8rw*$mMXg$mPVi%<DZY%?e*)$rXIR$r[GS%AOKC%Dooh$wc:<$wf8=%FZ<-%J%`R%'n+&%'q)'%Ke,l%O0Q<%,xpe%-&nf%PorV%T;B&%2.aO%21_P%V%c@%YF2e%79R9%7<P:%[0T*%`8:d%>+Z8%>.X9%aw\)%eC+N%C6Jw%C9Hx%g-Lh%jMq8%HA;a%HD9b%l8=R%oXaw%ML,K%MO*L%qC.<%tcRa%RVr5%RYp6%vMt&&$nCK%Wabt%Wd`u&&Xde&*$45%\lS^%^V\o&-Jld&0k<4%c^[]%caY^&2U]N&5v,s%hiLG%hlJH&7`N8&;+r]%mt=1%mw;2&<k>w&@6cG%s*-p%s-+q&Av/a&EAT1%x4sZ%x7q[&G+uK&JLDp&(?dD&(BbE&L6f5&OW5Z&/1lB&/4jD&S(n4&VI=Y&4<]-&4?[.&X3^s&[T.C&9GMl&9JKm&]>O]&`^t-&>R>V&>U<W&bI@G&eidl&C]/@&C`-A&gT11&jtUV&Hgu*&Hjs+&l^vp&p*F@&Mrei&Mucj&qigZ&vqN?&Tdmh&Tgki&x[oY'''?)&Yo^R&Yr\S'(f`C',2/h&_%O<&_(M='-qQ-'1<uR&d0@&&d3>''3'Al'6Gf<&i;0e&i>.f'822V';RW&&nEvO&nHtP'=<x@'@]Ge&sPg9&u:pJ'D/+?'GOOd'%Bo8'%Em9'I9q)'LZ@N'*M_w'*P]x'NDah'Qe18'/XPa'/[Nb'SORR'Vovw'4cAK'4f?L'XZC<'\%ga'9n25'9q06']e4&'a0XK'>xwt'?&uu'bp$e'f;I5'Ek*r'En(t'ib,d'm-Q4'Jup]'Jxn^'nlrN'r8As'P+aG'P._H'swc8'wC2]'U6R1'U9P2($-Sw('MxG'ZABp'ZD@q()8Da(,Xi1'_L3Z'_O1[(.C5K(1cYp'dW$D'dYwE(3N&5(8Uao'kI,C'kL*D(:@.4(=`RY'pSr-'pVp.(?Jss(BkCC'u^bl'ua`m(DUd](Gv4-(%iSV(%lQW(I`UG(M,$l(*tD@(*wBA(NkF1(R6jV(0*5*(0-3+(Sv6p(WA[@(55%i(6t/%(Zh>o(^3c?(<'-h(<*+i(_s/Y(c>T)(A1sR(A4qS(e(uC(hIDh(F<d<(F?b=(j3f-(mT5R(KGU&(KJS'(o>Vl(r_&<(PREe(PUCf(tIGV(wil&(U]6O(U`4P)$T8@)'t\e(\O>M(\R<O)+F@?).fdd(aZ/8(a]-9)0Q1))3qUN(fdtw(fgrx)5[vh)9'F8(koea(krcb):fgR)>26w(q%VK(q(TL)?qX<)C='a(v0G5(v3E6)E'I&)HGmK)&;7t)&>5u)J29e)O9uJ)--?s)-0=t)Q$Ad)TDf4)280])2;.^)V/2N)YOVs)7BvG)7EtH)[9x8)^ZG])<Mg1)<Pe2)`Dhw)ce8G)AXWp)A[Uq)eOYa)hp)1)FcHZ)FfF[)jZJK)n%np)Kn9D)MXBU)qLRJ)tlvo)R`AC)Rc?D)vWC4*$wgY)Wk2-)Wn0.*&b3s**-XC)\uwl)\xum*+m$]*/8I-)b+hV)b.fW*0wjG*4C9l)g6Y@)g9WA*6-[1*9N*V)lAJ*)lDH+*;8Kp*>Xp@)s3R()s6P**B*So*EJx?)x>Bh)xA@i*G5DY*JUi)*(I3R*(L1S*L@5C*O`Yh*-T$<*-Vw=*QK&-*TkJR*2^j&*2ah'*VUkl*Yv;<*7iZe*7lXf*[`\V*_,,&*<tKO*<wIP*`kM@*es4%*CfSN*CiQO*g]U?*k)$d*HqD8*HtB9*lhF)*p3jN*N'4w*N*2x*qs6h*u>[8*S2%a*S4xb*w)'R+%IKw*X<kK*X?iL+'3m<+*T<a*]G\5*]JZ6+,>^&+/_-K*bRLt*d<V0+30f%+6Q5J*iDTs*iGRt+8;Vd+;\&4*nOE]*nRC^+=FGN+@fks*sZ6G*s]4H+BQ88+Eq\]*xe'1*xh%2+G\(w+K'MG+(olp+(rjq+Lfna+P2>1+.%]Z+.([[+Qq_K+U=.p+4leX+4ocZ+XcgJ+\/6o+9wVC+:%TD+]nX4+a:'Y+?-G-+?0E.+c$Hs+fDmC+D87l+D;5m+h/9]+kO^-+IC(V+IF&W+m:*G+pZNl+NMn@+NPlA+rDp1+ue?V+SX_*+S[]++wO`p,%:P.,&vgC,(^)X,*E@m,,,X-,-hoB,/P1W,17Hl,2s`,,4ZwA,6B9V,8)Pk,9eh+,;M*@,=4AU,>pXj,@Wp*,B?2?,D&IT,Eb`i,H'r1,Id4F,KKK[,M2bp,No%0,PV<E,R=SZ,T$jo,Ua-/,WHDD,Y/[Y,Zkrn,\S5.,^:LC,_vcX,a^%m,cE=-,e,TB,fhkW,hP-l
+ vlist 382 1 b85VECTOR
+7uCHtaR7`_`jc&P7rt'waR7`_`wC3.7kRWXaR7`_a)dXM7^rJxaR7`_a,4$IzaR7`_a-&.?`jc&NaR7`_a,4$H`wC3,aR7`_a)dXKa)dXJaR7`_`wC3*a,4$FaR7`_`jc&Ka-&.=aR7`_za,4$FaR7`_7^rJua)dXJaR7`_7kRWS`wC3)aR7`_7rt's`jc&KaR7`_7uCHo]+QgXaR7`_7v5Re7^rJqaR7`_7uCHn7kRWQaR7`_7rt'r7rt'raR7`_7kRWR7uCHnaR7`_7^rJr7v5RdaR7`_z8-jL<aQ7[A`x/vL8+HY>aQ7[Aa/f5)7xuYSaQ7[Aa794h7l?EtaQ7[Aa9['fzaQ7[Aa:L<8`x/vJaQ7[Aa9['ea/f5'aQ7[Aa794fa794faQ7[Aa/f5&a9['caQ7[A`x/vGa:L<5aQ7[Aza9['caQ7[A7l?Eqa794eaQ7[A7xuYOa/f5%aQ7[A8+HY:`x/vGaQ7[A8-jL7]8wuQaQ7[A8.[`^7l?EmaQ7[A8-jL67xuYLaQ7[A8+HY98+HY8aQ7[A7xuYM8-jL6aQ7[A7l?En8.[`]aQ7[Az85BheaOV5ba+:2Y81k?taOV5ba82J)8,AnSaOV5ba=[pI7tIW-aOV5baA3D9zaOV5baBETaa+:2XaOV5baA3D8a82J'aOV5ba=[pFa=[pEaOV5ba82J&aA3D6aOV5ba+:2UaBET^aOV5bzaA3D6aOV5b7tIW*a=[pDaOV5b8,AnOa82J%aOV5b81k?na+:2UaOV5b85Bh^]@q8xaOV5b86U$17tIW(aOV5b85Bh]8,AnMaOV5b81k?m81k?laOV5b8,AnN85Bh\aOV5b7tIW)86U$/aOV5bz8:_aQaMAiaa/f5)87d&JaMAiaa<K]m80[-BaMAiaaCTVt7xuYRaMAiaaFP=&zaMAiaaG>,;a/f5(aMAiaaFP=%a<K]kaMAiaaCTVpaCTVoaMAiaa<K]iaFP<xaMAiaa/f5$aG>,8aMAiazaFP<xaMAia7xuYNaCTVnaMAia80[-=a<K]haMAia87d&Ba/f5$aMAia8:_aL]EieTaMAia8;MPa7xuYKaMAia8:_aL80[-;aMAia87d&A87d&@aMAia80[-<8:_aKaMAia7xuYL8;MP`aMAiaz8=h8GaJT2fa3h^G8;)%7aJT2fa@=FF84LjpaJT2faFnUa8'x-paJT2faIXhqzaJT2faJT2la3h^FaJT2faIXhpa@=FCaJT2faFnU_aFnU^aJT2fa@=FBaIXhnaJT2fa3h^AaJT2iaJT2fzaIXhnaJT2f8'x-kaFnU^aJT2f84Ljja@=F@aJT2f8;)%2a3h^AaJT2f8=h8A]I*l/aJT2f8>cW<8'x-gaJT2f8=h8A84LjgaJT2f8;)%18;)%1aJT2f84Lji8=h8@aJT2f8'x-i8>cW;aJT2fz8@J=naG>,6a794h8=>KTaG>,6aCTVt87d&IaG>,6aI/')8+HY<aG>,6aL:nBzaG>,6aMAiga794gaG>,6aL:nAaCTVqaG>,6aI/''aI/'&aG>,6aCTVoaL:n?aG>,6a794eaMAidaG>,6zaL:n?aG>,68+HY:aI/'%aG>,687d&CaCTVnaG>,68=>KNa794eaG>,68@J=g]KmN*aG>,68AQ988+HY7aG>,68@J=g87d&@aG>,68=>KM8=>KMaG>,687d&A8@J=faG>,68+HY88AQ96aG>,6z8BUCkaBETZa8YmK8?.MqaBETZaES@889bdbaBETZaJt)F8,i<taBETZaNEt?zaBETZaOV5ia8YmJaBETZaNEt?aES@6aBETZaJt)CaJt)BaBETZaES@5aNEt<aBETZa8YmGaOV5faBETZzaNEt<aBETZ8,i<qaJt)BaBETZ89bd_aES@5aBETZ8?.Mka8YmGaBETZ8BUCd]N,o+aBETZ8CeZ98,i<oaBETZ8BUCc89bd]aBETZ8?.Mj8?.MiaBETZ89bd^8BUCbaBETZ8,i<p8CeZ7aBETZz8D/xBa:L<2a9['f8@J=na:L<2aFP='8:_aQa:L<2aL:nC8-jL:a:L<2aOuSkza:L<2aQ7[Ia9['ea:L<2aOuSjaFP=%a:L<2aL:nAaL:n@a:L<2aFP=$aOuSga:L<2a9['caQ7[Ea:L<2zaOuSga:L<28-jL8aL:n?a:L<28:_aMaFP<xa:L<28@J=ha9['ca:L<28D/x:]Oc?_a:L<28EG*m8-jL5a:L<28D/x98:_aKa:L<28@J=g8@J=fa:L<28:_aL8D/x8a:L<28-jL68EG*ka:L<2z8E+oja-&.3a::XE8A:.Ba-&.3aG-<s8;<aHa-&.3aM*^l8.J'na-&.3aPqK>za-&.3aR7`ga::XDa-&.3aPqK=aG-<qa-&.3aM*^iaM*^ha-&.3aG-<paPqK:a-&.3a::XAaR7`ca-&.3zaPqK:a-&.38.J'kaM*^ga-&.38;<aDaG-<oa-&.38A:.;a::XAa-&.38E+ob]PcE(a-&.38FG068.J'ha-&.38E+ob8;<aBa-&.38A:.:8A:.9a-&.38;<aC8E+oaa-&.38.J'i8FG04a-&.3z8EG*uza:L<98AQ9?zaG>,<8;MPfzaMAii8.[`bzaQ7[IzzaRT=ha:L<8zaQ7[HaG>,:zaMAifaMAiezaG>,9aQ7[Eza:L<5aRT=fzzaQ7[Ez8.[`_aMAidz8;MPbaG>,8z8AQ98a:L<5z8EG*m]Q*w-z8Fcb:8.[`\z8EG*l8;MP`z8AQ978AQ96z8;MPa8EG*kz8.[`]yzz8E+oj7v5R]a::XE8A:.B7v5R]aG-<s8;<aH7v5R]aM*^l8.J'n7v5R]aPqK>z7v5R]aR7`ga::XD7v5R]aPqK=aG-<q7v5R]aM*^iaM*^h7v5R]aG-<paPqK:7v5R]a::XAaR7`c7v5R]zaPqK:7v5R]8.J'kaM*^g7v5R]8;<aDaG-<o7v5R]8A:.;a::XA7v5R]8E+ob]PcE(7v5R]8FG068.J'h7v5R]8E+ob8;<aB7v5R]8A:.:8A:.97v5R]8;<aC8E+oa7v5R]8.J'i8FG047v5R]z8D/xB8.[`\a9['f8@J=n8.[`\aFP='8:_aQ8.[`\aL:nC8-jL:8.[`\aOuSkz8.[`\aQ7[Ia9['e8.[`\aOuSjaFP=%8.[`\aL:nAaL:n@8.[`\aFP=$aOuSg8.[`\a9['caQ7[E8.[`\zaOuSg8.[`\8-jL8aL:n?8.[`\8:_aMaFP<x8.[`\8@J=ha9['c8.[`\8D/x:]Oc?_8.[`\8EG*m8-jL58.[`\8D/x98:_aK8.[`\8@J=g8@J=f8.[`\8:_aL8D/x88.[`\8-jL68EG*k8.[`\z8BUCk86U$/a8YmK8?.Mq86U$/aES@889bdb86U$/aJt)F8,i<t86U$/aNEt?z86U$/aOV5ia8YmJ86U$/aNEt?aES@686U$/aJt)CaJt)B86U$/aES@5aNEt<86U$/a8YmGaOV5f86U$/zaNEt<86U$/8,i<qaJt)B86U$/89bd_aES@586U$/8?.Mka8YmG86U$/8BUCd]N,o+86U$/8CeZ98,i<o86U$/8BUCc89bd]86U$/8?.Mj8?.Mi86U$/89bd^8BUCb86U$/8,i<p8CeZ786U$/z8@J=n8;MP`a794h8=>KT8;MP`aCTVt87d&I8;MP`aI/')8+HY<8;MP`aL:nBz8;MP`aMAiga794g8;MP`aL:nAaCTVq8;MP`aI/''aI/'&8;MP`aCTVoaL:n?8;MP`a794eaMAid8;MP`zaL:n?8;MP`8+HY:aI/'%8;MP`87d&CaCTVn8;MP`8=>KNa794e8;MP`8@J=g]KmN*8;MP`8AQ988+HY78;MP`8@J=g87d&@8;MP`8=>KM8=>KM8;MP`87d&A8@J=f8;MP`8+HY88AQ968;MP`z8=h8G8>cW;a3h^G8;)%78>cW;a@=FF84Ljp8>cW;aFnUa8'x-p8>cW;aIXhqz8>cW;aJT2la3h^F8>cW;aIXhpa@=FC8>cW;aFnU_aFnU^8>cW;a@=FBaIXhn8>cW;a3h^AaJT2i8>cW;zaIXhn8>cW;8'x-kaFnU^8>cW;84Ljja@=F@8>cW;8;)%2a3h^A8>cW;8=h8A]I*l/8>cW;8>cW<8'x-g8>cW;8=h8A84Ljg8>cW;8;)%18;)%18>cW;84Lji8=h8@8>cW;8'x-i8>cW;8>cW;z8:_aQ8AQ96a/f5)87d&J8AQ96a<K]m80[-B8AQ96aCTVt7xuYR8AQ96aFP=&z8AQ96aG>,;a/f5(8AQ96aFP=%a<K]k8AQ96aCTVpaCTVo8AQ96a<K]iaFP<x8AQ96a/f5$aG>,88AQ96zaFP<x8AQ967xuYNaCTVn8AQ9680[-=a<K]h8AQ9687d&Ba/f5$8AQ968:_aL]EieT8AQ968;MPa7xuYK8AQ968:_aL80[-;8AQ9687d&A87d&@8AQ9680[-<8:_aK8AQ967xuYL8;MP`8AQ96z85Bhe8CeZ7a+:2Y81k?t8CeZ7a82J)8,AnS8CeZ7a=[pI7tIW-8CeZ7aA3D9z8CeZ7aBETaa+:2X8CeZ7aA3D8a82J'8CeZ7a=[pFa=[pE8CeZ7a82J&aA3D68CeZ7a+:2UaBET^8CeZ7zaA3D68CeZ77tIW*a=[pD8CeZ78,AnOa82J%8CeZ781k?na+:2U8CeZ785Bh^]@q8x8CeZ786U$17tIW(8CeZ785Bh]8,AnM8CeZ781k?m81k?l8CeZ78,AnN85Bh\8CeZ77tIW)86U$/8CeZ7z8-jL<8EG*k`x/vL8+HY>8EG*ka/f5)7xuYS8EG*ka794h7l?Et8EG*ka9['fz8EG*ka:L<8`x/vJ8EG*ka9['ea/f5'8EG*ka794fa794f8EG*ka/f5&a9['c8EG*k`x/vGa:L<58EG*kza9['c8EG*k7l?Eqa794e8EG*k7xuYOa/f5%8EG*k8+HY:`x/vG8EG*k8-jL7]8wuQ8EG*k8.[`^7l?Em8EG*k8-jL67xuYL8EG*k8+HY98+HY88EG*k7xuYM8-jL68EG*k7l?En8.[`]8EG*kz7uCHt8FG04`jc&P7rt'w8FG04`wC3.7kRWX8FG04a)dXM7^rJx8FG04a,4$Iz8FG04a-&.?`jc&N8FG04a,4$H`wC3,8FG04a)dXKa)dXJ8FG04`wC3*a,4$F8FG04`jc&Ka-&.=8FG04za,4$F8FG047^rJua)dXJ8FG047kRWS`wC3)8FG047rt's`jc&K8FG047uCHo]+QgX8FG047v5Re7^rJq8FG047uCHn7kRWQ8FG047rt'r7rt'r8FG047kRWR7uCHn8FG047^rJr7v5Rd8FG04zzaRT=dzzyz
+ nlist 382 1 b85VECTOR
+8$sL?aR%6>`p]C(7vj/8aR%6>a($j&8,Oq4aQ$=Ea1B<t8/,uDaQ$=Da$guQ7q499aR%6Aa-Z_Q8%QaCaQ$=Ea8@L[7dlf_aR%6?a0d']7mwE;aQ$=Ea:rP`]Rk\vaR%6>a1j/2]ZEXpaQ$=Ea;iAh`p]BBaR%6?a0d'ta$guxaQ$=Da:rPna($inaR%6>a-Z`,a1B<xaQ$=Ca8@Lga-Z_kaR%6@a($j6a8@LcaQ$=Ca1B<ra0d'iaR%6@`p]CFa:rPoaQ$=Ca$gv0a1j/,aR%6?za;iAqaQ$=C\s`eKa0d'haR%6>7dlgqa:rPoaQ$=C7mwEMa-Z_iaR%6?7q49%a8@LcaQ$=C8%Qa:a($iiaR%6@7vj/6a1B<vaQ$=C8,Oq7`p]B8aR%6?8$sL3a$gunaQ$=C8/,uD4IDHjaR%6@8&$S<4Y11KaQ$=C8/xfF7dlfuaR%6?8$sL/7mwEOaQ$=D8/,uD7q49CaR%6?7vj/?8%QaKaQ$=D8,Oq:7vj/AaR%6?7q49F8,Oq8aQ$=D8%QaX8$sL?aR%6>7dlgx8/,uEaQ$=A7mwE_8&$SXaR%6@5(Kln8/xfEaQ$=D4n,BY82U=faOAqMa8`53867kIaOAqLa+j;W8,oYWaOAqMa>En;7u$`;aOAqNaB(Fp]^u6:aOAqMaC>G8a+j;saOAqNaB(Fta8`55aOAqLa>En?a>En@aOAqMa8`51aB(FxaOAqMa+j;haC>G@aOAqK4Y^O1aB(G%aOAqK7u$`Fa>EnAaOAqK8,oY]a8`50aOAqL82U=ma+j;kaOAqJ867kP4J,])aOAqJ87Mkl7u$`FaOAqK867kM8,oY\aOAqK82U=k82U=jaOAqJ8,oYb867kOaOAqL7u$`@87MkgaOAqM4i*v)88;[taM-K^a<l-+8;$uAaM-K_a03<W81&QLaM-K^aD,7Q8$BaPaM-K^aFjPj]P-jvaM-K\aGY]la03=5aM-K\aFjPja<l-,aM-K]aD,7NaD,7OaM-K[a<l-*aFjPkaM-K]a03=,aGY]kaM-K\4OS^8aFjPlaM-K]8$Ba[aD,7NaM-K\81&QYa<l-(aM-K[88;\(a03=&aM-K\8;$uAzaM-K[8;i-A8$BaUaM-K[8;$uA81&QVaM-KZ88;\,88;\'aM-K[81&QW8;$uAaM-K[8$BaU8;i-AaM-K\5+5i88;8JuaJ@lwa@Skw8>%E_aJ@lva4+;Q84c;FaJ@luaG)&O8(:`VaJ@lsaIjv2]_U<raJ@lsaJg:Ra4+<:aJ@lsaIjv1a@Sl%aJ@lsaG)&LaG)&NaJ@lsa@SkwaIjv3aJ@lra4+<1aJg:RaJ@lq]*ISgaIjv2aJ@lt8(:`XaG)&NaJ@lr84c;Oa@SkuaJ@lr8;8K%a4+<,aJ@lq8>%E^]2IK3aJ@lr8>v_'8(:`caJ@lt8>%E]84c;QaJ@lq8;8K%8;8K$aJ@lq84c;K8>%E\aJ@lq8(:`W8>v_'aJ@lq5/=Vk8=HJ&aG,t^aCc,n8@V'DaG,t\a7@i]87rQ>aG,t]aI9%T8+P9HaG,t[aLFWk]hcZ<aG,t\aMN1Wa7@j(aG,t]aLFWhaCc,taG,t\aI9%PaI9%UaG,tZaCc,jaLFWkaG,tZa7@ivaMN1WaG,t[]Jh%;aLFWiaG,t[8+P9KaI9%QaG,t\87rQDaCc,kaG,t[8=HJ)a7@iwaG,tY8@V'@4*>A7aG,tY8A]V-8+P9PaG,tY8@V'>87rQFaG,tY8=HJ'8=HJ)aG,tY87rQC8@V'@aG,tY8+P9K8A]V.aG,tY50&a>8?43^aB)a>aEWKc8B\)XaB)a?a8^5`89fp4aB)a@aK$d78,mZJaB)aDaNLZ)]Yd;iaB)aDaO]8ja8^6,aB)aDaNLZ'aEWKeaB)aCaK$d1aK$d5aB)aAaEWK_aNLZ(aB)aBa8^6$aO]8jaB)aG]SCosaNLZ'aB)aF8,mZOaK$d3aB)aD89fp8aEWKaaB)a@8?43_a8^6&aB)a>8B\)S4]4BYaB)a;8Cl]?8,mZTaB)a<8B\)S89fp6aB)a;8?43^8?43`aB)a<89fp78B\)TaB)a>8,mZP8Cl]AaB)a<52v)T8@LmMa:8ZwaFR128D3$9a:8Zwa9\x^8:aUXa:8[$aL=I&8-lHLa:8[&aOxT_]2EE>a:8[$aQ:iJa9]$-a:8ZxaOxT^aFR14a:8[%aL=HvaL=I&a:8[$aFR1/aOxT_a:8Zwa9]$&aQ:iJa:8[']Db/faOxT]a:8[&8-lHRaL=I$a:8Zp8:aU\aFR10a:8Zq8@LmPa9]$$a:8Zu8D3$44e9woa:8Zv8EJ8t8-lHUa:8Zx8D3$38:aU[a:8Zw8@LmN8@LmOa:8Zv8:aU[8D3$4a:8Zt8-lHP8EJ8wa:8Zq53XsU8A:e0a,fiLaG-dd8E,[<a,fiRa:;,o8;=45a,fiTaM+@]8.JQ\a,fiTaPr6cza,fiNaR8OQa:;-?a,fiPaPr6`aG-dga,fiMaM+@WaM+@[a,fiHaG-d`aPr6ba,fiBa:;-6aR8ORa,fi83m($UaPr6ba,fi88.JQcaM+@Ya,fi@8;=49aG-daa,fiL8A:e0a:;-4a,fiR8E,[84VThNa,fiO8FGt&8.JQda,fiM8E,[78;=47a,fiI8A:e08A:e0a,fiL8;=478E,[6a,fiH8.JQb8FGt&a,fiN53L[X8AQ963leGYaG>,68EG*p\jrsaa:L;i8;MP]]I`mKaMAib8.[`S]I`mMaQ7[BzzaRT=da:L<;]I`mPaQ7[@aG>,:]H<aGaMAi_aMAia3leG`aG>,4aQ7[A3_-C8a:L<2aRT=c\jrsa3leGaaQ7[?\xUx78.[`_aMAi_z8;MPbaG>,5]FmUA8AQ98a:L<.]LT0e8EG*kzz8Fcb88.[`^\jrsc8EG*k8;MPa\xUx<8AQ978AQ96\jrsc8;MP`8EG*kz8.[`_y3_-C453fkZ8A:e07uv8uaG-dd8E,[<7uv9&a:;,o8;=457uv9(aM+@]8.JQ\7uv9(aPr6cz7uv9$aR8OQa:;-?7uv9%aPr6`aG-dg7uv8waM+@WaM+@\7uv8taG-d`aPr6d7uv8ma:;-6aR8OR7uv8b4%`)+aPr6b7uv8a8.JQcaM+@Z7uv8j8;=49aG-db7uv8t8A:e0a:;-47uv8x8E,[74W=-`7uv9$8FGt&8.JQe7uv9$8E,[68;=487uv8v8A:e/8A:e07uv8w8;=488E,[97uv8t8.JQc8FGt&7uv8x53Dx68@LmM8.H*NaFR138D3$98.H*Na9\x^8:aUX8.H*OaL=I'8-lHL8.H*PaOxT_]2EE>8.H*OaQ:iJa9]$,8.H*NaOxT\aFR138.H*MaL=HvaL=I'8.H*MaFR1/aOxT_8.H*La9]$&aQ:iJ8.H*N]:)QhaOxT_8.H*L8-lHRaL=I$8.H*G8:aU\aFR108.H*F8@LmQa9]$$8.H*J8D3$44eYgJ8.H*K8EJ8t8-lHS8.H*M8D3$28:aU[8.H*M8@LmO8@LmO8.H*K8:aU[8D3$48.H*H8-lHP8EJ8w8.H*I52v;@8?43]8690laEWKc8B\)Y8690ka8^5`89fp48690laK$d68,mZL8690naNLZ*]Yd;i8690naO]8ja8^6+8690oaNLZ'aEWKe8690kaK$d1aK$d68690kaEWK_aNLZ*8690ma8^6&aO]8j8690m]O<GjaNLZ(8690m8,mZOaK$d38690m89fp8aEWKa8690k8?43_a8^6'8690h8B\)S4]4BY8690e8Cl]?8,mZS8690g8B\)R89fp68690g8?43_8?43_8690g89fp68B\)T8690g8,mZP8Cl]A8690h52:c)8=HJ&8;<D4aCc,m8@V'B8;<D1a7@i\87rQ?8;<D3aI9%T8+P9G8;<D0aLFWk]gn/:8;<D1aMN1Ua7@j'8;<D2aLFWhaCc,t8;<D1aI9%PaI9%T8;<D0aCc,kaLFWj8;<D0a7@iuaMN1W8;<D0]Jh%;aLFWi8;<D08+P9LaI9%Q8;<D087rQFaCc,k8;<D08=HJ(a7@ix8;<D.8@V'@3x\@g8;<D08A]V+8+P9R8;<D08@V'=87rQD8;<D/8=HJ'8=HJ'8;<D/87rQA8@V'@8;<D.8+P9J8A]V.8;<D.50+D.8;8Js8>P<La@Skx8>%E^8>P<Ka4+;S84c;E8>P<JaG)&N8(:`W8>P<HaIjv3]_U<r8>P<HaJg:Ra4+<98>P<HaIjv2a@Sl$8>P<HaG)&LaG)&N8>P<Ja@SktaIjv28>P<Ia4+<.aJg:R8>P<GzaIjv38>P<I8(:`YaG)&N8>P<G84c;Oa@Sku8>P<G8;8K%a4+<*8>P<F8>%E^]2IK38>P<F8>v_'8(:`c8>P<I8>%E]84c;N8>P<F8;8K%8;8Jx8>P<F84c;N8>%E\8>P<F8(:`Y8>v_(8>P<F5/=Vl88;[r8A<p2a<l-/8;$uA8A<p3a03<\81&QL8A<p2aD,7S8$BaQ8A<p3aFjPj]QgaI8A<p3aGY]ja03=58A<p2aFjPka<l-,8A<p1aD,7NaD,7Q8A<p2a<l-'aFjPk8A<p3a03=+aGY]k8A<p14S'==aFjPk8A<p18$Ba]aD,7N8A<p281&QVa<l-'8A<p188;\%a03='8A<p28;$u@z8A<p08;i-A8$BaS8A<p08;$uB81&QV8A<p/88;\*88;\*8A<p/81&QU8;$uA8A<p18$Ba\8;i-A8A<p05,oxO82U=e8CQ@ua8`59867kI8CQ@wa+j;V8,oYW8CQ@ua>EnF7u$`98CQ@vaB(Fs]`=mC8CQ@xaC>G6a+j;s8CQ@xaB(Foa8`548CQ@wa>En:a>En@8CQ@va8`5-aB(G$8CQ@wa+j;naC>G@8CQ@u4Y^O1aB(Fx8CQ@u7u$`Ua>En@8CQ@v8,oY]a8`518CQ@w82U=ia+j;l8CQ@t867kQ4I`qe8CQ@t87Mkp7u$`H8CQ@u867kP8,oY]8CQ@v82U=k82U=l8CQ@u8,oY`867kL8CQ@t7u$`F87Mkg8CQ@w4piDe8,Oq38E3ama1B=/8/,uC8E3ana$guO8%QaB8E3ala8@Lj7mwE<8E3aoa:rPi]ZEXp8E3aoa;iAaa$guw8E3aoa:rPfa1B<x8E3ama8@L_a8@Ld8E3aoa1B<ea:rPo8E3ama$guva;iAp8E3amza:rPn8E3am7mwEma8@La8E3an8%QaAa1B<u8E3am8,Oq6a$gum8E3al8/,uJ4XnAA8E3an8/xfF7mwER8E3ao8/,uD8%QaK8E3am8,Oq88,Oq88E3al8%QaP8/,uF8E3al7mwER8/xfE8E3ao4n&FV7vj/88F4Zia($iG8$sL@8F4Zi`p]A`7q4958F4Zia-Z_c7dlf_8F4Zja0d'o]SDK18F4Zja1j/,`p]BD8F4Zia0d'ka($im8F4Zja-Z_`a-Z_i8F4Zka($i)a0d'g8F4Zj`p]BTa1j/,8F4Ziza0d'i8F4Zh7dlgsa-Z_l8F4Zi7q49Da($ih8F4Zi7vj/L`p]B<8F4Zk8$sL74Gjfj8F4Zj8&$S87dlfu8F4Zi8$sL97q49E8F4Zk7vj/<7vj/C8F4Zk7q48`8$sLB8F4Zi7dlg68&$SU8F4Zi5(HxV]%T57aRT=d]q%`r\qS5Qy4jlE/
+ uvlist 439 1 b85VECTOR2
+z!7_[,H$$$$'7m>0s7_[,H7uNfZ7_[,H8%v5I7_[,H8+HY87_[,H8.1k07_[,H80p((7_[,H83Y9u7_[,H86BKm7_[,H89+]d7_[,H8:Jf`7_[,H8;io\7_[,H8=3xX7_[,H8>S,T7_[,H8?r5P7_[,H8A<>L7_[,H8B[GH7_[,H8D%PD7_[,H8EDY@7_[,H8Fcb:7_[,Hz7m>0s7_[,H!7m>0s$$$$'7uNfZ7m>0s8%v5I7m>0s8+HY87m>0s8.1k07m>0s80p((7m>0s83Y9u7m>0s86BKm7m>0s89+]d7m>0s8:Jf`7m>0s8;io\7m>0s8=3xX7m>0s8>S,T7m>0s8?r5P7m>0s8A<>L7m>0s8B[GH7m>0s8D%PD7m>0s8EDY@7m>0s8Fcb:7m>0sz7uNfZ7_[,H7uNfZ7m>0s!7uNfZ$$$$'8%v5I7uNfZ8+HY87uNfZ8.1k07uNfZ80p((7uNfZ83Y9u7uNfZ86BKm7uNfZ89+]d7uNfZ8:Jf`7uNfZ8;io\7uNfZ8=3xX7uNfZ8>S,T7uNfZ8?r5P7uNfZ8A<>L7uNfZ8B[GH7uNfZ8D%PD7uNfZ8EDY@7uNfZ8Fcb:7uNfZz8%v5I7_[,H8%v5I7m>0s8%v5I7uNfZ!8%v5I$$$$'8+HY88%v5I8.1k08%v5I80p((8%v5I83Y9u8%v5I86BKm8%v5I89+]d8%v5I8:Jf`8%v5I8;io\8%v5I8=3xX8%v5I8>S,T8%v5I8?r5P8%v5I8A<>L8%v5I8B[GH8%v5I8D%PD8%v5I8EDY@8%v5I8Fcb:8%v5Iz8+HY87_[,H8+HY87m>0s8+HY87uNfZ8+HY88%v5I!8+HY8$$$$'8.1k08+HY880p((8+HY883Y9u8+HY886BKm8+HY889+]d8+HY88:Jf`8+HY88;io\8+HY88=3xX8+HY88>S,T8+HY88?r5P8+HY88A<>L8+HY88B[GH8+HY88D%PD8+HY88EDY@8+HY88Fcb:8+HY8z8.1k07_[,H8.1k07m>0s8.1k07uNfZ8.1k08%v5I8.1k08+HY8!8.1k0$$$$'80p((8.1k083Y9u8.1k086BKm8.1k089+]d8.1k08:Jf`8.1k08;io\8.1k08=3xX8.1k08>S,T8.1k08?r5P8.1k08A<>L8.1k08B[GH8.1k08D%PD8.1k08EDY@8.1k08Fcb:8.1k0z80p((7_[,H80p((7m>0s80p((7uNfZ80p((8%v5I80p((8+HY880p((8.1k0!80p(($$$$'83Y9u80p((86BKm80p((89+]d80p((8:Jf`80p((8;io\80p((8=3xX80p((8>S,T80p((8?r5P80p((8A<>L80p((8B[GH80p((8D%PD80p((8EDY@80p((8Fcb:80p((z83Y9u7_[,H83Y9u7m>0s83Y9u7uNfZ83Y9u8%v5I83Y9u8+HY883Y9u8.1k083Y9u80p((83Y9u83Y9u83Y9u86BKm83Y9u89+]d83Y9u8:Jf`83Y9u8;io\83Y9u8=3xX83Y9u8>S,T83Y9u8?r5P83Y9u8A<>L83Y9u8B[GH83Y9u8D%PD83Y9u8EDY@83Y9u8Fcb:83Y9uz86BKm7_[,H86BKm7m>0s86BKm7uNfZ86BKm8%v5I86BKm8+HY886BKm8.1k086BKm80p((86BKm83Y9u!86BKm$$$$'89+]d86BKm8:Jf`86BKm8;io\86BKm8=3xX86BKm8>S,T86BKm8?r5P86BKm8A<>L86BKm8B[GH86BKm8D%PD86BKm8EDY@86BKm8Fcb:86BKmz89+]d7_[,H89+]d7m>0s89+]d7uNfZ89+]d8%v5I89+]d8+HY889+]d8.1k089+]d80p((89+]d83Y9u89+]d86BKm!89+]d$$$$'8:Jf`89+]d8;io\89+]d8=3xX89+]d8>S,T89+]d8?r5P89+]d8A<>L89+]d8B[GH89+]d8D%PD89+]d8EDY@89+]d8Fcb:89+]dz8:Jf`7_[,H8:Jf`7m>0s8:Jf`7uNfZ8:Jf`8%v5I8:Jf`8+HY88:Jf`8.1k08:Jf`80p((8:Jf`83Y9u8:Jf`86BKm8:Jf`89+]d!8:Jf`$$$$'8;io\8:Jf`8=3xX8:Jf`8>S,T8:Jf`8?r5P8:Jf`8A<>L8:Jf`8B[GH8:Jf`8D%PD8:Jf`8EDY@8:Jf`8Fcb:8:Jf`z8;io\7_[,H8;io\7m>0s8;io\7uNfZ8;io\8%v5I8;io\8+HY88;io\8.1k08;io\80p((8;io\83Y9u8;io\86BKm8;io\89+]d8;io\8:Jf`!8;io\$$$$'8=3xX8;io\8>S,T8;io\8?r5P8;io\8A<>L8;io\8B[GH8;io\8D%PD8;io\8EDY@8;io\8Fcb:8;io\z8=3xX7_[,H8=3xX7m>0s8=3xX7uNfZ8=3xX8%v5I8=3xX8+HY88=3xX8.1k08=3xX80p((8=3xX83Y9u8=3xX86BKm8=3xX89+]d8=3xX8:Jf`8=3xX8;io\!8=3xX$$$$'8>S,T8=3xX8?r5P8=3xX8A<>L8=3xX8B[GH8=3xX8D%PD8=3xX8EDY@8=3xX8Fcb:8=3xXz8>S,T7_[,H8>S,T7m>0s8>S,T7uNfZ8>S,T8%v5I8>S,T8+HY88>S,T8.1k08>S,T80p((8>S,T83Y9u8>S,T86BKm8>S,T89+]d8>S,T8:Jf`8>S,T8;io\8>S,T8=3xX!8>S,T$$$$'8?r5P8>S,T8A<>L8>S,T8B[GH8>S,T8D%PD8>S,T8EDY@8>S,T8Fcb:8>S,Tz8?r5P7_[,H8?r5P7m>0s8?r5P7uNfZ8?r5P8%v5I8?r5P8+HY88?r5P8.1k08?r5P80p((8?r5P83Y9u8?r5P86BKm8?r5P89+]d8?r5P8:Jf`8?r5P8;io\8?r5P8=3xX8?r5P8>S,T!8?r5P$$$$'8A<>L8?r5P8B[GH8?r5P8D%PD8?r5P8EDY@8?r5P8Fcb:8?r5Pz8A<>L7_[,H8A<>L7m>0s8A<>L7uNfZ8A<>L8%v5I8A<>L8+HY88A<>L8.1k08A<>L80p((8A<>L83Y9u8A<>L86BKm8A<>L89+]d8A<>L8:Jf`8A<>L8;io\8A<>L8=3xX8A<>L8>S,T8A<>L8?r5P!8A<>L$$$$'8B[GH8A<>L8D%PD8A<>L8EDY@8A<>L8Fcb:8A<>Lz8B[GH7_[,H8B[GH7m>0s8B[GH7uNfZ8B[GH8%v5I8B[GH8+HY88B[GH8.1k08B[GH80p((8B[GH83Y9u8B[GH86BKm8B[GH89+]d8B[GH8:Jf`8B[GH8;io\8B[GH8=3xX8B[GH8>S,T8B[GH8?r5P8B[GH8A<>L!8B[GH$$$$'8D%PD8B[GH8EDY@8B[GH8Fcb:8B[GHz8D%PD7_[,H8D%PD7m>0s8D%PD7uNfZ8D%PD8%v5I8D%PD8+HY88D%PD8.1k08D%PD80p((8D%PD83Y9u8D%PD86BKm8D%PD89+]d8D%PD8:Jf`8D%PD8;io\8D%PD8=3xX8D%PD8>S,T8D%PD8?r5P8D%PD8A<>L8D%PD8B[GH!8D%PD$$$$'8EDY@8D%PD8Fcb:8D%PDz8EDY@7_[,H8EDY@7m>0s8EDY@7uNfZ8EDY@8%v5I8EDY@8+HY88EDY@8.1k08EDY@80p((8EDY@83Y9u8EDY@86BKm8EDY@89+]d8EDY@8:Jf`8EDY@8;io\8EDY@8=3xX8EDY@8>S,T8EDY@8?r5P8EDY@8A<>L8EDY@8B[GH8EDY@8D%PD!8EDY@$$$$'8Fcb:8EDY@7Qx'rz7gkb/z7reTbz7x7xRz8(_GAz8,gb4z8/Pt,z82:0xz84xBpz87aThz89eb6z8;/k2z8<Nt.z8=n(*z8?81%z8@W9vz8AvBrz8C@Knz8D_Tjz8F)]ez7Qx'ry7gkb/y7reTby7x7xRy8(_GAy8,gb4y8/Pt,y82:0xy84xBpy87aThy89eb6y8;/k2y8<Nt.y8=n(*y8?81%y8@W9vy8AvBry8C@Kny8D_Tjy8F)]ey
+ smoothing on
+ disp_padding 0
+ disp_height 1
+ disp_zero_value 0
+ disp_autobump off
+ autobump_visibility 1
+ step_size 0
+ volume_padding 0
+ declare dcc_name constant STRING
+ dcc_name "pSphereShape1"
+ declare maya_full_name constant STRING
+ maya_full_name "|pSphere1|pSphereShape1"
+}
+
+standard_surface
+{
+ name test/aiStandardSurface1
+ declare dcc_name constant STRING
+ dcc_name "aiStandardSurface1"
+}
+

--- a/testsuite/test_1457/data/scene.ass
+++ b/testsuite/test_1457/data/scene.ass
@@ -146,7 +146,12 @@ z!7_[,H$$$$'7m>0s7_[,H7uNfZ7_[,H8%v5I7_[,H8+HY87_[,H8.1k07_[,H80p((7_[,H83Y9u7_[
 standard_surface
 {
  name test/aiStandardSurface1
+ base test/my_noise
  declare dcc_name constant STRING
  dcc_name "aiStandardSurface1"
 }
 
+noise
+{
+	name test/my_noise
+}

--- a/testsuite/test_1457/data/scene.ass
+++ b/testsuite/test_1457/data/scene.ass
@@ -16,13 +16,10 @@ options
  xres 960
  yres 540
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "test/persp/perspShape"
- color_manager "test/defaultColorMgtGlobals"
- meters_per_unit 0.00999999978
+ meters_per_unit 0.01
  frame 1
- procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8
@@ -42,20 +39,12 @@ gaussian_filter
 driver_exr
 {
  name test/defaultArnoldDriver/driver_exr.RGBA
- filename "C:/Users/blaines.ADS/Documents/maya/projects/default/images/sphere.exr"
+ filename "sphere.exr"
  color_space ""
  declare dcc_name constant STRING
  dcc_name "defaultArnoldDriver"
 }
 
-color_manager_ocio
-{
- name test/defaultColorMgtGlobals
- config "C:/Program Files/Autodesk/Maya2024/resources/OCIO-configs/Maya2022-default/config.ocio"
- color_space_linear "ACEScg"
- declare dcc_name constant STRING
- dcc_name "defaultColorMgtGlobals"
-}
 
 persp_camera
 {

--- a/testsuite/test_1457/data/test.cpp
+++ b/testsuite/test_1457/data/test.cpp
@@ -1,0 +1,35 @@
+#include <ai.h>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+int main(int argc, char **argv)
+{
+    AiBegin(); 
+    AiMsgSetConsoleFlags(nullptr, AI_LOG_ALL);
+    AtParamValueMap* params = AiParamValueMap();
+    AiSceneLoad(nullptr, "scene.ass", nullptr);
+    AiSceneWrite(nullptr, "scene.usda", params);
+    AiParamValueMapDestroy(params);
+    AiEnd();
+
+    AiBegin();
+    AiSceneLoad(nullptr, "scene.usda", nullptr);
+
+    const static AtString shaderName("/test/aiStandardSurface1/aiStandardSurface1");
+    AtNode *shader = AiNodeLookUpByName(nullptr, shaderName);
+    bool success = (shader != nullptr);
+    AiEnd();
+
+    return (success) ? 0 : 1;
+
+}
+
+
+
+
+
+
+

--- a/testsuite/test_1457/data/test.cpp
+++ b/testsuite/test_1457/data/test.cpp
@@ -20,11 +20,12 @@ int main(int argc, char **argv)
 
     const static AtString shaderName("/test/aiStandardSurface1/aiStandardSurface1");
     AtNode *shader = AiNodeLookUpByName(nullptr, shaderName);
-    bool success = (shader != nullptr);
+    const static AtString noiseName("/test/aiStandardSurface1/my_noise");
+    AtNode *noise = AiNodeLookUpByName(nullptr, noiseName);
+    bool success = (shader != nullptr && noise != nullptr);
     AiEnd();
 
     return (success) ? 0 : 1;
-
 }
 
 

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -1158,7 +1158,15 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
     TfToken arnoldContext("arnold");
     if (shader) {
         // write the surface shader under the material's scope
+        size_t npos = shaderName.rfind('/');
+        const char *prevName = AiNodeGetName(shader);
+        if (npos != std::string::npos) {
+            std::string nodeLastName = shaderName.substr(npos);
+            AiNodeSetStr(shader, str::name, AtString(nodeLastName.c_str()));
+        }
+
         writer.WritePrimitive(shader); 
+        
         UsdShadeOutput surfaceOutput = mat.CreateSurfaceOutput(arnoldContext);
         // retrieve the new shader name (with the material scope applied)
         shaderName = UsdArnoldPrimWriter::GetArnoldNodeName(shader, writer);
@@ -1166,6 +1174,9 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
             // Connect the surface shader output to the material
             std::string surfaceTargetName = shaderName + std::string(".outputs:surface");
             surfaceOutput.ConnectToSource(SdfPath(surfaceTargetName));
+        }
+        if (npos != std::string::npos) {
+            AiNodeSetStr(shader, str::name, AtString(prevName));
         }
     }
     if (displacement) {

--- a/translator/writer/prim_writer.cpp
+++ b/translator/writer/prim_writer.cpp
@@ -1157,7 +1157,9 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
 
     TfToken arnoldContext("arnold");
     if (shader) {
-        // write the surface shader under the material's scope
+        // Write the surface shader under the material's scope.
+        // Here we only want to consider the last name in the prim 
+        // hierarchy, so we're stripping the scope here
         size_t npos = shaderName.rfind('/');
         const char *prevName = AiNodeGetName(shader);
         if (npos != std::string::npos) {
@@ -1176,6 +1178,7 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
             surfaceOutput.ConnectToSource(SdfPath(surfaceTargetName));
         }
         if (npos != std::string::npos) {
+            // eventually restore the previous arnold node name
             AiNodeSetStr(shader, str::name, AtString(prevName));
         }
     }

--- a/translator/writer/writer.cpp
+++ b/translator/writer/writer.cpp
@@ -204,6 +204,8 @@ void UsdArnoldWriter::WritePrimitive(const AtNode *node)
     // Note that we're storing the name of the arnold node, which might be slightly
     // different from the USD prim name, since UsdArnoldPrimWriter::GetArnoldNodeName
     // replaces some forbidden characters by underscores.
+    // Note that we don't really need to take into account the "strip hierarchy" here
+    // since we're testing the arnold node name    
     if (!nodeName.empty()) {
         if (IsNodeExported(nodeName))
             return;

--- a/translator/writer/writer.h
+++ b/translator/writer/writer.h
@@ -90,6 +90,16 @@ public:
         }
         
     }
+    const std::string &GetStripHierarchy() const {return _stripHierarchy;}
+    void SetStripHierarchy(const std::string &s) {
+        _stripHierarchy = s;
+        if (!_stripHierarchy.empty() && _stripHierarchy.back() == '/') {
+            _stripHierarchy = 
+                _stripHierarchy.substr(0, _stripHierarchy.length() - 1);            
+        }
+        
+    }
+    
     const std::string &GetDefaultPrim() const {return _defaultPrim;}
     void SetDefaultPrim(const std::string &defaultPrim) {_defaultPrim = defaultPrim;}
 
@@ -191,6 +201,7 @@ private:
     std::unordered_set<std::string> _exportedNodes; // List of node names that were exported (including material scope)
     std::unordered_set<const AtNode *> _exportedShaders; // list of shader nodes that were exported
     std::string _scope;                // scope in which the primitives must be written
+    std::string _stripHierarchy;       // When writing out a primitive, strip a given hierarchy from the arnold node name
     bool _allAttributes;               // write all attributes to usd prims, even if they're left to default
     UsdTimeCode _time;                 // current time required by client code
     std::vector<float> _authoredFrames;// list of frames that were previously authored in this usd stage


### PR DESCRIPTION
**Changes proposed in this pull request**
When we write a shader primitive, we force it to be under the hierarchy of the material it's assigned to.
But because of that, when the whole USD scene is exported under a given scope, then we will find the scope twice under the shader.
This PR strips this scope before writing the usd prim, so that we get the expected scene hierarchy

**Issues fixed in this pull request**
Fixes #1457 
