### PR TITLE
Ensure testsuite logs are appended for resaved tests

### DIFF
--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -172,10 +172,12 @@ def run_test(target, source, env):
    sa.path.remove(os.path.join(test_dir, 'STATUS.vg'))
    sa.path.remove(os.path.join(test_dir, '%s.vg.xml' % TEST_NAME))
    sa.path.remove(os.path.join(test_dir, 'TIMINGS'))
-
+   log_files = glob.glob(os.path.join(test_dir, '*.log'))
+   for log_file in log_files:
+      sa.path.remove(log_file) 
+   
    nMemErrors, nMemLeaksDL, nMemLeaksPL, nMemLeaksIL, nMemLeaksSR = 0, 0, 0, 0, 0
-   appendLog = False
-
+   
    for cmd in test_env['TEST_SCRIPT'].splitlines():
       if not cmd:
          continue
@@ -225,10 +227,9 @@ def run_test(target, source, env):
 
       retcode, out = sa.system.execute(cmd, cwd=test_dir, env=local_env, shell=use_shell, timeout=test_env.get('TIMELIMIT', 0), verbose=show_test_output)
 
-      with open(os.path.join(test_dir, "%s.log") % TEST_NAME, 'a' if appendLog else 'w') as f:
+      with open(os.path.join(test_dir, "%s.log") % TEST_NAME, 'a') as f:
          f.writelines(l + '\n' for l in out)
       
-      appendLog = True
       running_time = time.time() - before_time
       TOTAL_RUNNING_TIME += running_time
       if test_env['USE_VALGRIND'] != 'False':

--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -174,6 +174,7 @@ def run_test(target, source, env):
    sa.path.remove(os.path.join(test_dir, 'TIMINGS'))
 
    nMemErrors, nMemLeaksDL, nMemLeaksPL, nMemLeaksIL, nMemLeaksSR = 0, 0, 0, 0, 0
+   appendLog = False
 
    for cmd in test_env['TEST_SCRIPT'].splitlines():
       if not cmd:
@@ -221,10 +222,13 @@ def run_test(target, source, env):
       print('====Exec %s' % cmd)
       print(os.getenv('PATH'))
 
-      retcode, out = sa.system.execute(cmd, cwd=test_dir, env=local_env, shell=use_shell, timeout=test_env.get('TIMELIMIT', 0), verbose=show_test_output)
-      with open(os.path.join(test_dir, "%s.log") % TEST_NAME, 'w') as f:
-         f.writelines(l + '\n' for l in out)
 
+      retcode, out = sa.system.execute(cmd, cwd=test_dir, env=local_env, shell=use_shell, timeout=test_env.get('TIMELIMIT', 0), verbose=show_test_output)
+
+      with open(os.path.join(test_dir, "%s.log") % TEST_NAME, 'a' if appendLog else 'w') as f:
+         f.writelines(l + '\n' for l in out)
+      
+      appendLog = True
       running_time = time.time() - before_time
       TOTAL_RUNNING_TIME += running_time
       if test_env['USE_VALGRIND'] != 'False':


### PR DESCRIPTION
Some tests are running several processes, like those that resave a scene and then kick the resaved scene. In this case, the log file is being overwritten over and over. This change ensures the log is appended so that we can get the full info.