### PR TITLE
Support overrides in hydra procedural

### DIFF
--- a/testsuite/test_0031/README
+++ b/testsuite/test_0031/README
@@ -2,3 +2,4 @@ Test Overrides attribute on top of a usd file
 
 author: sebastien ortega
 
+PARAMS: {'diff_hardfail': 0.07}

--- a/testsuite/test_0031/data/test.ass
+++ b/testsuite/test_0031/data/test.ass
@@ -110,6 +110,7 @@ def Cube \"cube\"
 {
     double size=2
 	float3 xformOp:translate= (-4.8,0, 0)
+	bool primvars:arnold:smoothing = 0
     uniform token[] xformOpOrder = [\"xformOp:translate\"]
 }
 def Sphere \"sphere\"

--- a/testsuite/test_0032/data/test.ass
+++ b/testsuite/test_0032/data/test.ass
@@ -110,6 +110,7 @@ def Cube \"cube\"
 {
     double size=2
 	float3 xformOp:translate= (-4.8,0, 0)
+	bool primvars:arnold:smoothing = 0
     uniform token[] xformOpOrder = [\"xformOp:translate\"]
 }
 def Sphere \"sphere\"


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds support for overrides when a usd file is read, going through the render delegate. This fixes test_0017 in hydra mode. Tests 31 and 32 needed to set the cube smoothing attribute as we did in other tests.
Right after these last PRs are merged, I'm planning to factorize the code used in both usd and hydra readers, as there's more and more stuff in common. 

**Issues fixed in this pull request**
Fixes #1585

**Additional context**
Add any other context or screenshots about the pull request here.
