### PR TITLE
Add support for pixel aspect ratio in the render delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [usd#612](https://github.com/Autodesk/arnold-usd/issues/612) - Add support for orthographic camera in the hydra render delegate.
 - [usd#1726](https://github.com/Autodesk/arnold-usd/issues/1726) - Add usdz as a supported format of the scene reader
 - [usd#1077](https://github.com/Autodesk/arnold-usd/issues/1077) - Support --threads / -j argument in husk to control the amount of render threads
+- [usd#658](https://github.com/Autodesk/arnold-usd/issues/658) - Support pixel aspect ratio in Hydra
 
 ### Bug fixes
 - [usd#1709](https://github.com/Autodesk/arnold-usd/issues/1709) - Procedural failures if schemas are present

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -80,6 +80,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     ((aovSettings, "aovDescriptor.aovSettings"))
     (productType)
     (productName)
+    (pixelAspectRatio)
     (driver_exr)
     (sourceType)
     (sourceName)
@@ -639,7 +640,12 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         if (value.IsHolding<GfVec4f>()) {
             _windowNDC = value.UncheckedGet<GfVec4f>();
         }
-    } else if (key == _tokens->resolution) {
+    } else if (key == _tokens->pixelAspectRatio) {
+        if (value.IsHolding<float>()) {
+            _pixelAspectRatio = value.UncheckedGet<float>();
+        }
+    } 
+    else if (key == _tokens->resolution) {
         if (value.IsHolding<GfVec2i>()) {
             _resolution = value.UncheckedGet<GfVec2i>();
         }

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -488,6 +488,14 @@ public:
     HDARNOLD_API
     GfVec4f GetWindowNDC() const {return _windowNDC;}
 
+    /// Get the current pixel aspect ratio, defaulting to 1
+    ///
+    /// @return Float Pixel Aspect Ratio value, as defined in the Render Settings
+    
+    HDARNOLD_API
+    float GetPixelAspectRatio() const {return _pixelAspectRatio;}
+
+
     /// Get the current resolution, as returned from the render settings
     ///
     /// @return width / height resolution, as a Vec2i
@@ -664,6 +672,8 @@ private:
     GfVec4f _windowNDC = GfVec4f(0, 0, 1, 1);
     // resolution as returned from the render settings
     GfVec2i _resolution = GfVec2i(0, 0);
+    float _pixelAspectRatio = 1.f;
+    
     /// Top level render context using Hydra. Ie. Hydra, Solaris, Husk.
     TfToken _context;
     bool _isBatch = false; // are we in a batch rendering context (e.g. Husk)

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -530,6 +530,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         }
     }
     GfVec4f windowNDC = _renderDelegate->GetWindowNDC();
+    float pixelAspectRatio = _renderDelegate->GetPixelAspectRatio();
     // check if we have a non-default window
     bool hasWindowNDC = (!GfIsClose(windowNDC[0], 0.0f, AI_EPSILON)) || 
                         (!GfIsClose(windowNDC[1], 0.0f, AI_EPSILON)) || 
@@ -566,7 +567,6 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
 
     if (windowChanged) {
         renderParam->Interrupt(true, false);
-        AiNodeResetParameter(options, str::pixel_aspect_ratio);
         if (hasWindowNDC) {
             _windowNDC = windowNDC;
             
@@ -626,8 +626,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
 
                 // For interactive renders, need to adjust the pixel aspect ratio to match the window NDC
                 if (!_renderDelegate->IsBatchContext()) {
-                    float pixel_aspect_ratio = xDelta / yDelta;
-                    AiNodeSetFlt(options, str::pixel_aspect_ratio, pixel_aspect_ratio);
+                    pixelAspectRatio *= xDelta / yDelta;
                 }
             
             } else {
@@ -650,6 +649,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             _windowNDC = GfVec4f(0.f, 0.f, 1.f, 1.f);
         }
     }
+    AiNodeSetFlt(options, str::pixel_aspect_ratio, pixelAspectRatio);
 
     auto checkShader = [&] (AtNode* shader, const AtString& paramName) {
         auto* options = _renderDelegate->GetOptions();


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds support for pixel aspect ratio as a hydra render setting. We need to eventually combine it with some existing code that uses pixel aspect ratio for anamorphic windowNDC settings.

We already have tests with pixel aspect ratio settings, but the testsuite cannot exercise this code path with hydra render settings.

**Issues fixed in this pull request**
Fixes #658 
