### PR TITLE
Update oldest test scenes for light attributes

### DIFF
--- a/testsuite/test_0003/data/sphere.usd
+++ b/testsuite/test_0003/data/sphere.usd
@@ -7,6 +7,6 @@ def Sphere "sphere"
 
 def DomeLight "dome"
 {
- float intensity=2
+ float inputs:intensity=2
  float primvars:arnold:camera=0.4
 }

--- a/testsuite/test_0004/data/sphere.usd
+++ b/testsuite/test_0004/data/sphere.usd
@@ -7,5 +7,5 @@ def Sphere "sphere"
 
 def DistantLight "distant"
 {
-float intensity=2
+float inputs:intensity=2
 }

--- a/testsuite/test_0005/data/sphere.usd
+++ b/testsuite/test_0005/data/sphere.usd
@@ -7,8 +7,8 @@ def Sphere "sphere"
 
 def DomeLight "dome"
 {
- float intensity=2
- asset texture:file=@ok.tx@
+ float inputs:intensity=2
+ asset inputs:texture:file=@ok.tx@
  float primvars:arnold:camera=0
 
 }

--- a/testsuite/test_0006/data/sphere.usd
+++ b/testsuite/test_0006/data/sphere.usd
@@ -7,8 +7,8 @@ def Sphere "sphere"
 
 def DiskLight "distant"
 {
- float intensity=2
- float radius = 5
+ float inputs:intensity=2
+ float inputs:radius = 5
  float3 xformOp:translate= (0,0, 5)
  uniform token[] xformOpOrder = ["xformOp:translate"]
 }

--- a/testsuite/test_0007/data/sphere.usd
+++ b/testsuite/test_0007/data/sphere.usd
@@ -7,9 +7,9 @@ def Sphere "sphere"
 
 def RectLight "distant"
 {
- float intensity=5
- float width = 1
- float height = 10
+ float inputs:intensity=5
+ float inputs:width = 1
+ float inputs:height = 10
  float3 xformOp:translate= (0,0, 5)
  uniform token[] xformOpOrder = ["xformOp:translate"]
 }

--- a/testsuite/test_0008/data/sphere.usd
+++ b/testsuite/test_0008/data/sphere.usd
@@ -7,10 +7,10 @@ def Sphere "sphere"
 
 def SphereLight "distant"
 {
- float intensity=50
- float exposure=3
- float radius = 5 
+ float inputs:intensity=50
+ float inputs:exposure=3
+ float inputs:radius = 5 
  float3 xformOp:translate= (0,0, 15)
- bool normalize=true
+ bool inputs:normalize=true
  uniform token[] xformOpOrder = ["xformOp:translate"]
 }

--- a/testsuite/test_0009/data/sphere.usd
+++ b/testsuite/test_0009/data/sphere.usd
@@ -7,10 +7,10 @@ def Sphere "sphere"
 
 def SphereLight "distant"
 {
- float exposure=3
- float intensity=15
- float radius = 5 
- int treatAsPoint=1
+ float inputs:exposure=3
+ float inputs:intensity=15
+ float inputs:radius = 5 
+ bool treatAsPoint=True
  float3 xformOp:translate= (0,0, 15)
  uniform token[] xformOpOrder = ["xformOp:translate"]
 }

--- a/testsuite/test_0009/data/test.ass
+++ b/testsuite/test_0009/data/test.ass
@@ -81,7 +81,7 @@ standard_surface
 set_parameter
 {
  name root_op
- selection "usd/*"
+ selection "usd/sphere"
  assignment "shader=\"myshader\""
 
 }

--- a/testsuite/test_0022/data/scene.usd
+++ b/testsuite/test_0022/data/scene.usd
@@ -7,7 +7,7 @@
 
 def DistantLight "distant"
 {
-float intensity=1
+float inputs:intensity=1
 float primvars:arnold:exposure=3
 float3 primvars:arnold:color=(0,1,0)
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
The procedural, even when built against the latest USD, still supports the "old" light format, where the "inputs:" namespace didn't exist. This want meant to be able to kick usd files exported from older versions of Solaris. But this is less important on the render delegate side, it's more tricky to do, and we will soon be able to drop support for the old format. 
So we won't be doing any fix in the code for now, we'll just fix the test scenes, so that they are based on the new format

**Issues fixed in this pull request**
Fixes #1543 
