### PR TITLE
Ensure we don't map/unmap empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - [usd#1477](https://github.com/Autodesk/arnold-usd/issues/1477) - Fix the motion blur with interframe geometry samples in the render delegate
 - [usd#1477](https://github.com/Autodesk/arnold-usd/issues/1477) - A a note in the README for the flickering issue with instances which can be fixed with the `USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY` environment variable. 
 - [usd#1426](https://github.com/Autodesk/arnold-usd/issues/1426) - Skinned transforms are now correctly used on the skinned meshes.
+- [usd#1502](https://github.com/Autodesk/arnold-usd/issues/1502) - Render delegate crashes with empty arrays.
+
 
 ## [7.0.0.1] - 2021-11-24
 

--- a/render_delegate/basis_curves.cpp
+++ b/render_delegate/basis_curves.cpp
@@ -116,11 +116,13 @@ void HdArnoldBasisCurves::Sync(
         }
         const auto numVertexCounts = vertexCounts.size();
         auto* numPointsArray = AiArrayAllocate(numVertexCounts, 1, AI_TYPE_UINT);
-        auto* numPoints = static_cast<uint32_t*>(AiArrayMap(numPointsArray));
-        std::transform(vertexCounts.cbegin(), vertexCounts.cend(), numPoints, [](const int i) -> uint32_t {
-            return static_cast<uint32_t>(i);
-        });
-        AiArrayUnmap(numPointsArray);
+        if (numVertexCounts > 0) {
+            auto* numPoints = static_cast<uint32_t*>(AiArrayMap(numPointsArray));
+            std::transform(vertexCounts.cbegin(), vertexCounts.cend(), numPoints, [](const int i) -> uint32_t {
+                return static_cast<uint32_t>(i);
+            });
+            AiArrayUnmap(numPointsArray);
+        }
         AiNodeSetArray(GetArnoldNode(), str::num_points, numPointsArray);
     }
 
@@ -198,12 +200,14 @@ void HdArnoldBasisCurves::Sync(
                     } else if (desc.value.IsHolding<VtVec3fArray>()) {
                         const auto& v = desc.value.UncheckedGet<VtVec3fArray>();
                         auto* arr = AiArrayAllocate(v.size(), 1, AI_TYPE_VECTOR2);
-                        std::transform(
-                            v.begin(), v.end(), static_cast<GfVec2f*>(AiArrayMap(arr)),
-                            [](const GfVec3f& in) -> GfVec2f {
-                                return {in[0], in[1]};
-                            });
-                        AiArrayUnmap(arr);
+                        if (!v.empty()) {
+                            std::transform(
+                                v.begin(), v.end(), static_cast<GfVec2f*>(AiArrayMap(arr)),
+                                [](const GfVec3f& in) -> GfVec2f {
+                                    return {in[0], in[1]};
+                                });
+                            AiArrayUnmap(arr);
+                        }
                         AiNodeSetArray(GetArnoldNode(), str::uvs, arr);
                     } else {
                         // If it's an unsupported type, just set it as user data.


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR ensures that we don't call AiArrayMap / AiArrayUnmap with empty arrays, which can happen sometimes when primvars are empty arrays.


**Issues fixed in this pull request**
Fixes #1502 
