### PR TITLE
Fix render delegate compile errors on Linux

### DIFF
--- a/render_delegate/render_delegate.cpp
+++ b/render_delegate/render_delegate.cpp
@@ -935,7 +935,7 @@ VtDictionary HdArnoldRenderDelegate::GetRenderStats() const
     const int height = AiNodeGetInt(_options, str::yres);
     constexpr std::size_t maxResChars{256};
     char resolutionBuffer[maxResChars];
-    std::snprintf(&resolutionBuffer[0], maxResChars, "%s %i x %i", renderStatus.c_str(), width, height);
+    snprintf(&resolutionBuffer[0], maxResChars, "%s %i x %i", renderStatus.c_str(), width, height);
     stats[_tokens->renderProgressAnnotation] = VtValue(resolutionBuffer);
 
     // If there are cryptomatte drivers, we look for the metadata that is stored in each of them.

--- a/render_delegate/render_param.cpp
+++ b/render_delegate/render_param.cpp
@@ -50,6 +50,7 @@ HdArnoldRenderParam::HdArnoldRenderParam(HdArnoldRenderDelegate* delegate) : _de
 #else
 HdArnoldRenderParam::HdArnoldRenderParam()
 #endif
+
 {
     _needsRestart.store(false, std::memory_order::memory_order_release);
     _aborted.store(false, std::memory_order::memory_order_release);
@@ -247,7 +248,9 @@ void HdArnoldRenderParam::WriteDebugScene() const
 
 double HdArnoldRenderParam::GetElapsedRenderTime() const
 {
-    const auto t0 = _renderStartTime.load();
+    _renderTimeMutex.lock();
+    const auto t0 = _renderStartTime;
+    _renderTimeMutex.unlock();
     const auto t1 = std::chrono::system_clock::now();
     const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
 

--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -42,8 +42,8 @@
 
 #include "hdarnold.h"
 
-#include <atomic>
 #include <chrono>
+#include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -151,7 +151,9 @@ public:
 private:
     inline void ResetStartTimer()
     {
-        _renderStartTime.store(std::chrono::system_clock::now(), std::memory_order::memory_order_release);
+        _renderTimeMutex.lock();
+        _renderStartTime = std::chrono::system_clock::now();
+        _renderTimeMutex.unlock();
     }
 
 #ifdef ARNOLD_MULTIPLE_RENDER_SESSIONS
@@ -165,7 +167,8 @@ private:
     /// Indicate if rendering has been paused.
     std::atomic<bool> _paused;
 
-    std::atomic<std::chrono::time_point<std::chrono::system_clock>> _renderStartTime;
+    std::chrono::time_point<std::chrono::system_clock> _renderStartTime;
+    mutable std::mutex _renderTimeMutex;
 
     unsigned int _msgLogCallback;
     std::string _logMsg;


### PR DESCRIPTION
**Changes proposed in this pull request**
- Replace std::atomic + chronos::time_point usage with a std::mutex, as time_point isn't guaranteed to be trivially copyable
- Fix compile errors on Linux/Mac

**Additional context**
Add any other context or screenshots about the pull request here.
