### PR TITLE
Check the value of PROCEDURAL_USE_HYDRA instead of if it's defined

### DIFF
--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -42,14 +42,18 @@
 #define XARNOLDUSDSTRINGIZE(x) ARNOLDUSDSTRINGIZE(x)
 #define ARNOLDUSDSTRINGIZE(x) #x
 
+#include <iostream>
 inline ProceduralReader *CreateProceduralReader(AtUniverse *universe)
 {
 #ifdef ENABLE_HYDRA_IN_USD_PROCEDURAL
     if (ArchHasEnv("PROCEDURAL_USE_HYDRA")) {
-        return new HydraArnoldReader(universe);
-    } else {
-        return new UsdArnoldReader();
+        const std::string useHydra = ArchGetEnv("PROCEDURAL_USE_HYDRA");
+        int envVal = std::stoi(useHydra);
+        if (envVal != 0)
+            return new HydraArnoldReader(universe);
     }
+    return new UsdArnoldReader();
+    
 #else
     return new UsdArnoldReader();
 #endif

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -46,9 +46,13 @@ inline ProceduralReader *CreateProceduralReader(AtUniverse *universe)
 {
 #ifdef ENABLE_HYDRA_IN_USD_PROCEDURAL
     if (ArchHasEnv("PROCEDURAL_USE_HYDRA")) {
-        const std::string useHydra = ArchGetEnv("PROCEDURAL_USE_HYDRA");
-        int envVal = std::stoi(useHydra);
-        if (envVal != 0)
+        std::string useHydra = ArchGetEnv("PROCEDURAL_USE_HYDRA");
+        std::string::size_type i = useHydra.find(" ");
+        while(i != std::string::npos) {
+            useHydra.erase(i, 1);
+            i = useHydra.find(" ");
+        }
+        if (useHydra != "0")
             return new HydraArnoldReader(universe);
     }
     return new UsdArnoldReader();

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -42,7 +42,6 @@
 #define XARNOLDUSDSTRINGIZE(x) ARNOLDUSDSTRINGIZE(x)
 #define ARNOLDUSDSTRINGIZE(x) #x
 
-#include <iostream>
 inline ProceduralReader *CreateProceduralReader(AtUniverse *universe)
 {
 #ifdef ENABLE_HYDRA_IN_USD_PROCEDURAL


### PR DESCRIPTION
So far we were using the hydra procedural as soon as the variable PROCEDURAL_USE_HYDRA is defined. But it can be useful to switch this variable back and forth so in this PR I'm checking its value. If it's set to "0" we use the regular usd procedural, but otherwise we create the hydra reader