### PR TITLE
Correct motion blur with interframe geometry samples

### DIFF
--- a/render_delegate/utils.cpp
+++ b/render_delegate/utils.cpp
@@ -1410,9 +1410,13 @@ size_t HdArnoldSetPositionFromPrimvar(
     }
     if (!varyingTopology) {
         auto* arr = AiArrayAllocate(v0.size(), xf.count, AI_TYPE_VECTOR);
-        for (size_t index = 0; index < xf.count; index++)
-            AiArraySetKey(arr, index, xf.values[index].data());
-        
+        for (size_t index = 0; index < xf.count; index++) {
+            auto t = xf.times[0];
+            if (xf.count > 1)
+                t += index * (xf.times[xf.count-1] - xf.times[0]) / (static_cast<float>(xf.count)-1.f);
+            const auto data = xf.Resample(t);
+            AiArraySetKey(arr, index, data.data());
+        }  
         AiNodeSetArray(node, paramName, arr);
         return xf.count;
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
- The function sceneDelegate->SamplePrimvar returns the geometry samples found inside the shutter range plus the samples at the shutter bounds, they are directly passed to arnold. Arnold needs equally spaced samples and this PR add code to resample the keys making sure they are equally spaced.

**Issues fixed in this pull request**
Fixes #1476 
