### PR TITLE
Remove deprecated ENABLE_MATERIALX build variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [usd#1471](https://github.com/Autodesk/arnold-usd/issues/1471) - Support relative paths for Arnold and USD Sdk
 - [usd#1466](https://github.com/Autodesk/arnold-usd/issues/1466) - Allow to run the testsuite without any build of the procedural
 - [usd#1508](https://github.com/Autodesk/arnold-usd/issues/1508) - Support relative paths for python / boost / tbb
+- [usd#1512](https://github.com/Autodesk/arnold-usd/issues/1512) - Remove deprecated ENABLE_MATERIALX build variable
 
 ### Bugfixes
 - [usd#1485](https://github.com/Autodesk/arnold-usd/issues/1485) - MaterialX shader nodes should have "auto" colorspace by default 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif ()
 endif ()
 
-if (ENABLE_MATERIALX)
-    add_compile_options(-DARNOLD_MATERIALX=1)
-endif ()
-
 # Common directory includes.
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/common")
 set(COMMON_SRC

--- a/SConstruct
+++ b/SConstruct
@@ -107,7 +107,6 @@ vars.AddVariables(
     BoolVariable('BUILD_DOCS', 'Whether or not to build the documentation.', True),
     BoolVariable('PROC_SCENE_FORMAT', 'Whether or not to build the procedural with a scene format plugin.', True),
     BoolVariable('DISABLE_CXX11_ABI', 'Disable the use of the CXX11 abi for gcc/clang', False),
-    BoolVariable('ENABLE_MATERIALX', 'Support reading MaterialX shaders', False),
     StringVariable('BOOST_LIB_NAME', 'Boost library name pattern', 'boost_%s'),
     StringVariable('TBB_LIB_NAME', 'TBB library name pattern', '%s'),
     StringVariable('USD_MONOLITHIC_LIBRARY', 'Name of the USD monolithic library', 'usd_ms'),
@@ -387,9 +386,6 @@ env.Append(LIBPATH = [p for p in [BOOST_LIB, PYTHON_LIB, TBB_LIB, GOOGLETEST_LIB
 
 env['ROOT_DIR'] = os.getcwd()
 
-if env['ENABLE_MATERIALX']:
-    env.Append(CPPDEFINES = Split('ARNOLD_MATERIALX'))
-    
 # including common headers
 env.Append(CPPPATH = [os.path.join(env['ROOT_DIR'], 'common')])
 env['COMMON_SRC'] = [os.path.join(env['ROOT_DIR'], 'common', src) for src in find_files_recursive(os.path.join(env['ROOT_DIR'], 'common'), ['.cpp'])]

--- a/cmake/utils/options.cmake
+++ b/cmake/utils/options.cmake
@@ -34,8 +34,6 @@ option(BUILD_TESTSUITE "Builds the testsuite" OFF)
 option(BUILD_UNIT_TESTS "Build the unit tests" OFF)
 option(BUILD_USE_PYTHON3 "Use python 3." OFF)
 
-option(ENABLE_MATERIALX "Support reading MaterialX shaders." OFF)
-
 set(PREFIX_PROCEDURAL "procedural" CACHE STRING "Directory to install the procedural under.")
 set(PREFIX_PLUGINS "plugin" CACHE STRING "Directory to install the plugins (Hydra and Ndr) under.")
 set(PREFIX_HEADERS "include" CACHE STRING "Directory to install the headers under.")

--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -650,11 +650,9 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNode(const HdMaterialNode& node, const Co
     const auto* nodeTypeStr = node.identifier.GetText();
     bool isMaterialx = false;
     const AtString nodeType(strncmp(nodeTypeStr, "arnold:", 7) == 0 ? nodeTypeStr + 7 : nodeTypeStr);
-#ifdef ARNOLD_MATERIALX
     if (node.identifier != str::t_ND_standard_surface_surfaceshader && strncmp(nodeTypeStr, "ND_", 3) == 0) {
         isMaterialx = true;
     }
-#endif
 
     TF_DEBUG(HDARNOLD_MATERIAL)
         .Msg("HdArnoldNodeGraph::ReadMaterial - node %s - type %s\n", node.path.GetText(), nodeType.c_str());
@@ -814,11 +812,8 @@ HdArnoldNodeGraph::NodeDataPtr HdArnoldNodeGraph::GetNode(const SdfPath& path, c
 
 AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const AtString &nodeName, AtParamValueMap *params)
 {
-    // Disable materialx support until it's included in the USD libs
-    // that are shipped with Arnold
-#ifdef ARNOLD_MATERIALX
-    
-//#if ARNOLD_VERSION_NUM < 70103
+    // MaterialX support in USD was added in Arnold 7.1.4
+#if ARNOLD_VERSION_NUM < 70104
 //    return nullptr;
     const char *nodeTypeChar = nodeType.c_str();
     if (nodeType == str::ND_standard_surface_surfaceshader) {
@@ -829,11 +824,7 @@ AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const At
         AtNode *node = AiNode(_renderDelegate->GetUniverse(), str::osl, nodeName);
         // Get the OSL description of this mtlx shader. Its attributes will be prefixed with 
         // "param_shader_"
-#if ARNOLD_VERSION_NUM > 70104
         AtString oslCode = AiMaterialxGetOslShaderCode(nodeType.c_str(), "shader", params);
-#else
-        AtString oslCode = AiMaterialxGetOslShaderCode(nodeType.c_str(), "shader");
-#endif
         // Set the OSL code. This will create a new AtNodeEntry with parameters
         // based on the osl code
         AiNodeSetStr(node, str::code, oslCode);

--- a/render_delegate/node_graph.cpp
+++ b/render_delegate/node_graph.cpp
@@ -813,7 +813,7 @@ HdArnoldNodeGraph::NodeDataPtr HdArnoldNodeGraph::GetNode(const SdfPath& path, c
 AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const AtString &nodeName, AtParamValueMap *params)
 {
     // MaterialX support in USD was added in Arnold 7.1.4
-#if ARNOLD_VERSION_NUM < 70104
+#if ARNOLD_VERSION_NUM >= 70104
 //    return nullptr;
     const char *nodeTypeChar = nodeType.c_str();
     if (nodeType == str::ND_standard_surface_surfaceshader) {
@@ -824,7 +824,12 @@ AtNode *HdArnoldNodeGraph::GetMaterialxShader(const AtString &nodeType, const At
         AtNode *node = AiNode(_renderDelegate->GetUniverse(), str::osl, nodeName);
         // Get the OSL description of this mtlx shader. Its attributes will be prefixed with 
         // "param_shader_"
+        // The params argument was added in Arnold 7.2.0.0
+#if ARNOLD_VERSION_NUM > 70104
         AtString oslCode = AiMaterialxGetOslShaderCode(nodeType.c_str(), "shader", params);
+#else
+        AtString oslCode = AiMaterialxGetOslShaderCode(nodeType.c_str(), "shader");
+#endif
         // Set the OSL code. This will create a new AtNodeEntry with parameters
         // based on the osl code
         AiNodeSetStr(node, str::code, oslCode);

--- a/translator/reader/read_shader.cpp
+++ b/translator/reader/read_shader.cpp
@@ -71,7 +71,7 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         return;
     }
 
-#ifdef ARNOLD_MATERIALX
+#if ARNOLD_VERSION_NUM > 70104
     // MaterialX shader representing standard surface. In this case we just want to create an arnold standard_surface
     // shader and translate it as is
     if (shaderId == "ND_standard_surface_surfaceshader") {
@@ -104,7 +104,6 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         // "param_shader_"
         UsdAttributeVector attributes = prim.GetAttributes();
 
-#if ARNOLD_VERSION_NUM > 70104
         AtParamValueMap * params = AiParamValueMap();
         for (const auto &attribute : attributes) {
             if(attribute.HasAuthoredConnections()) {
@@ -115,9 +114,6 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AtString oslCode = AiMaterialxGetOslShaderCode(shaderId.c_str(), "shader", params);
         AiParamValueMapDestroy(params);
         params = nullptr;
-#else
-        AtString oslCode = AiMaterialxGetOslShaderCode(shaderId.c_str(), "shader");
-#endif
         // Set the OSL code. This will create a new AtNodeEntry with parameters
         // based on the osl code
         AiNodeSetStr(node, str::code, oslCode);

--- a/translator/reader/read_shader.cpp
+++ b/translator/reader/read_shader.cpp
@@ -71,7 +71,7 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         return;
     }
 
-#if ARNOLD_VERSION_NUM > 70104
+#if ARNOLD_VERSION_NUM >= 70104
     // MaterialX shader representing standard surface. In this case we just want to create an arnold standard_surface
     // shader and translate it as is
     if (shaderId == "ND_standard_surface_surfaceshader") {
@@ -94,8 +94,6 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
     }   
 
     // Materialx shaders will start with "ND_" in USD
-    // We cannot read this for arnold versions up to 7.1.2.x, as the API to get OSL code didn't exist
-// #if ARNOLD_VERSION_NUM >= 70103
     if (strncmp(shaderId.c_str(), "ND_", 3) == 0) {
         // Create an OSL inline shader
         node = context.CreateArnoldNode("osl", nodeName.c_str());       
@@ -104,6 +102,8 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         // "param_shader_"
         UsdAttributeVector attributes = prim.GetAttributes();
 
+        // The "params" argument was added to AiMaterialxGetOslShader in 7.2.0.0
+#if ARNOLD_VERSION_NUM > 70104
         AtParamValueMap * params = AiParamValueMap();
         for (const auto &attribute : attributes) {
             if(attribute.HasAuthoredConnections()) {
@@ -114,6 +114,9 @@ void UsdArnoldReadShader::Read(const UsdPrim &prim, UsdArnoldReaderContext &cont
         AtString oslCode = AiMaterialxGetOslShaderCode(shaderId.c_str(), "shader", params);
         AiParamValueMapDestroy(params);
         params = nullptr;
+#else        
+        AtString oslCode = AiMaterialxGetOslShaderCode(shaderId.c_str(), "shader");
+#endif
         // Set the OSL code. This will create a new AtNodeEntry with parameters
         // based on the osl code
         AiNodeSetStr(node, str::code, oslCode);


### PR DESCRIPTION
We no longer need the ENABLE_MATERIALX build variable, since we can just check for arnold versions being >= 7.1.4.0.

Fixes #1512 
