### PR TITLE
USD 1572 | Fix crash when restarting an interactive render

### DIFF
--- a/render_delegate/render_param.h
+++ b/render_delegate/render_param.h
@@ -135,9 +135,6 @@ public:
     /// Restart the AiMsg callback
     void RestartRenderMsgLog();
 
-    /// Used by the AiMsg callback to cache the render status
-    void CacheLogMessage(const char* msgString, int severity);
-
     /// Retrieve the last Arnold status message (threadsafe)
     ///
     /// @return render details, i.e. 'Rendering' or '[gpu] compiling shaders'
@@ -171,8 +168,6 @@ private:
     mutable std::mutex _renderTimeMutex;
 
     unsigned int _msgLogCallback;
-    std::string _logMsg;
-    mutable std::mutex _logMutex;
 
     /// Shutter range.
     GfVec2f _shutter = {0.0f, 0.0f};


### PR DESCRIPTION
**Changes proposed in this pull request**
- Now caching the Arnold render status in a global string (protected by a mutex), instead of in a variable owned by render_param.

**Issues fixed in this pull request**
Fixes [#1572](https://github.com/Autodesk/arnold-usd/issues/1572)

**Additional context**
Add any other context or screenshots about the pull request here.
