### PR TITLE
Fix render delegate build with older versions of USD

### DIFF
--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -493,7 +493,10 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             AiNodeSetPtr(options, str::camera, currentCamera);
         }
         // TODO: We should test the type of the arnold camera instead ?
-        isOrtho =  camera->GetProjection() == HdCamera::Projection::Orthographic;;
+#if PXR_VERSION >= 2102
+        // Ortho cameras were not supported in older versions of USD
+        isOrtho =  camera->GetProjection() == HdCamera::Projection::Orthographic;
+#endif
     }
     const auto dataWindow = _GetDataWindow(renderPassState);
     const auto width = static_cast<int>(dataWindow.GetWidth());


### PR DESCRIPTION
Older versions of USD didn't support orthographic projections in HdCamera. 
This PR adds some ifdefs to ensure the code compiles properly with e.g. USD 20.11

I'm also simplifying a bit a previous set of ifdefs that could be factorized as a single one.