### PR TITLE
Fix compilation warnings on windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -378,7 +378,11 @@ if env['COMPILER'] in ['gcc', 'clang']:
 elif env['COMPILER'] == 'msvc':
     env.Append(CCFLAGS=Split('/EHsc'))
     env.Append(LINKFLAGS=Split('/Machine:X64'))
-    env.Append(CCFLAGS=Split('/D "NOMINMAX" /Zc:inline-'))
+    # Ignore all the linking warnings we get on windows, coming from USD
+    env.Append(LINKFLAGS=Split('/ignore:4099'))
+    env.Append(LINKFLAGS=Split('/ignore:4217'))
+
+    env.Append(CCFLAGS=Split('/D "NOMINMAX" /D "TBB_SUPPRESS_DEPRECATED_MESSAGES" /Zc:inline-'))
     # Optimization/profile/debug flags
     if env['MODE'] == 'opt':
         env.Append(CCFLAGS=Split('/O2 /Oi /Ob2 /MD'))

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -1773,7 +1773,7 @@ AtArray* HdArnoldGetShidxs(const HdGeomSubsets& subsets, int numFaces, HdArnoldS
     if (numFaces > 0) {
         auto* shidxs = static_cast<uint8_t*>(AiArrayMap(shidxsArray));
         uint8_t subsetId = 0;
-        std::fill(shidxs, shidxs + numFaces, numSubsets);
+        std::fill(shidxs, shidxs + numFaces, static_cast<uint8_t>(numSubsets));
         for (const auto& subset : subsets) {
             arnoldSubsets.push_back(subset.materialId);
             for (auto id : subset.indices) {

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -261,11 +261,12 @@ size_t ReadArray(
                 AiNodeSetArray(node, AtString(attrName), AiArrayConvert(size, 1, attrType, array->cdata()));
             } else {
                 // Different data representation between USD and Arnold, we need to
-                // copy the vector. Note that we could instead allocate the AtArray
-                // and set the elements one by one, but I'm assuming it's faster
-                // this way
+                // copy the vector. 
                 VtArray<A> arnold_vec;
-                arnold_vec.assign(array->cbegin(), array->cend());
+                arnold_vec.reserve(array->size());
+                for (const auto &elem : (*array))
+                    arnold_vec.push_back(static_cast<A>(elem));
+                
                 AiNodeSetArray(node, AtString(attrName), AiArrayConvert(size, 1, attrType, arnold_vec.cdata()));
             }
         } else

--- a/tools/usdgenschema/main.cpp
+++ b/tools/usdgenschema/main.cpp
@@ -64,6 +64,7 @@ SdfPrimSpecHandle _GetDefiningLayerAndPrim(UsdStageRefPtr stage, std::string sch
             }
         }
     }
+    return {};
 }
 
 std::string _GetLibPrefix(SdfLayerHandle layer)


### PR DESCRIPTION
Building arnold-usd on windows is currently triggering a lot of compilation / linking warnings.
This PR fixes them by : 
- ignoring 2 linking issues coming from how we link against USD "4099" and "4217"
- adding a variable that ignores TBB deprecation messages (also coming from USD)
- Properly cast variables in two pieces of code. When going through vectors, the implicit type conversion was causing warnings
- A recent change wasn't always returning a value in a function

All these changes give us a clean build log, without warnings