### PR TITLE
Support nodes mask in the hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Feature
 - [usd#1615](https://github.com/Autodesk/arnold-usd/issues/1615) - add bespoke usdgenschema command to create arnold schema without python
 - [usd#739](https://github.com/Autodesk/arnold-usd/issues/739) - Implement the ArnoldProceduralCustom prim in hydra.
+- [usd#1644](https://github.com/Autodesk/arnold-usd/issues/1644) - Support nodes mask in the hydra procedural
 
 ## [7.2.3.2] - 2023-08-30
 

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -130,10 +130,13 @@ void HydraArnoldReader::Read(const std::string &filename, AtArray *overrides,
     // TODO check that we were able to load the stage
 
 
-    // TODO: if we have a procedural parent, we want to skip certain kind of prims
-    // There is a code like this one in the UsdReader
-    //int procMask = (_procParent) ? (AI_NODE_CAMERA | AI_NODE_LIGHT | AI_NODE_SHAPE | AI_NODE_SHADER | AI_NODE_OPERATOR)
-    //                             : AI_NODE_ALL;
+    // if we have a procedural parent, we want to skip certain kind of prims
+    HdArnoldRenderDelegate *arnoldRenderDelegate = static_cast<HdArnoldRenderDelegate*>(_renderDelegate);
+    int procMask = (arnoldRenderDelegate->GetProceduralParent()) ?
+        (AI_NODE_CAMERA | AI_NODE_LIGHT | AI_NODE_SHAPE | AI_NODE_SHADER | AI_NODE_OPERATOR)
+        : AI_NODE_ALL;
+        
+    arnoldRenderDelegate->SetMask(procMask);
 
     // Populates the rootPrim in the HdRenderIndex.
     // This creates the arnold nodes, but they don't contain any data
@@ -255,7 +258,7 @@ void HydraArnoldReader::SetMotionBlur(bool motionBlur, float motionStart , float
 void HydraArnoldReader::SetDebug(bool b) {}
 void HydraArnoldReader::SetThreadCount(unsigned int t) {}
 void HydraArnoldReader::SetConvertPrimitives(bool b) {}
-//void HydraArnoldReader::SetMask(int m) { _mask = m; }
+void HydraArnoldReader::SetMask(int m) {static_cast<HdArnoldRenderDelegate*>(_renderDelegate)->SetMask(m); }
 void HydraArnoldReader::SetPurpose(const std::string &p) { _purpose = TfToken(p.c_str()); }
 void HydraArnoldReader::SetId(unsigned int id) { _id = id; }
 void HydraArnoldReader::SetRenderSettings(const std::string &renderSettings) {_renderSettings = renderSettings;}

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -33,7 +33,7 @@ public:
     void SetDebug(bool b) override;
     void SetThreadCount(unsigned int t) override;
     void SetConvertPrimitives(bool b) override;
-    void SetMask(int m) override {};
+    void SetMask(int m) override;
     void SetPurpose(const std::string &p) override;
     void SetId(unsigned int id) override;
     void SetRenderSettings(const std::string &renderSettings) override;

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -389,30 +389,32 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
     }
     _supportedRprimTypes = {HdPrimTypeTokens->mesh, HdPrimTypeTokens->volume, HdPrimTypeTokens->points,
                             HdPrimTypeTokens->basisCurves, str::t_procedural_custom};
-    auto* shapeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHAPE);
-    while (!AiNodeEntryIteratorFinished(shapeIter)) {
-        const auto* nodeEntry = AiNodeEntryIteratorGetNext(shapeIter);
-        TfToken rprimType{ArnoldUsdMakeCamelCase(TfStringPrintf("Arnold_%s", AiNodeEntryGetName(nodeEntry)))};
-        _supportedRprimTypes.push_back(rprimType);
-        _nativeRprimTypes.insert({rprimType, AiNodeEntryGetNameAtString(nodeEntry)});
+    if (_mask & AI_NODE_SHAPE) {
+        auto* shapeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHAPE);
+        while (!AiNodeEntryIteratorFinished(shapeIter)) {
+            const auto* nodeEntry = AiNodeEntryIteratorGetNext(shapeIter);
+            TfToken rprimType{ArnoldUsdMakeCamelCase(TfStringPrintf("Arnold_%s", AiNodeEntryGetName(nodeEntry)))};
+            _supportedRprimTypes.push_back(rprimType);
+            _nativeRprimTypes.insert({rprimType, AiNodeEntryGetNameAtString(nodeEntry)});
 
-        NativeRprimParamList paramList;
-        auto* paramIter = AiNodeEntryGetParamIterator(nodeEntry);
-        while (!AiParamIteratorFinished(paramIter)) {
-            const auto* param = AiParamIteratorGetNext(paramIter);
-            const auto paramName = AiParamGetName(param);
-            if (ArnoldUsdIgnoreParameter(paramName)) {
-                continue;
+            NativeRprimParamList paramList;
+            auto* paramIter = AiNodeEntryGetParamIterator(nodeEntry);
+            while (!AiParamIteratorFinished(paramIter)) {
+                const auto* param = AiParamIteratorGetNext(paramIter);
+                const auto paramName = AiParamGetName(param);
+                if (ArnoldUsdIgnoreParameter(paramName)) {
+                    continue;
+                }
+    #if PXR_VERSION >= 2011
+                paramList.emplace(TfToken{TfStringPrintf("arnold:%s", paramName.c_str())}, param);
+    #else
+                paramList.emplace_back(TfToken{TfStringPrintf("arnold:%s", paramName.c_str())}, param);
+    #endif
             }
-#if PXR_VERSION >= 2011
-            paramList.emplace(TfToken{TfStringPrintf("arnold:%s", paramName.c_str())}, param);
-#else
-            paramList.emplace_back(TfToken{TfStringPrintf("arnold:%s", paramName.c_str())}, param);
-#endif
-        }
 
-        _nativeRprimParams.emplace(AiNodeEntryGetNameAtString(nodeEntry), std::move(paramList));
-        AiParamIteratorDestroy(paramIter);
+            _nativeRprimParams.emplace(AiNodeEntryGetNameAtString(nodeEntry), std::move(paramList));
+            AiParamIteratorDestroy(paramIter);
+        }
     }
     std::lock_guard<std::mutex> guard(_mutexResourceRegistry);
     if (_counterResourceRegistry.fetch_add(1) == 0) {
@@ -952,6 +954,9 @@ void HdArnoldRenderDelegate::DestroyInstancer(HdInstancer* instancer) { delete i
 #if PXR_VERSION >= 2102
 HdRprim* HdArnoldRenderDelegate::CreateRprim(const TfToken& typeId, const SdfPath& rprimId)
 {
+    if (!(_mask & AI_NODE_SHAPE))
+        return nullptr;
+
     _renderParam->Interrupt();
     if (typeId == HdPrimTypeTokens->mesh) {
         return new HdArnoldMesh(this, rprimId);
@@ -978,6 +983,9 @@ HdRprim* HdArnoldRenderDelegate::CreateRprim(const TfToken& typeId, const SdfPat
 #else
 HdRprim* HdArnoldRenderDelegate::CreateRprim(const TfToken& typeId, const SdfPath& rprimId, const SdfPath& instancerId)
 {
+    if (!(_mask & AI_NODE_SHAPE))
+        return nullptr;
+
     _renderParam->Interrupt();
     if (typeId == HdPrimTypeTokens->mesh) {
         return new HdArnoldMesh(this, rprimId, instancerId);
@@ -1019,31 +1027,40 @@ HdSprim* HdArnoldRenderDelegate::CreateSprim(const TfToken& typeId, const SdfPat
         DirtyDependency(sprimId);
 
     if (typeId == HdPrimTypeTokens->camera) {
-        return new HdArnoldCamera(this, sprimId);
+        return (_mask & AI_NODE_CAMERA) ? 
+            new HdArnoldCamera(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->material) {
-        return new HdArnoldNodeGraph(this, sprimId);
+        return (_mask & AI_NODE_SHADER) ? 
+            new HdArnoldNodeGraph(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->sphereLight) {
-        return HdArnoldLight::CreatePointLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreatePointLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->distantLight) {
-        return HdArnoldLight::CreateDistantLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateDistantLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->diskLight) {
-        return HdArnoldLight::CreateDiskLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateDiskLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->rectLight) {
-        return HdArnoldLight::CreateRectLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateRectLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->cylinderLight) {
-        return HdArnoldLight::CreateCylinderLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateCylinderLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->domeLight) {
-        return HdArnoldLight::CreateDomeLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateDomeLight(this, sprimId) : nullptr;
     }
     if (typeId == _tokens->GeometryLight) {
-        return HdArnoldLight::CreateGeometryLight(this, sprimId);
+        return (_mask & AI_NODE_LIGHT) ? 
+            HdArnoldLight::CreateGeometryLight(this, sprimId) : nullptr;
     }
     if (typeId == HdPrimTypeTokens->simpleLight) {
         return nullptr;

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -504,6 +504,12 @@ public:
     /// @return 
     const AtNode *GetProceduralParent() const { return _procParent; }
 
+    /// @brief set the node mask for translation. Default behaviour is AI_NODE_ALL which will
+    /// support all arnold types. By setting it to a different value, some node types will be filtered
+    /// out, following the arnold rules for node masks.
+    /// @param mask as an integer, combining the different bits for node types (e.g. AI_NODE_SHAPE, AI_NODE_SHADER, etc...)
+    void SetMask(int mask) {_mask = mask;}
+
 #if PXR_VERSION >= 2108
     /// Get the descriptors for the commands supported by this render delegate.
     HDARNOLD_API
@@ -627,6 +633,7 @@ private:
     bool _isArnoldActive = false;
     std::unordered_set<AtString, AtStringHash> _cryptomatteDrivers;
     std::string _outputOverride;
+    int _mask = AI_NODE_ALL;  // mask for node types to be translated
 
     std::mutex _nodesMutex;
     bool _renderDelegateOwnsUniverse;


### PR DESCRIPTION
**Changes proposed in this pull request**
When the render delegate is used through a procedural, we need to ensure some nodes are filtered out (options, etc..).
This PR adds the node mask that is already used in the USD reader, and uses it to eventually skip certain nodes to be created by the render delegate. This fixes a few more tests in "hydra" mode

**Issues fixed in this pull request**
Fixes #1644 

