### PR TITLE
Fix windows warning with default CXX_STANDARD

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -393,7 +393,9 @@ if env['_COMPILER'] in ['gcc', 'clang']:
 
 # msvc settings
 elif env['_COMPILER'] == 'msvc':
-    env.Append(CCFLAGS=Split('/std:c++{}'.format(env['CXX_STANDARD'])))
+    cxx_standard = env['CXX_STANDARD'];
+    if cxx_standard != '11':
+        env.Append(CCFLAGS=Split('/std:c++{}'.format(cxx_standard)))
     env.Append(CCFLAGS=Split('/EHsc'))
     env.Append(LINKFLAGS=Split('/Machine:X64'))
     # Ignore all the linking warnings we get on windows, coming from USD


### PR DESCRIPTION
On windows, if CXX_STANDARD is not set, it will default to 11.
The recently introduced code that adds the argument /std:c++ is now dumping a lot of warnings in this case, since this argument
doesn't work with /std:c++11