### PR TITLE
Fix build issue with older usd cuts ARNOLD-14004

### DIFF
--- a/libs/common/shape_utils.cpp
+++ b/libs/common/shape_utils.cpp
@@ -18,7 +18,7 @@
 #include "shape_utils.h"
 
 #include "constant_strings.h"
-
+#include <pxr/base/gf/vec3f.h>
 #include <pxr/base/tf/staticTokens.h>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
The changes introduced in #1636  are not building with older versions of USD. A simple include is missing