### PR TITLE
Support object path in hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [usd#1644](https://github.com/Autodesk/arnold-usd/issues/1644) - Support nodes mask in the hydra procedural
 - [usd#1656](https://github.com/Autodesk/arnold-usd/issues/1656) - Use the same tessellation for sphere primitives as Hydra
 - [usd#1632](https://github.com/Autodesk/arnold-usd/issues/1632) - Support custom materialx node definitions placed in a folder defined by the environment variable PXR_MTLX_STDLIB_SEARCH_PATHS
+- [usd#1587](https://github.com/Autodesk/arnold-usd/issues/1587) - Support object path in the hydra procedural
+
 
 ### Bug fixes
 - [usd#1613](https://github.com/Autodesk/arnold-usd/issues/1613) - Invisible Hydra primitives should ignore arnold visibility

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -146,7 +146,8 @@ void HydraArnoldReader::Read(const std::string &filename, AtArray *overrides,
     // Populates the rootPrim in the HdRenderIndex.
     // This creates the arnold nodes, but they don't contain any data
     SdfPathVector _excludedPrimPaths; // excluding nothing
-    _imagingDelegate->Populate(stage->GetPrimAtPath(SdfPath::AbsoluteRootPath()), _excludedPrimPaths);
+    SdfPath rootPath = (path.empty()) ? SdfPath::AbsoluteRootPath() : SdfPath(path.c_str());
+    _imagingDelegate->Populate(stage->GetPrimAtPath(rootPath), _excludedPrimPaths);
 
     // Not sure about the meaning of collection geometry -- should that be extended ?
     HdRprimCollection collection(HdTokens->geometry, HdReprSelector(HdReprTokens->hull));

--- a/testsuite/test_0020/README
+++ b/testsuite/test_0020/README
@@ -2,3 +2,4 @@ Test Object Path #8519
 
 author: sebastien ortega
 
+PARAMS: {'diff_hardfail': 0.07}


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR checks the root path specified by the procedural, in hydra mode, and only reads the usd stage from that primitive.
It fixes test_0020, although a tiny threshold needs to be added due to the cone tessellation

**Issues fixed in this pull request**
Fixes #1587 


**Additional context**
Add any other context or screenshots about the pull request here.
