### PR TITLE
Add support for -j argument in husk #1077

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [usd#612](https://github.com/Autodesk/arnold-usd/issues/612) - Add support for orthographic camera in the hydra render delegate.
 - [usd#1678](https://github.com/Autodesk/arnold-usd/issues/1678) - Add support for Arnold shaders with multiple outputs
 - [usd#1726](https://github.com/Autodesk/arnold-usd/issues/1726) - Add usdz as a supported format of the scene reader
+- [usd#1077](https://github.com/Autodesk/arnold-usd/issues/1077) - Support --threads / -j argument in husk to control the amount of render threads
 
 ### Bug fixes
 - [usd#1709](https://github.com/Autodesk/arnold-usd/issues/1709) - Procedural failures if schemas are present

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -651,7 +651,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             for (unsigned int i = 0; i < commandLine.size(); ++i) {
                 // husk argument for output image
                 if (commandLine[i] == "-o" && i < commandLine.size() - 2) {
-                    _outputOverride = commandLine[i+1];
+                    _outputOverride = commandLine[++i];
                     break;
                 }
                 // husk argument for thread count (#1077)
@@ -659,7 +659,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
                         && i < commandLine.size() - 2) {
                     // if for some reason the argument value is not a number, atoi should return 0
                     // which is also the default arnold value. 
-                    AiNodeSetInt(_options, str::threads, std::atoi(commandLine[i+1].c_str()));
+                    AiNodeSetInt(_options, str::threads, std::atoi(commandLine[++i].c_str()));
                 }
             }
         }

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -649,9 +649,17 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         if (value.IsHolding<VtStringArray>()) {
             const VtStringArray commandLine = value.UncheckedGet<VtArray<std::string>>();
             for (unsigned int i = 0; i < commandLine.size(); ++i) {
+                // husk argument for output image
                 if (commandLine[i] == "-o" && i < commandLine.size() - 2) {
                     _outputOverride = commandLine[i+1];
                     break;
+                }
+                // husk argument for thread count (#1077)
+                if ((commandLine[i] == "-j" || commandLine[i] == "--threads") 
+                        && i < commandLine.size() - 2) {
+                    // if for some reason the argument value is not a number, atoi should return 0
+                    // which is also the default arnold value. 
+                    AiNodeSetInt(_options, str::threads, std::atoi(commandLine[i+1].c_str()));
                 }
             }
         }


### PR DESCRIPTION
**Changes proposed in this pull request**
When we parse the command line arguments in the render delegate (which at the moment is specific to husk), we now look for an argument -j or --threads that is used to specify the amount of threads.

Unortunately this is hard to test, since the options attribute "threads" is an exception and is never saved to ass files

**Issues fixed in this pull request**
Fixes #1077
