### PR TITLE
Return a zero value when an attribute type is not recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [usd#1735](https://github.com/Autodesk/arnold-usd/issues/1735) - Fix usdskel geometry and motion blur interpolation outside the keyframe boundaries.
 - [usd#1524](https://github.com/Autodesk/arnold-usd/issues/1524) - Fix material binding on instances under a SkelRoot
 - [usd#1718](https://github.com/Autodesk/arnold-usd/issues/1718) - Support primvars:arnold attributes in Arnold typed schemas
+- [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a zero value when an attribute type is not recognized
 
 ## [7.2.4.1] - 2023-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [usd#1077](https://github.com/Autodesk/arnold-usd/issues/1077) - Support --threads / -j argument in husk to control the amount of render threads
 - [usd#658](https://github.com/Autodesk/arnold-usd/issues/658) - Support pixel aspect ratio in Hydra
 - [usd#1746](https://github.com/Autodesk/arnold-usd/issues/1746) - Made the behaviour for doubleSided gprims consistent between USD and Hydra
-- [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a zero value when an attribute type is not recognized
+- [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a default value when an attribute type is not recognized
 
 ### Bug fixes
 - [usd#1709](https://github.com/Autodesk/arnold-usd/issues/1709) - Procedural failures if schemas are present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [usd#1077](https://github.com/Autodesk/arnold-usd/issues/1077) - Support --threads / -j argument in husk to control the amount of render threads
 - [usd#658](https://github.com/Autodesk/arnold-usd/issues/658) - Support pixel aspect ratio in Hydra
 - [usd#1746](https://github.com/Autodesk/arnold-usd/issues/1746) - Made the behaviour for doubleSided gprims consistent between USD and Hydra
+- [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a zero value when an attribute type is not recognized
 
 ### Bug fixes
 - [usd#1709](https://github.com/Autodesk/arnold-usd/issues/1709) - Procedural failures if schemas are present
@@ -17,7 +18,6 @@
 - [usd#1735](https://github.com/Autodesk/arnold-usd/issues/1735) - Fix usdskel geometry and motion blur interpolation outside the keyframe boundaries.
 - [usd#1524](https://github.com/Autodesk/arnold-usd/issues/1524) - Fix material binding on instances under a SkelRoot
 - [usd#1718](https://github.com/Autodesk/arnold-usd/issues/1718) - Support primvars:arnold attributes in Arnold typed schemas
-- [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a zero value when an attribute type is not recognized
 
 ## [7.2.4.1] - 2023-10-18
 

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -425,7 +425,7 @@ static inline bool VtValueGetBool(const VtValue& value)
         VtArray<long> array = value.UncheckedGet<VtArray<long>>();
         return array.empty() ? false : (array[0] != 0);   
     }
-    return value.Get<bool>();
+    return false;
 }
 
 static inline float VtValueGetFloat(const VtValue& value)
@@ -451,7 +451,7 @@ static inline float VtValueGetFloat(const VtValue& value)
         VtArray<GfHalf> array = value.UncheckedGet<VtArray<GfHalf>>();
         return array.empty() ? 0.f : static_cast<float>(array[0]);
     }
-    return value.Get<float>();
+    return 0.f;
 }
 
 static inline unsigned char VtValueGetByte(const VtValue& value)
@@ -475,7 +475,7 @@ static inline unsigned char VtValueGetByte(const VtValue& value)
         return array.empty() ? 0 : array[0];   
     }
 
-    return value.Get<unsigned char>();
+    return 0;
 }
 
 static inline int VtValueGetInt(const VtValue& value)
@@ -493,7 +493,7 @@ static inline int VtValueGetInt(const VtValue& value)
         return array.empty() ? 0 : (int) array[0];
     }
 
-    return value.Get<int>();
+    return 0;
 }
 
 static inline unsigned int VtValueGetUInt(const VtValue& value)
@@ -512,7 +512,7 @@ static inline unsigned int VtValueGetUInt(const VtValue& value)
         return array.empty() ? 0 : array[0];   
     }
 
-    return value.Get<unsigned int>();
+    return 0;
 }
 
 static inline GfVec2f VtValueGetVec2f(const VtValue& value)
@@ -543,7 +543,7 @@ static inline GfVec2f VtValueGetVec2f(const VtValue& value)
         return array.empty() ? GfVec2f(0.f, 0.f) : 
             GfVec2f(static_cast<float>(array[0][0]), static_cast<float>(array[0][1]));
     }    
-    return value.Get<GfVec2f>();
+    return GfVec2f(0.f, 0.f);
 }
 
 static inline GfVec3f VtValueGetVec3f(const VtValue& value)
@@ -578,7 +578,7 @@ static inline GfVec3f VtValueGetVec3f(const VtValue& value)
             GfVec3f(static_cast<float>(array[0][0]), 
                 static_cast<float>(array[0][1]), static_cast<float>(array[0][2]));
     }    
-    return value.Get<GfVec3f>();
+    return GfVec3f(0.f, 0.f, 0.f);
 }
 
 static inline GfVec4f VtValueGetVec4f(const VtValue& value)
@@ -613,7 +613,7 @@ static inline GfVec4f VtValueGetVec4f(const VtValue& value)
             GfVec4f(static_cast<float>(array[0][0]), static_cast<float>(array[0][1]), 
                 static_cast<float>(array[0][2]), static_cast<float>(array[0][3]));
     }    
-    return value.Get<GfVec4f>();
+    return GfVec4f(0.f, 0.f, 0.f, 0.f);
 }
 
 static inline std::string _VtValueResolvePath(const SdfAssetPath& assetPath, const UsdAttribute* attr = nullptr)
@@ -686,7 +686,7 @@ static inline std::string VtValueGetString(const VtValue& value, const UsdAttrib
         return _VtValueResolvePath(assetPath, attr);
     }
 
-    return value.Get<std::string>();
+    return std::string();
 }
 
 static inline bool VtValueGetMatrix(const VtValue& value, AtMatrix& matrix)

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -405,7 +405,7 @@ void ReadSubsetsMaterialBinding(
     unsigned int elementCount, bool assignDefault = true);
 
 
