### PR TITLE
Support Arnold RenderVars filters and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 - [usd#1538](https://github.com/Autodesk/arnold-usd/issues/1538) - Fix triplanar in USD Materialx
 - [usd#1588](https://github.com/Autodesk/arnold-usd/issues/1588) - Arnold schemas under a point instancer should be hidden
+- [usd#1595](https://github.com/Autodesk/arnold-usd/issues/1595) - Support Arnold RenderVar filters in Hydra 
 
 ## [7.2.2.1] - 2023-06-21
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Read the RenderVar arnold:format attribute and use it as the aov format if it is declared 
- Read the RenderVar arnold:filter and use the defined filter as the aov filter.

**Issues fixed in this pull request**
Fixes #1595
