### PR TITLE
Restore cryptomatte filters assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfix
 - [usd#1678](https://github.com/Autodesk/arnold-usd/issues/1678) - Add support for Arnold shaders with multiple outputs
 - [usd#1711](https://github.com/Autodesk/arnold-usd/issues/1711) - Fix duplicated arnold user data introduced in 7.2.3.0
+- [usd#1728](https://github.com/Autodesk/arnold-usd/issues/1728) - Fix cryptomatte compatibility with Nuke.
 
 ## [7.2.4.0] - 2023-10-04
 

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -297,7 +297,7 @@ AtNode* _CreateFilter(HdArnoldRenderDelegate* renderDelegate, const HdAovSetting
     // We need to make sure that it's holding a string, then try to create it to make sure
     // it's a node type supported by Arnold.
     const auto filterType = _GetOptionalSetting(aovSettings, _tokens->aovSettingFilter, std::string{});
-    if (filterType.empty() || filterType == "cryptomatte_filter") {
+    if (filterType.empty()) {
         return nullptr;
     }
     const auto filterNameStr =


### PR DESCRIPTION
**Changes proposed in this pull request**
- Revert change made in revert change made in https://github.com/Autodesk/arnold-usd/pull/1697 as they were working with cryptomatte in houdini but were not in nuke.

**Issues fixed in this pull request**
Fixes #1728

