### PR TITLE
Fix geometry light not working in 7.2.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [usd#1673](https://github.com/Autodesk/arnold-usd/issues/1673) - UsdUvTexture ignores missing textures in hydra
 - [usd#1675](https://github.com/Autodesk/arnold-usd/issues/1675) - Fix UsdUvTexture default wrap modes and uvset coordinates.
 - [usd#1657](https://github.com/Autodesk/arnold-usd/issues/1657) - Fix a motion blur sampling bug happening when a mesh has facevarying indexed normals and different number of indices per key frame.
-
+- [usd#1693](https://github.com/Autodesk/arnold-usd/issues/1693) - Fix geometry light not rendering in recent version.
 
 ### Build
 - [usd#1648](https://github.com/Autodesk/arnold-usd/issues/1648) - Fix schemas generation issue that was intermittently failing

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -518,7 +518,7 @@ AtNode *HdArnoldMesh::_GetMeshLight(HdSceneDelegate* sceneDelegate, const SdfPat
             // We'll name it based on the mesh name, adding a light suffix
             std::string lightName = AiNodeGetName(GetArnoldNode());
             lightName += "/light";
-            _renderDelegate->CreateArnoldNode(str::mesh_light, AtString(lightName.c_str()));
+            _geometryLight = _renderDelegate->CreateArnoldNode(str::mesh_light, AtString(lightName.c_str()));
         }
         AiNodeSetPtr(_geometryLight, str::mesh, (void*)GetArnoldNode());
     } else if (_geometryLight) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- reassign the _geometryLight variable which was remove during the refactoring of the render delegate.

**Issues fixed in this pull request**
Fixes #1693 

