### PR TITLE
Support relative paths for python / boost / tbb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [usd#1463](https://github.com/Autodesk/arnold-usd/issues/1463) - Fix Windows builds with CMake
 - [usd#1471](https://github.com/Autodesk/arnold-usd/issues/1471) - Support relative paths for Arnold and USD Sdk
 - [usd#1466](https://github.com/Autodesk/arnold-usd/issues/1466) - Allow to run the testsuite without any build of the procedural
+- [usd#1508](https://github.com/Autodesk/arnold-usd/issues/1508) - Support relative paths for python / boost / tbb
 
 ### Bugfixes
 - [usd#1485](https://github.com/Autodesk/arnold-usd/issues/1485) - MaterialX shader nodes should have "auto" colorspace by default 

--- a/SConstruct
+++ b/SConstruct
@@ -147,8 +147,8 @@ if IS_DARWIN:
 env['ARNOLD_ADP_DISABLE'] = "1"
 os.environ['ARNOLD_ADP_DISABLE'] = '1'
 
-def get_optional_env_var(env_name):
-    return env.subst(env[env_name]) if env_name in env else None
+def get_optional_env_path(env_name):
+    return os.path.abspath(env.subst(env[env_name])) if env_name in env else None
 
 USD_BUILD_MODE        = env['USD_BUILD_MODE']
 
@@ -214,12 +214,12 @@ env['USD_BIN'] = USD_BIN
 env['PREFIX_RENDER_DELEGATE'] = PREFIX_RENDER_DELEGATE
 
 # these could be supplied by linux / osx
-BOOST_INCLUDE = get_optional_env_var('BOOST_INCLUDE')
-BOOST_LIB = get_optional_env_var('BOOST_LIB')
-PYTHON_INCLUDE = get_optional_env_var('PYTHON_INCLUDE')
-PYTHON_LIB = get_optional_env_var('PYTHON_LIB')
-TBB_INCLUDE = get_optional_env_var('TBB_INCLUDE')
-TBB_LIB = get_optional_env_var('TBB_LIB')
+BOOST_INCLUDE = get_optional_env_path('BOOST_INCLUDE')
+BOOST_LIB = get_optional_env_path('BOOST_LIB')
+PYTHON_INCLUDE = get_optional_env_path('PYTHON_INCLUDE')
+PYTHON_LIB = get_optional_env_path('PYTHON_LIB')
+TBB_INCLUDE = get_optional_env_path('TBB_INCLUDE')
+TBB_LIB = get_optional_env_path('TBB_LIB')
 if env['ENABLE_UNIT_TESTS']:
     GOOGLETEST_INCLUDE = env.subst(env['GOOGLETEST_INCLUDE'])
     GOOGLETEST_LIB = env.subst(env['GOOGLETEST_LIB'])


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we convert the python / boost / tbb paths to be absolute paths in the Sconstruct

**Issues fixed in this pull request**
Fixes #1508
