### PR TITLE
Fix cryptomatte render by not assigning the cryptomatte_filter filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [usd#1675](https://github.com/Autodesk/arnold-usd/issues/1675) - Fix UsdUvTexture default wrap modes and uvset coordinates.
 - [usd#1657](https://github.com/Autodesk/arnold-usd/issues/1657) - Fix a motion blur sampling bug happening when a mesh has facevarying indexed normals and different number of indices per key frame.
 - [usd#1693](https://github.com/Autodesk/arnold-usd/issues/1693) - Fix geometry light not rendering in recent version.
+- [usd#1696](https://github.com/Autodesk/arnold-usd/issues/1696) - Fix cryptomatte render by restoring previous filter assignment to the default filter.
 
 ### Build
 - [usd#1648](https://github.com/Autodesk/arnold-usd/issues/1648) - Fix schemas generation issue that was intermittently failing

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -298,7 +298,7 @@ AtNode* _CreateFilter(HdArnoldRenderDelegate* renderDelegate, const HdAovSetting
     // We need to make sure that it's holding a string, then try to create it to make sure
     // it's a node type supported by Arnold.
     const auto filterType = _GetOptionalSetting(aovSettings, _tokens->aovSettingFilter, std::string{});
-    if (filterType.empty()) {
+    if (filterType.empty() || filterType == "cryptomatte_filter") {
         return nullptr;
     }
     const auto filterNameStr =


### PR DESCRIPTION
**Changes proposed in this pull request**
- Before the change in https://github.com/Autodesk/arnold-usd/commit/a9f4157230b901094d826f9ac5e6435d11e70368 cryptomatte was passing the htoa tests. Assigning a cryptomatte_filter to a cryptomatte aov does not work as it is now, this change looks for the filter type and skip cryptomatte_filter to restore the previous behaviour.

**Issues fixed in this pull request**
Fixes #1696