-static inline bool VtValueGetBool(const VtValue& value)
+static inline bool VtValueGetBool(const VtValue& value, bool defaultValue = false)
 {
     if (value.IsHolding<bool>())
         return value.UncheckedGet<bool>();
@@ -425,10 +425,10 @@ static inline bool VtValueGetBool(const VtValue& value)
         VtArray<long> array = value.UncheckedGet<VtArray<long>>();
         return array.empty() ? false : (array[0] != 0);   
     }
-    return false;
+    return defaultValue;
 }
 
-static inline float VtValueGetFloat(const VtValue& value)
+static inline float VtValueGetFloat(const VtValue& value, float defaultValue = 0.f)
 {
     if (value.IsHolding<float>())
         return value.UncheckedGet<float>();
@@ -451,10 +451,10 @@ static inline float VtValueGetFloat(const VtValue& value)
         VtArray<GfHalf> array = value.UncheckedGet<VtArray<GfHalf>>();
         return array.empty() ? 0.f : static_cast<float>(array[0]);
     }
-    return 0.f;
+    return defaultValue;
 }
 
-static inline unsigned char VtValueGetByte(const VtValue& value)
+static inline unsigned char VtValueGetByte(const VtValue& value, unsigned char defaultValue = 0)
 {
     if (value.IsHolding<int>())
         return static_cast<unsigned char>(value.UncheckedGet<int>());
@@ -475,10 +475,10 @@ static inline unsigned char VtValueGetByte(const VtValue& value)
         return array.empty() ? 0 : array[0];   
     }
 
-    return 0;
+    return defaultValue;
 }
 
-static inline int VtValueGetInt(const VtValue& value)
+static inline int VtValueGetInt(const VtValue& value, int defaultValue = 0)
 {
     if (value.IsHolding<int>())
         return value.UncheckedGet<int>();
@@ -493,10 +493,10 @@ static inline int VtValueGetInt(const VtValue& value)
         return array.empty() ? 0 : (int) array[0];
     }
 
-    return 0;
+    return defaultValue;
 }
 
-static inline unsigned int VtValueGetUInt(const VtValue& value)
+static inline unsigned int VtValueGetUInt(const VtValue& value, unsigned int defaultValue = 0)
 {
     if (value.IsHolding<unsigned int>()) {
         return value.UncheckedGet<unsigned int>();
@@ -512,10 +512,10 @@ static inline unsigned int VtValueGetUInt(const VtValue& value)
         return array.empty() ? 0 : array[0];   
     }
 
-    return 0;
+    return defaultValue;
 }
 
-static inline GfVec2f VtValueGetVec2f(const VtValue& value)
+static inline GfVec2f VtValueGetVec2f(const VtValue& value, GfVec2f defaultValue = GfVec2f(0.f))
 {
     if (value.IsHolding<GfVec2f>())
         return value.UncheckedGet<GfVec2f>();
@@ -543,10 +543,10 @@ static inline GfVec2f VtValueGetVec2f(const VtValue& value)
         return array.empty() ? GfVec2f(0.f, 0.f) : 
             GfVec2f(static_cast<float>(array[0][0]), static_cast<float>(array[0][1]));
     }    
-    return GfVec2f(0.f, 0.f);
+    return defaultValue;
 }
 
-static inline GfVec3f VtValueGetVec3f(const VtValue& value)
+static inline GfVec3f VtValueGetVec3f(const VtValue& value, const GfVec3f defaultValue = GfVec3f(0.f))
 {
     if (value.IsHolding<GfVec3f>())
         return value.UncheckedGet<GfVec3f>();
@@ -578,10 +578,10 @@ static inline GfVec3f VtValueGetVec3f(const VtValue& value)
             GfVec3f(static_cast<float>(array[0][0]), 
                 static_cast<float>(array[0][1]), static_cast<float>(array[0][2]));
     }    
-    return GfVec3f(0.f, 0.f, 0.f);
+    return defaultValue;
 }
 
-static inline GfVec4f VtValueGetVec4f(const VtValue& value)
+static inline GfVec4f VtValueGetVec4f(const VtValue& value, const GfVec4f defaultValue = GfVec4f(0.f))
 {
     if (value.IsHolding<GfVec4f>())
         return value.UncheckedGet<GfVec4f>();
@@ -613,7 +613,7 @@ static inline GfVec4f VtValueGetVec4f(const VtValue& value)
             GfVec4f(static_cast<float>(array[0][0]), static_cast<float>(array[0][1]), 
                 static_cast<float>(array[0][2]), static_cast<float>(array[0][3]));
     }    
-    return GfVec4f(0.f, 0.f, 0.f, 0.f);
+    return defaultValue;
 }
 
 static inline std::string _VtValueResolvePath(const SdfAssetPath& assetPath, const UsdAttribute* attr = nullptr)


### PR DESCRIPTION
Crashes where reported in ARNOLD-14028, which happen when we try to get the value of an attribute which type isn't supported.
At the moment, after testing specific attribute types in VtValueGet* functions, we do a blind value.Get with the type that we want to convert it to.
But apparently, this can sometimes crash in USD when the types don't match. Now, we're instead returning a 0-value when the value doesn't hold any of the types that are supported