### PR TITLE
Force the color aov to be interpreted as the Arnold beauty pass, regardless of the LPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## [Unreleased]
 
 ### Bugfix
+-[usd#1732](https://github.com/Autodesk/arnold-usd/issues/1732) - Force the "color" AOV to be interpreted as the Arnold beauty pass.
+
+
+## [7.2.4.1] - 2023-10-19
+
+### Bugfix
 - [usd#1678](https://github.com/Autodesk/arnold-usd/issues/1678) - Add support for Arnold shaders with multiple outputs
 - [usd#1711](https://github.com/Autodesk/arnold-usd/issues/1711) - Fix duplicated arnold user data introduced in 7.2.3.0
 - [usd#1728](https://github.com/Autodesk/arnold-usd/issues/1728) - Fix cryptomatte compatibility with Nuke.

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -784,7 +784,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                 // But Arnold won't recognize this as being the actual beauty and adaptive sampling
                 // won't apply properly (see #1006). So we want to detect which output is the actual beauty 
                 // and treat it as Arnold would expect.
-                bool isBeauty = (sourceName == "C.*") && (binding.aovName == HdAovTokens->color);
+                bool isBeauty = binding.aovName == HdAovTokens->color;
                 
                 // When using a raw buffer, we have special behavior for color, depth and ID. Otherwise we are creating
                 // an aov with the same name. We can't just check for the source name; for example: using a primvar


### PR DESCRIPTION
**Changes proposed in this pull request**
- Avoid testing the lpe for the beauty in the render delegate to be consistent with the procedural behaviour

**Issues fixed in this pull request**
Fixes #1732
