### PR TITLE
Fix render delegate builds with older versions of Arnold

### DIFF
--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -268,13 +268,18 @@ double HdArnoldRenderParam::GetElapsedRenderTime() const
 
 void HdArnoldRenderParam::StartRenderMsgLog()
 {
+    // The "Status" logs mask was introduced in Arnold 7.1.3.0
+#if ARNOLD_VERSION_NUM >= 70103
     _msgLogCallback = AiMsgRegisterCallback(_MsgStatusCallback, AI_LOG_STATUS, nullptr);
+#endif
 }
 
 void HdArnoldRenderParam::StopRenderMsgLog()
 {
-    AiMsgDeregisterCallback(_msgLogCallback);
-    _msgLogCallback = 0;
+    if (_msgLogCallback != 0) {
+        AiMsgDeregisterCallback(_msgLogCallback);
+        _msgLogCallback = 0;
+    }
 }
 
 void HdArnoldRenderParam::RestartRenderMsgLog()

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -171,7 +171,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock> _renderStartTime;
     mutable std::mutex _renderTimeMutex;
 
-    unsigned int _msgLogCallback;
+    unsigned int _msgLogCallback = 0;
 
     /// Shutter range.
     GfVec2f _shutter = {0.0f, 0.0f};


### PR DESCRIPTION
**Changes proposed in this pull request**
Versions of Arnold which are older than 7.1.3.0 didn't have the AI_LOG_STATUS bit mask. This PR adds version checks to fix the compilation with such cuts

