### PR TITLE
Deprecate old typed schemas format

### DIFF
--- a/libs/common/parameters_utils.cpp
+++ b/libs/common/parameters_utils.cpp
@@ -379,13 +379,11 @@ inline void _SetRayFlag(AtNode* node, const std::string& paramName, const std::s
  *   Read all the arnold-specific attributes that were saved in this USD
  *primitive. Arnold attributes are prefixed with the namespace 'arnold:' We will
  *strip this prefix, look for the corresponding arnold parameter, and convert it
- *based on its type. The input attribute acceptEmptyScope is for backward compatibility,
- *in order to keep supporting usd files authored with previous versions of arnold-usd.
- * (before #583). It's meant to be removed
+ *based on its type. 
  **/
 void ReadArnoldParameters(
     const UsdPrim &prim, ArnoldAPIAdapter &context, AtNode *node, const TimeSettings &time,
-    const std::string &scope, bool acceptEmptyScope)
+    const std::string &scope)
 {    
     const AtNodeEntry *nodeEntry = AiNodeGetNodeEntry(node);
     if (nodeEntry == nullptr) {
@@ -434,6 +432,9 @@ void ReadArnoldParameters(
     for (size_t i = 0; i < attributeCount; ++i) {
         // The attribute can either come from the attributes list, or from the primvars list
         const UsdAttribute &attr = (readPrimvars) ? primvars[i].GetAttr() : attributes[i];
+        if (!attr.HasAuthoredValue() && !attr.HasAuthoredConnections())
+            continue;
+
         TfToken attrNamespace = attr.GetNamespace();
         std::string attrNamespaceStr = attrNamespace.GetString();
         std::string arnoldAttr = attr.GetBaseName().GetString();
@@ -462,9 +463,7 @@ void ReadArnoldParameters(
             if (arnoldAttr[0] == 'i' && (scope.empty() || namespaceIncludesScope)) {
                 _ReadArrayLink(prim, attr, time, context, node, scope);
             }
-            // this flag acceptEmptyScope is temporary and meant to be removed
-            if (!acceptEmptyScope || !attrNamespace.GetString().empty())
-                continue;
+            continue;
         }
         if (isOsl && arnoldAttr == "code")
             continue;
@@ -484,9 +483,7 @@ void ReadArnoldParameters(
             }
             continue;
         }
-        if (acceptEmptyScope && arnoldAttr == "xformOpOrder")
-            continue;
-
+        
         const AtParamEntry *paramEntry = AiNodeEntryLookUpParameter(nodeEntry, AtString(arnoldAttr.c_str()));
         if (paramEntry == nullptr) {
             // For custom procedurals, there will be an attribute node_entry that should be ignored.

--- a/libs/common/parameters_utils.h
+++ b/libs/common/parameters_utils.h
@@ -29,7 +29,7 @@ void ReadPrimvars(
 
 void ReadArnoldParameters(
         const UsdPrim &prim, ArnoldAPIAdapter &context, AtNode *node, const TimeSettings &time,
-        const std::string &scope = "arnold", bool acceptEmptyScope = false);
+        const std::string &scope = "arnold");
 
 void _ReadArrayLink(
         const UsdPrim &prim, const UsdAttribute &attr, const TimeSettings &time, 

--- a/libs/translator/reader/read_arnold_type.cpp
+++ b/libs/translator/reader/read_arnold_type.cpp
@@ -67,7 +67,7 @@ void UsdArnoldReadArnoldType::Read(const UsdPrim &prim, UsdArnoldReaderContext &
     	// the last argument is set to true in order to be backwards compatible
     	// and to keep supporting usd files authored with previous versions of USD
     	// (before #583). To be removed
-    	ReadArnoldParameters(prim, context, node, time, "arnold", true); 
+    	ReadArnoldParameters(prim, context, node, time, "arnold"); 
     }
     ReadPrimvars(prim, node, time, context);
 

--- a/libs/translator/reader/read_arnold_type.cpp
+++ b/libs/translator/reader/read_arnold_type.cpp
@@ -62,12 +62,9 @@ void UsdArnoldReadArnoldType::Read(const UsdPrim &prim, UsdArnoldReaderContext &
     // looking for an attribute namespace "inputs", otherwise this is just an
     // arnold typed schema and we don't want any namespace.
     if (objType == "Shader")
-    	ReadArnoldParameters(prim, context, node, time, "inputs");
+        ReadArnoldParameters(prim, context, node, time, "inputs");
     else {
-    	// the last argument is set to true in order to be backwards compatible
-    	// and to keep supporting usd files authored with previous versions of USD
-    	// (before #583). To be removed
-    	ReadArnoldParameters(prim, context, node, time, "arnold"); 
+        ReadArnoldParameters(prim, context, node, time, "arnold"); 
     }
     ReadPrimvars(prim, node, time, context);
 

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1547,7 +1547,6 @@ void UsdArnoldReadProceduralCustom::Read(const UsdPrim &prim, UsdArnoldReaderCon
     
     ReadPrimvars(prim, node, time, context);
     ReadMaterialBinding(prim, node, context, false); // don't assign the default shader
-    // The attributes will be read here, without an arnold scope, as in UsdArnoldReadArnoldType
     ReadArnoldParameters(prim, context, node, time, "arnold");
 
     // Check the prim visibility, set the AtNode visibility to 0 if it's hidden

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1548,7 +1548,7 @@ void UsdArnoldReadProceduralCustom::Read(const UsdPrim &prim, UsdArnoldReaderCon
     ReadPrimvars(prim, node, time, context);
     ReadMaterialBinding(prim, node, context, false); // don't assign the default shader
     // The attributes will be read here, without an arnold scope, as in UsdArnoldReadArnoldType
-    ReadArnoldParameters(prim, context, node, time, "arnold", true);
+    ReadArnoldParameters(prim, context, node, time, "arnold");
 
     // Check the prim visibility, set the AtNode visibility to 0 if it's hidden
     if (!context.GetPrimVisibility(prim, time.frame)) {
@@ -1623,7 +1623,7 @@ void UsdArnoldReadProcViewport::Read(const UsdPrim &prim, UsdArnoldReaderContext
         setMatrixParam = (!AiM4IsIdentity(AiArrayGetMtx(matrices, 0)));
 
     // ensure we read all the parameters from the procedural
-    ReadArnoldParameters(prim, context, proc, time, "arnold", true);
+    ReadArnoldParameters(prim, context, proc, time, "arnold");
     ReadPrimvars(prim, proc, time, context);
 
     AtParamValueMap *params =

--- a/libs/translator/writer/write_arnold_type.cpp
+++ b/libs/translator/writer/write_arnold_type.cpp
@@ -139,7 +139,8 @@ void UsdArnoldWriteGinstance::_ProcessInstanceAttribute(
         return;
 
     if (writeValue) {
-        UsdAttribute attr = prim.CreateAttribute(TfToken(attrName), usdType, false);
+        std::string namespacedAttr = std::string("arnold:") + std::string(attrName);
+        UsdAttribute attr = prim.CreateAttribute(TfToken(namespacedAttr.c_str()), usdType, false);
         if (attrType == AI_TYPE_BOOLEAN)
             writer.SetAttribute(attr, AiNodeGetBool(node, AtString(attrName)));
         else if (attrType == AI_TYPE_BYTE)

--- a/testsuite/test_0015/data/scene.usda
+++ b/testsuite/test_0015/data/scene.usda
@@ -68,9 +68,9 @@ def "World"
 
     def ArnoldSkydomeLight "light"
     {
-        float camera = 0.5
-        color3f color = (1, 0.4, 1)
-        float intensity = 1
+        float arnold:camera = 0.5
+        color3f arnold:color = (1, 0.4, 1)
+        float arnold:intensity = 1
     }
 }
 

--- a/testsuite/test_0034/data/scene.usda
+++ b/testsuite/test_0034/data/scene.usda
@@ -14,10 +14,8 @@ def ArnoldOptions "options"
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
     bool texture_automip = 0
     bool texture_per_file_stats = 1
-    string texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
     int threads = 40
     int xres = 960
     int yres = 540

--- a/testsuite/test_0043/data/proc.usd
+++ b/testsuite/test_0043/data/proc.usd
@@ -2,12 +2,12 @@
 
 def ArnoldUsd "usdProc"
 {
-    string filename = "sphere.usd"
-    matrix4d[] matrix.timeSamples = {
+    string arnold:filename = "sphere.usd"
+    matrix4d[] arnold:matrix.timeSamples = {
         -0.5: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-0.5, 0, 0, 1) )],
         0: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )],
         0.5: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0.5, 0, 0, 1) )],
     }
-    float motion_start = -0.5
-    float motion_end = 0.5
+    float arnold:motion_start = -0.5
+    float arnold:motion_end = 0.5
 }

--- a/testsuite/test_0050/data/test.usda
+++ b/testsuite/test_0050/data/test.usda
@@ -2,24 +2,23 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -28,33 +27,33 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def "persp"
 {
     def ArnoldPerspCamera "perspShape"
     {
-        float[] aperture_size = [0]
-        float far_clip = 10000
-        float[] focus_distance = [1]
-        float[] fov = [54.432224]
-        float2[] lens_shift = [(0, 0)]
-        float2[] lens_tilt_angle = [(0, 0)]
-        vector3f[] look_at = [(0, 0, -1)]
-        matrix4d[] matrix = [( (0.7071067690849304, 0, -0.7071067690849304, 0), (-0.33129456639289856, 0.8834522366523743, -0.33129456639289856, 0), (0.6246950626373291, 0.4685212969779968, 0.6246950626373291, 0), (30.483577728271484, 22.862686157226562, 30.483577728271484, 1) )]
-        float motion_end = 0
-        float near_clip = 0.1
-        vector3f[] position = [(0, 0, 0)]
+        float[] arnold:aperture_size = [0]
+        float arnold:far_clip = 10000
+        float[] arnold:focus_distance = [1]
+        float[] arnold:fov = [54.432224]
+        float2[] arnold:lens_shift = [(0, 0)]
+        float2[] arnold:lens_tilt_angle = [(0, 0)]
+        vector3f[] arnold:look_at = [(0, 0, -1)]
+        matrix4d[] arnold:matrix = [( (0.7071067690849304, 0, -0.7071067690849304, 0), (-0.33129456639289856, 0.8834522366523743, -0.33129456639289856, 0), (0.6246950626373291, 0.4685212969779968, 0.6246950626373291, 0), (30.483577728271484, 22.862686157226562, 30.483577728271484, 1) )]
+        float arnold:motion_end = 0
+        float arnold:near_clip = 0.1
+        vector3f[] arnold:position = [(0, 0, 0)]
         string primvars:dcc_name = "perspShape" (
             elementSize = 1
             interpolation = "constant"
         )
-        float2[] screen_window_max = [(1, 1)]
-        float2[] screen_window_min = [(-1, -1)]
-        vector3f[] up = [(0, 1, 0)]
-        color4f uv_remap = (0, 0, 0, 1)
+        float2[] arnold:screen_window_max = [(1, 1)]
+        float2[] arnold:screen_window_min = [(-1, -1)]
+        vector3f[] arnold:up = [(0, 1, 0)]
+        color4f arnold:uv_remap = (0, 0, 0, 1)
     }
 }
 

--- a/testsuite/test_0088/data/test.ass
+++ b/testsuite/test_0088/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33300006
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/Users/blaines/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8
@@ -35,7 +33,7 @@ gaussian_filter
 driver_tiff
 {
  name defaultArnoldDriver@driver_tiff.RGBA
- filename "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+ filename "testrender.tif"
  color_space ""
 }
 

--- a/testsuite/test_0101/data/test.ass
+++ b/testsuite/test_0101/data/test.ass
@@ -14,11 +14,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/Users/blaines/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0107/data/test.ass
+++ b/testsuite/test_0107/data/test.ass
@@ -18,11 +18,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/Users/blaines/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0116/data/test.ass
+++ b/testsuite/test_0116/data/test.ass
@@ -238,7 +238,7 @@ toon
 driver_tiff
 {
  name defaultArnoldDriver@driver_tiff.contour
- filename "C:/Users/blaines/Documents/maya/projects/default/images/testrender_contour.tif"
+ filename "testrender_contour.tif"
  compression "lzw"
  format "int8"
  tiled off
@@ -253,7 +253,7 @@ driver_tiff
 driver_tiff
 {
  name defaultArnoldDriver@driver_tiff.highlight
- filename "C:/Users/blaines/Documents/maya/projects/default/images/testrender_highlight.tif"
+ filename "testrender_highlight.tif"
  compression "lzw"
  format "int8"
  tiled off
@@ -268,7 +268,7 @@ driver_tiff
 driver_tiff
 {
  name defaultArnoldDriver@driver_tiff.rim_light
- filename "C:/Users/blaines/Documents/maya/projects/default/images/testrender_rim_light.tif"
+ filename "testrender_rim_light.tif"
  compression "lzw"
  format "int8"
  tiled off

--- a/testsuite/test_0132/data/test.usda
+++ b/testsuite/test_0132/data/test.usda
@@ -15,10 +15,8 @@ def ArnoldOptions "options"
         elementSize = 1
         interpolation = "constant"
     )
-    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
     bool arnold:texture_automip = 0
     bool arnold:texture_per_file_stats = 1
-    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
     int arnold:threads = 40
     int arnold:xres = 160
     int arnold:yres = 120
@@ -32,7 +30,7 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
     string arnold:color_space = ""
-    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:filename = "testrender.tif"
     string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 

--- a/testsuite/test_0132/data/test.usda
+++ b/testsuite/test_0132/data/test.usda
@@ -2,38 +2,38 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 {
-    string name = "defaultArnoldFilter@gaussian_filter"
+    string arnold:name = "defaultArnoldFilter@gaussian_filter"
 }
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
-    string name = "defaultArnoldDriver@driver_tiff.RGBA"
+    string arnold:color_space = ""
+    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 
 def "persp"

--- a/testsuite/test_0139/data/test.usda
+++ b/testsuite/test_0139/data/test.usda
@@ -11,24 +11,22 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -37,8 +35,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def Xform "geo" (

--- a/testsuite/test_0140/data/test.usda
+++ b/testsuite/test_0140/data/test.usda
@@ -11,22 +11,22 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -35,8 +35,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def Xform "geo" (

--- a/testsuite/test_0145/data/test.usda
+++ b/testsuite/test_0145/data/test.usda
@@ -3,24 +3,22 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "D:/arnold/mtoa/build/windows_x86_64/20200000/msvc_opt/testsuite/test_0000/"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -29,8 +27,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def "persp"

--- a/testsuite/test_0151/data/test.usda
+++ b/testsuite/test_0151/data/test.usda
@@ -2,33 +2,31 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter/gaussian_filter defaultArnoldDriver/driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter/gaussian_filter defaultArnoldDriver/driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def "defaultArnoldFilter"
 {
     def ArnoldGaussianFilter "gaussian_filter"
     {
-        string name = "defaultArnoldFilter/gaussian_filter"
+        string arnold:name = "defaultArnoldFilter/gaussian_filter"
     }
 }
 
@@ -36,9 +34,9 @@ def "defaultArnoldDriver"
 {
     def ArnoldDriverTiff "driver_tiff_RGBA"
     {
-        string color_space = "sRGB"
-        string filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
-        string name = "defaultArnoldDriver/driver_tiff.RGBA"
+        string arnold:color_space = "sRGB"
+        string arnold:filename = "testrender.tif"
+        string arnold:name = "defaultArnoldDriver/driver_tiff.RGBA"
     }
 }
 

--- a/testsuite/test_0161/data/nested_proc.usda
+++ b/testsuite/test_0161/data/nested_proc.usda
@@ -4,8 +4,8 @@ def "transform1"
 {
     def ArnoldUsd "correctStandinTransform"
     {
-        string filename = "cube.usda"
-        matrix4d[] matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
+        string arnold:filename = "cube.usda"
+        matrix4d[] arnold:matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
         string primvars:dcc_name = "correctStandinTransform" (
             elementSize = 1
             interpolation = "constant"

--- a/testsuite/test_0162/data/nested_proc.usda
+++ b/testsuite/test_0162/data/nested_proc.usda
@@ -4,8 +4,8 @@ def "transform1"
 {
     def ArnoldUsd "correctStandinTransform"
     {
-        string filename = "sphere.usda"
-        matrix4d[] matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
+        string arnold:filename = "sphere.usda"
+        matrix4d[] arnold:matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
         string primvars:dcc_name = "correctStandinTransform" (
             elementSize = 1
             interpolation = "constant"

--- a/testsuite/test_0170/data/test.usda
+++ b/testsuite/test_0170/data/test.usda
@@ -15,10 +15,8 @@ def ArnoldOptions "options"
         elementSize = 1
         interpolation = "constant"
     )
-    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
     bool arnold:texture_automip = 0
     bool arnold:texture_per_file_stats = 1
-    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
     int arnold:threads = 40
     int arnold:xres = 160
     int arnold:yres = 120
@@ -32,7 +30,7 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
     string arnold:color_space = ""
-    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:filename = "testrender.tif"
     string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 

--- a/testsuite/test_0170/data/test.usda
+++ b/testsuite/test_0170/data/test.usda
@@ -2,38 +2,38 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 {
-    string name = "defaultArnoldFilter@gaussian_filter"
+    string arnold:name = "defaultArnoldFilter@gaussian_filter"
 }
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
-    string name = "defaultArnoldDriver@driver_tiff.RGBA"
+    string arnold:color_space = ""
+    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 
 def "persp"

--- a/testsuite/test_0173/data/test.usda
+++ b/testsuite/test_0173/data/test.usda
@@ -20,7 +20,7 @@ def Xform "testgeometry_rubbertoy1" (
 
     def ArnoldSphere "sphere_0"
     {
-        float[] radius = [1]
+        float[] arnold:radius = [1]
         rel material:binding = </materials/materiallibrary1>
     }
 }

--- a/testsuite/test_0186/data/test.usda
+++ b/testsuite/test_0186/data/test.usda
@@ -10,16 +10,16 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -28,8 +28,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def Xform "cameras"

--- a/testsuite/test_0194/data/test.usda
+++ b/testsuite/test_0194/data/test.usda
@@ -10,16 +10,16 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -28,8 +28,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def Xform "cameras"

--- a/testsuite/test_0196/data/test.usda
+++ b/testsuite/test_0196/data/test.usda
@@ -10,16 +10,16 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -28,8 +28,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 def Xform "cameras"

--- a/testsuite/test_0213/data/test.usda
+++ b/testsuite/test_0213/data/test.usda
@@ -11,16 +11,16 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    int xres = 160
-    int yres = 120
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -29,8 +29,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 

--- a/testsuite/test_0214/data/test.usda
+++ b/testsuite/test_0214/data/test.usda
@@ -12,16 +12,16 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/cameras/camera1"
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string[] outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    int xres = 160
-    int yres = 120
+    int arnold:AA_samples = 3
+    string arnold:camera = "/cameras/camera1"
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string[] arnold:outputs = ["RGBA RGBA /defaultArnoldFilter_gaussian_filter /defaultArnoldDriver_driver_tiff_RGBA"]
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
@@ -30,8 +30,8 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
 }
 
 

--- a/testsuite/test_0225/data/test.usda
+++ b/testsuite/test_0225/data/test.usda
@@ -5,38 +5,38 @@
 )
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    string procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    string texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 {
-    string name = "defaultArnoldFilter@gaussian_filter"
+    string arnold:name = "defaultArnoldFilter@gaussian_filter"
 }
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
-    string name = "defaultArnoldDriver@driver_tiff.RGBA"
+    string arnold:color_space = ""
+    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 
 def "persp"

--- a/testsuite/test_0225/data/test.usda
+++ b/testsuite/test_0225/data/test.usda
@@ -18,10 +18,8 @@ def ArnoldOptions "options"
         elementSize = 1
         interpolation = "constant"
     )
-    string arnold:procedural_searchpath = "C:/Users/blaines/Documents/maya/projects/default/"
     bool arnold:texture_automip = 0
     bool arnold:texture_per_file_stats = 1
-    string arnold:texture_searchpath = "C:/Users/blaines/Documents/maya/projects/default/sourceimages"
     int arnold:threads = 40
     int arnold:xres = 160
     int arnold:yres = 120
@@ -35,7 +33,7 @@ def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
     string arnold:color_space = ""
-    string arnold:filename = "C:/Users/blaines/Documents/maya/projects/default/images/testrender.tif"
+    string arnold:filename = "testrender.tif"
     string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 

--- a/testsuite/test_0242/data/test.usda
+++ b/testsuite/test_0242/data/test.usda
@@ -5,36 +5,36 @@
 )
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 {
-    string name = "defaultArnoldFilter@gaussian_filter"
+    string arnold:name = "defaultArnoldFilter@gaussian_filter"
 }
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
-    string name = "defaultArnoldDriver@driver_tiff.RGBA"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
+    string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 
 def "persp"

--- a/testsuite/test_1237/data/test.usda
+++ b/testsuite/test_1237/data/test.usda
@@ -2,36 +2,36 @@
 
 def ArnoldOptions "options"
 {
-    int AA_samples = 3
-    string camera = "/persp/perspShape"
-    float frame = 1
-    int GI_diffuse_depth = 1
-    int GI_specular_depth = 1
-    int GI_transmission_depth = 8
-    string name = "options"
-    string[] outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
-    float pixel_aspect_ratio = 1.3333333
+    int arnold:AA_samples = 3
+    string arnold:camera = "/persp/perspShape"
+    float arnold:frame = 1
+    int arnold:GI_diffuse_depth = 1
+    int arnold:GI_specular_depth = 1
+    int arnold:GI_transmission_depth = 8
+    string arnold:name = "options"
+    string[] arnold:outputs = ["RGBA RGBA defaultArnoldFilter@gaussian_filter defaultArnoldDriver@driver_tiff.RGBA"]
+    float arnold:pixel_aspect_ratio = 1.3333333
     string primvars:render_layer = "defaultRenderLayer" (
         elementSize = 1
         interpolation = "constant"
     )
-    bool texture_automip = 0
-    bool texture_per_file_stats = 1
-    int threads = 40
-    int xres = 160
-    int yres = 120
+    bool arnold:texture_automip = 0
+    bool arnold:texture_per_file_stats = 1
+    int arnold:threads = 40
+    int arnold:xres = 160
+    int arnold:yres = 120
 }
 
 def ArnoldGaussianFilter "defaultArnoldFilter_gaussian_filter"
 {
-    string name = "defaultArnoldFilter@gaussian_filter"
+    string arnold:name = "defaultArnoldFilter@gaussian_filter"
 }
 
 def ArnoldDriverTiff "defaultArnoldDriver_driver_tiff_RGBA"
 {
-    string color_space = ""
-    string filename = "testrender.tif"
-    string name = "defaultArnoldDriver@driver_tiff.RGBA"
+    string arnold:color_space = ""
+    string arnold:filename = "testrender.tif"
+    string arnold:name = "defaultArnoldDriver@driver_tiff.RGBA"
 }
 
 def "persp"


### PR DESCRIPTION
This PR removes the deprecated attribute format for typed schemas. They require an arnold: namespace, and we're no longer supporting formats without it.
Several test scenes were outdated and are fixed here. 
Also, the writer was still authoring attributes without this namespace for ArnoldGinstance primitives