### PR TITLE
Declare filename attributes as assets in the schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [usd#1502](https://github.com/Autodesk/arnold-usd/issues/1502) - Render delegate crashes with empty arrays.
 - [usd#1522](https://github.com/Autodesk/arnold-usd/issues/1522) - Support UsdPrimvarReader_float2 shader returning the "st" variable
 - [usd#1530](https://github.com/Autodesk/arnold-usd/issues/1530) - Fix a crash when a user primvars has an empty array on a keyframe
+- [usd#1532](https://github.com/Autodesk/arnold-usd/issues/1532) - Schemas are not declaring asset parameters for filenames
 
 ## [7.0.0.1] - 2021-11-24
 


### PR DESCRIPTION
**Changes proposed in this pull request**
The filename attributes have been modified to be set as assets instead of strings. But this change had to be ported to the schemas

**Issues fixed in this pull request**
Fixes #1532 
