### PR TITLE
Refactoring to add support for cacheID in the hydra delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@
 - [usd#1632](https://github.com/Autodesk/arnold-usd/issues/1632) - Support custom materialx node definitions placed in a folder defined by the environment variable PXR_MTLX_STDLIB_SEARCH_PATHS
 - [usd#1586](https://github.com/Autodesk/arnold-usd/issues/1586) - Support motion blur in the hydra procedural
 - [usd#1587](https://github.com/Autodesk/arnold-usd/issues/1587) - Support object path in the hydra procedural
+- [usd#1664](https://github.com/Autodesk/arnold-usd/issues/1664) - Support hydra procedural with a cacheID
 
 ### Bug fixes
 - [usd#1613](https://github.com/Autodesk/arnold-usd/issues/1613) - Invisible Hydra primitives should ignore arnold visibility
 - [usd#1641](https://github.com/Autodesk/arnold-usd/issues/1641) - Ensure nodes created by the render delegate have the correct parent procedural.
-- [usd#1648](https://github.com/Autodesk/arnold-usd/issues/1648) - Fix an issue where the schemas were generated only once every 2 attempts.   
 - [usd#1652](https://github.com/Autodesk/arnold-usd/issues/1652) - Restore the schema installed files organisation. 
+
+### Build
+- [usd#1648](https://github.com/Autodesk/arnold-usd/issues/1648) - Fix schemas generation issue that was intermittently failing
 
 ## [7.2.3.2] - 2023-08-30
 

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(COMMON_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/constant_strings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/parameters_utils.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/rendersettings_utils.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/procedural_reader.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/shape_utils.cpp")
 
 set(COMMON_HDR

--- a/libs/common/SConscript
+++ b/libs/common/SConscript
@@ -24,6 +24,7 @@ source_files = [
     'parameters_utils.cpp',
     'rendersettings_utils.cpp',
     'shape_utils.cpp',
+    'procedural_reader.cpp',
 ]
 
 if not system.IS_WINDOWS:

--- a/libs/common/procedural_reader.cpp
+++ b/libs/common/procedural_reader.cpp
@@ -1,0 +1,103 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "procedural_reader.h"
+#include <ai.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdUtils/stageCache.h>
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/path.h>
+
+int s_anonymousOverrideCounter = 0;
+static AtMutex s_overrideReaderMutex;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void ProceduralReader::Read(const std::string &filename, 
+    AtArray *overrides, const std::string &path)
+{
+    // Nodes were already exported, should we skip here,
+    // or should we just append the new nodes ?
+    if (!GetNodes().empty()) {
+        return;
+    }
+
+    SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(filename);
+    _filename = filename;   // Store the filename that is currently being read
+    _overrides = nullptr;
+
+    if (overrides == nullptr || AiArrayGetNumElements(overrides) == 0) {
+        // Only open the usd file as a root layer
+        if (rootLayer == nullptr) {
+            AiMsgError("[usd] Failed to open file (%s)", filename.c_str());
+            _overrides = nullptr;
+            return;
+        }
+        UsdStageRefPtr stage = UsdStage::Open(rootLayer, UsdStage::LoadAll);
+        ReadStage(stage, path);
+    } else {
+        _overrides = overrides; // Store the overrides that are currently being applied
+        auto getLayerName = []() -> std::string {
+            int counter;
+            {
+                std::lock_guard<AtMutex> guard(s_overrideReaderMutex);
+                counter = s_anonymousOverrideCounter++;
+            }
+            std::stringstream ss;
+            ss << "anonymous__override__" << counter << ".usda";
+            return ss.str();
+        };
+
+        auto overrideLayer = SdfLayer::CreateAnonymous(getLayerName());
+        const auto overrideCount = AiArrayGetNumElements(overrides);
+
+        std::vector<std::string> layerNames;
+        layerNames.reserve(overrideCount);
+        // Make sure they kep around after the loop scope ends.
+        std::vector<SdfLayerRefPtr> layers;
+        layers.reserve(overrideCount);
+
+        for (auto i = decltype(overrideCount){0}; i < overrideCount; ++i) {
+            auto layer = SdfLayer::CreateAnonymous(getLayerName());
+            if (layer->ImportFromString(AiArrayGetStr(overrides, i).c_str())) {
+                layerNames.emplace_back(layer->GetIdentifier());
+                layers.push_back(layer);
+            }
+        }
+
+        overrideLayer->SetSubLayerPaths(layerNames);
+        // If there is no rootLayer for a usd file, we only pass the overrideLayer to prevent
+        // USD from crashing #235
+        auto stage = rootLayer ? UsdStage::Open(rootLayer, overrideLayer, UsdStage::LoadAll)
+                               : UsdStage::Open(overrideLayer, UsdStage::LoadAll);
+
+        ReadStage(stage, path);
+    }
+
+    _filename = "";       // finished reading, let's clear the filename
+    _overrides = nullptr; // clear the overrides pointer. Note that we don't own this array
+}
+
+bool ProceduralReader::Read(int cacheId, const std::string &path)
+{
+    if (!GetNodes().empty()) {
+        return true;
+    }
+    _cacheId = cacheId;
+    // Load the USD stage in memory using a cache ID
+    UsdStageCache &stageCache = UsdUtilsStageCache::Get();
+    UsdStageCache::Id id = UsdStageCache::Id::FromLongInt(cacheId);
+   
+    UsdStageRefPtr stage = (id.IsValid()) ? stageCache.Find(id) : nullptr;
+    if (!stage) {
+        AiMsgWarning("[usd] Cache ID not valid %d", cacheId);
+        _cacheId = 0;
+        return false;
+    }
+    ReadStage(stage, path);
+    return true;
+
+}
+
+

--- a/libs/common/procedural_reader.h
+++ b/libs/common/procedural_reader.h
@@ -3,7 +3,10 @@
 //
 
 #pragma once
+#include <ai.h>
+#include <pxr/usd/usd/stage.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
 /// @brief This is the base class for any arnold procedural reader
 class ProceduralReader {
 public:
@@ -20,8 +23,21 @@ public:
     virtual void SetUniverse(AtUniverse *universe) = 0;
     virtual void SetRenderSettings(const std::string &renderSettings) = 0;
     virtual void CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) = 0;
-    virtual void Read(
-        const std::string &filename, AtArray *overrides, const std::string &path = "") = 0; // read a USD file
-    virtual bool Read(int cacheId, const std::string &path = "") = 0; // read a USdStage from memory
+    virtual void ReadStage(UsdStageRefPtr stage,
+                   const std::string &path) = 0;
+    
     virtual const std::vector<AtNode *> &GetNodes() const = 0;
+
+    const std::string &GetFilename() const { return _filename; }
+    const AtArray *GetOverrides() const { return _overrides; }
+    int GetCacheId() const {return _cacheId;}
+
+    void Read(const std::string &filename, 
+        AtArray *overrides, const std::string &path = "");
+
+    bool Read(int cacheId, const std::string &path = "");
+protected:
+    std::string _filename;
+    AtArray *_overrides = nullptr;
+    int _cacheId = 0;   // usdStage cacheID used with a StageCache
 };

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -19,12 +19,9 @@ public:
     ~HydraArnoldReader();
     const std::vector<AtNode *> &GetNodes() const override;
 
-    void Read(const std::string &filename, AtArray *overrides,
-              const std::string &path = "") override; // read a USD file
-
-    // TODO: what should the behavior in case we have a cacheId ?
-    bool Read(int cacheId, const std::string &path = "") override {return false;};
-
+    void ReadStage(UsdStageRefPtr stage,
+                   const std::string &path) override; // read a specific UsdStage
+    
     void SetProceduralParent(AtNode *node) override;
     void SetUniverse(AtUniverse *universe) override;
   

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -84,7 +84,6 @@ namespace {
 };
 // global reader registry, will be used in the default case
 static UsdArnoldReaderRegistry *s_readerRegistry = nullptr;
-static int s_anonymousOverrideCounter = 0;
 static int s_mustDeleteRegistry = 0;
 
 static AtMutex s_globalReaderMutex;
@@ -99,88 +98,6 @@ UsdArnoldReader::~UsdArnoldReader()
     }
     // What do we want to do at destruction here ?
     // Should we delete the created nodes in case there was no procParent ?
-}
-
-void UsdArnoldReader::Read(const std::string &filename, AtArray *overrides, const std::string &path)
-{
-    // Nodes were already exported, should we skip here,
-    // or should we just append the new nodes ?
-    if (!_nodes.empty()) {
-        return;
-    }
-
-    SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(filename);
-    _filename = filename;   // Store the filename that is currently being read
-    _overrides = overrides; // Store the overrides that are currently being applied
-
-    if (overrides == nullptr || AiArrayGetNumElements(overrides) == 0) {
-        // Only open the usd file as a root layer
-        if (rootLayer == nullptr) {
-            AiMsgError("[usd] Failed to open file (%s)", filename.c_str());
-            return;
-        }
-        UsdStageRefPtr stage = UsdStage::Open(rootLayer, UsdStage::LoadAll);
-        ReadStage(stage, path);
-    } else {
-        auto getLayerName = []() -> std::string {
-            int counter;
-            {
-                std::lock_guard<AtMutex> guard(s_globalReaderMutex);
-                counter = s_anonymousOverrideCounter++;
-            }
-            std::stringstream ss;
-            ss << "anonymous__override__" << counter << ".usda";
-            return ss.str();
-        };
-
-        auto overrideLayer = SdfLayer::CreateAnonymous(getLayerName());
-        const auto overrideCount = AiArrayGetNumElements(overrides);
-
-        std::vector<std::string> layerNames;
-        layerNames.reserve(overrideCount);
-        // Make sure they kep around after the loop scope ends.
-        std::vector<SdfLayerRefPtr> layers;
-        layers.reserve(overrideCount);
-
-        for (auto i = decltype(overrideCount){0}; i < overrideCount; ++i) {
-            auto layer = SdfLayer::CreateAnonymous(getLayerName());
-            if (layer->ImportFromString(AiArrayGetStr(overrides, i).c_str())) {
-                layerNames.emplace_back(layer->GetIdentifier());
-                layers.push_back(layer);
-            }
-        }
-
-        overrideLayer->SetSubLayerPaths(layerNames);
-        // If there is no rootLayer for a usd file, we only pass the overrideLayer to prevent
-        // USD from crashing #235
-        auto stage = rootLayer ? UsdStage::Open(rootLayer, overrideLayer, UsdStage::LoadAll)
-                               : UsdStage::Open(overrideLayer, UsdStage::LoadAll);
-
-        ReadStage(stage, path);
-    }
-
-    _filename = "";       // finished reading, let's clear the filename
-    _overrides = nullptr; // clear the overrides pointer. Note that we don't own this array
-}
-
-bool UsdArnoldReader::Read(int cacheId, const std::string &path)
-{
-    if (!_nodes.empty()) {
-        return true;
-    }
-    _cacheId = cacheId;
-    // Load the USD stage in memory using a cache ID
-    UsdStageCache &stageCache = UsdUtilsStageCache::Get();
-    UsdStageCache::Id id = UsdStageCache::Id::FromLongInt(cacheId);
-   
-    UsdStageRefPtr stage = (id.IsValid()) ? stageCache.Find(id) : nullptr;
-    if (!stage) {
-        AiMsgWarning("[usd] Cache ID not valid %d", cacheId);
-        _cacheId = 0;
-        return false;
-    }
-    ReadStage(stage, path);
-    return true;
 }
 
 void UsdArnoldReader::TraverseStage(UsdPrim *rootPrim, UsdArnoldReaderContext &context, 

--- a/libs/translator/reader/reader.h
+++ b/libs/translator/reader/reader.h
@@ -56,8 +56,6 @@ public:
           _threadCount(1),
           _mask(AI_NODE_ALL),
           _defaultShader(nullptr),
-          _overrides(nullptr),
-          _cacheId(0),
           _hasRootPrim(false),
           _readStep(READ_NOT_STARTED),
           _purpose(UsdGeomTokens->render),
@@ -66,11 +64,8 @@ public:
     }
     ~UsdArnoldReader();
 
-    void Read(const std::string &filename, AtArray *overrides,
-              const std::string &path = "") override; // read a USD file
-    bool Read(int cacheId, const std::string &path = "") override; // read a USdStage from memory
     void ReadStage(UsdStageRefPtr stage,
-                   const std::string &path = ""); // read a specific UsdStage
+                   const std::string &path) override; // read a specific UsdStage
     void ReadPrimitive(const UsdPrim &prim, UsdArnoldReaderContext &context, bool isInstance = false, AtArray *parentMatrix = nullptr);
 
     void ClearNodes();
@@ -100,13 +95,11 @@ public:
     bool GetDebug() const { return _debug; }
     bool GetConvertPrimitives() const { return _convert; }
     const TimeSettings &GetTimeSettings() const { return _time; }
-    const std::string &GetFilename() const { return _filename; }
-    const AtArray *GetOverrides() const { return _overrides; }
+        
     unsigned int GetThreadCount() const { return _threadCount; }
     int GetMask() const { return _mask; }
     unsigned int GetId() const { return _id;}
     const TfToken &GetPurpose() const {return _purpose;}
-    int GetCacheId() const {return _cacheId;}
     const std::string &GetRenderSettings() const {return _renderSettings;}
 
     static unsigned int ReaderThread(void *data);
@@ -231,9 +224,7 @@ private:
     std::unordered_map<std::string, UsdCollectionAPI> _shadowLinksMap;
     
     AtNode *_defaultShader;
-    std::string _filename; // usd filename that is currently being read
-    AtArray *_overrides;   // usd overrides that are currently being applied on top of the usd file
-    int _cacheId;          // usdStage cacheID used with a StageCache
+    
     bool _hasRootPrim;     // are we reading this stage based on a root primitive
     UsdPrim _rootPrim;     // eventual root primitive used to traverse the stage
     AtMutex _readerLock; // arnold mutex for multi-threaded translator


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR factorizes some of the code that was duplicated between the hydra and the usd reader, and moves it to the ProceduralReader class. Now the class that needs to be overridden is ReadStage that will work for usd filenames or a stage cache ID.

**Issues fixed in this pull request**
Fixes #1664 
