### PR TITLE
Use VtValueGet functions from the render delegate

### DIFF
--- a/libs/common/parameters_utils.h
+++ b/libs/common/parameters_utils.h
@@ -154,6 +154,8 @@ static inline bool VtValueGetBool(const VtValue& value, bool defaultValue = fals
         return value.UncheckedGet<bool>();
     if (value.IsHolding<int>())
         return value.UncheckedGet<int>() != 0;
+    if (value.IsHolding<unsigned int>())
+        return value.UncheckedGet<unsigned int>() != 0;
     if (value.IsHolding<long>())
         return value.UncheckedGet<long>() != 0;
     if (value.IsHolding<VtArray<bool>>()) {
@@ -162,6 +164,10 @@ static inline bool VtValueGetBool(const VtValue& value, bool defaultValue = fals
     }
     if (value.IsHolding<VtArray<int>>()) {
         VtArray<int> array = value.UncheckedGet<VtArray<int>>();
+        return array.empty() ? false : (array[0] != 0);
+    }
+    if (value.IsHolding<VtArray<unsigned int>>()) {
+        VtArray<unsigned int> array = value.UncheckedGet<VtArray<unsigned int>>();
         return array.empty() ? false : (array[0] != 0);
     }
     if (value.IsHolding<VtArray<long>>()) {
@@ -199,6 +205,7 @@ static inline float VtValueGetFloat(const VtValue& value, float defaultValue = 0
 
 static inline unsigned char VtValueGetByte(const VtValue& value, unsigned char defaultValue = 0)
 {
+    //uint8_t, int, unsigned char, long, unsigned int>
     if (value.IsHolding<int>())
         return static_cast<unsigned char>(value.UncheckedGet<int>());
     if (value.IsHolding<long>())

--- a/libs/common/parameters_utils.h
+++ b/libs/common/parameters_utils.h
@@ -187,7 +187,7 @@ inline bool VtValueGet(const VtValue& value, CastTo& data)
 static inline bool VtValueGetBool(const VtValue& value, bool defaultValue = false)
 {   
     if (!value.IsEmpty())
-        VtValueGet<bool, int, unsigned int, long>(value, defaultValue);
+        VtValueGet<bool, int, unsigned int, char, unsigned char, long, unsigned long>(value, defaultValue);
     return defaultValue;
 }
 
@@ -202,7 +202,7 @@ static inline float VtValueGetFloat(const VtValue& value, float defaultValue = 0
 static inline unsigned char VtValueGetByte(const VtValue& value, unsigned char defaultValue = 0)
 {
     if (!value.IsEmpty())
-        VtValueGet<unsigned char, uint8_t, int, long, unsigned int>(value, defaultValue);
+        VtValueGet<unsigned char, int, unsigned int, uint8_t, char, long, unsigned long>(value, defaultValue);
 
     return defaultValue;
 }
@@ -210,7 +210,7 @@ static inline unsigned char VtValueGetByte(const VtValue& value, unsigned char d
 static inline int VtValueGetInt(const VtValue& value, int defaultValue = 0)
 {
     if (!value.IsEmpty())
-        VtValueGet<int, long, unsigned int, unsigned char>(value, defaultValue);
+        VtValueGet<int, long, unsigned int, unsigned char, char, unsigned long>(value, defaultValue);
 
     return defaultValue;
 }
@@ -218,7 +218,7 @@ static inline int VtValueGetInt(const VtValue& value, int defaultValue = 0)
 static inline unsigned int VtValueGetUInt(const VtValue& value, unsigned int defaultValue = 0)
 {
     if (!value.IsEmpty())
-        VtValueGet<unsigned int, int, unsigned char>(value, defaultValue);
+        VtValueGet<unsigned int, int, unsigned char, char, unsigned long, long>(value, defaultValue);
 
     return defaultValue;
 }

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -64,118 +64,6 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 
 namespace {
 
-auto nodeSetByteFromInt = [](AtNode* node, const AtString paramName, int v) {
-    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
-};
-auto nodeSetByteFromUChar = [](AtNode* node, const AtString paramName, unsigned char v) {
-    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
-};
-auto nodeSetByteFromLong = [](AtNode* node, const AtString paramName, long v) {
-    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
-};
-auto nodeSetByteFromUInt = [](AtNode* node, const AtString paramName, unsigned int v) {
-    AiNodeSetByte(node, paramName, static_cast<uint8_t>(v));
-};
-auto nodeSetIntFromLong = [](AtNode* node, const AtString paramName, long v) {
-    AiNodeSetInt(node, paramName, static_cast<int>(v));
-};
-auto nodeSetIntFromUInt = [](AtNode* node, const AtString paramName, unsigned int v) {
-    AiNodeSetInt(node, paramName, static_cast<unsigned int>(v));
-};
-auto nodeSetUIntFromInt = [](AtNode* node, const AtString paramName, int v) {
-    AiNodeSetUInt(node, paramName, static_cast<unsigned int>(std::max(0, v)));
-};
-auto nodeSetStrFromToken = [](AtNode* node, const AtString paramName, TfToken v) {
-    AiNodeSetStr(node, paramName, AtString(v.GetText()));
-};
-auto nodeSetStrFromStdStr = [](AtNode* node, const AtString paramName, const std::string& v) {
-    AiNodeSetStr(node, paramName, AtString(v.c_str()));
-};
-auto nodeSetBoolFromInt = [](AtNode* node, const AtString paramName, int v) { AiNodeSetBool(node, paramName, v != 0); };
-auto nodeSetBoolFromUInt = [](AtNode* node, const AtString paramName, unsigned int v) {
-    AiNodeSetBool(node, paramName, v != 0);
-};
-auto nodeSetBoolFromLong = [](AtNode* node, const AtString paramName, long v) {
-    AiNodeSetBool(node, paramName, v != 0);
-};
-auto nodeSetFltFromHalf = [](AtNode* node, const AtString paramName, GfHalf v) {
-    AiNodeSetFlt(node, paramName, static_cast<float>(v));
-};
-auto nodeSetFltFromDouble = [](AtNode* node, const AtString paramName, double v) {
-    AiNodeSetFlt(node, paramName, static_cast<float>(v));
-};
-auto nodeSetRGBFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
-    AiNodeSetRGB(node, paramName, v[0], v[1], v[2]);
-};
-auto nodeSetRGBAFromVec4 = [](AtNode* node, const AtString paramName, const GfVec4f& v) {
-    AiNodeSetRGBA(node, paramName, v[0], v[1], v[2], v[3]);
-};
-auto nodeSetVecFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
-    AiNodeSetVec(node, paramName, v[0], v[1], v[2]);
-};
-auto nodeSetVec2FromVec2 = [](AtNode* node, const AtString paramName, const GfVec2f& v) {
-    AiNodeSetVec2(node, paramName, v[0], v[1]);
-};
-auto nodeSetRGBFromVec3h = [](AtNode* node, const AtString paramName, const GfVec3h& v) {
-    AiNodeSetRGB(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-};
-auto nodeSetRGBAFromVec4h = [](AtNode* node, const AtString paramName, const GfVec4h& v) {
-    AiNodeSetRGBA(
-        node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]),
-        static_cast<float>(v[3]));
-};
-auto nodeSetVecFromVec3h = [](AtNode* node, const AtString paramName, const GfVec3h& v) {
-    AiNodeSetVec(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-};
-auto nodeSetVec2FromVec2h = [](AtNode* node, const AtString paramName, const GfVec2h& v) {
-    AiNodeSetVec2(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]));
-};
-auto nodeSetRGBFromVec3d = [](AtNode* node, const AtString paramName, const GfVec3d& v) {
-    AiNodeSetRGB(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-};
-auto nodeSetRGBAFromVec4d = [](AtNode* node, const AtString paramName, const GfVec4d& v) {
-    AiNodeSetRGBA(
-        node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]),
-        static_cast<float>(v[3]));
-};
-auto nodeSetVecFromVec3d = [](AtNode* node, const AtString paramName, const GfVec3d& v) {
-    AiNodeSetVec(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-};
-auto nodeSetVec2FromVec2d = [](AtNode* node, const AtString paramName, const GfVec2d& v) {
-    AiNodeSetVec2(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]));
-};
-
-auto nodeSetRGBFromVec4 = [](AtNode* node, const AtString paramName, const GfVec4f& v) {
-    AiNodeSetRGB(node, paramName, v[0], v[1], v[2]);
-};
-auto nodeSetRGBFromVec4d = [](AtNode* node, const AtString paramName, const GfVec4d& v) {
-    AiNodeSetRGB(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-};
-
-auto nodeSetRGBAFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
-    AiNodeSetRGBA(node, paramName, v[0], v[1], v[2], 1.f);
-};
-auto nodeSetRGBAFromVec3d = [](AtNode* node, const AtString paramName, const GfVec3d& v) {
-    AiNodeSetRGBA(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]), 1.f);
-};
-
-
-auto nodeSetMatrixFromMatrix4f = [](AtNode* node, const AtString paramName, const GfMatrix4f& m) {
-    AtMatrix atMatrix;
-    std::copy_n(m.data(), 16, &atMatrix.data[0][0]);
-    AiNodeSetMatrix(node, paramName, atMatrix);
-};
-
-auto nodeSetMatrixFromMatrix4d = [](AtNode* node, const AtString paramName, const GfMatrix4d& m) {
-    AiNodeSetMatrix(node, paramName, HdArnoldConvertMatrix(m));
-};
-
-auto nodeSetStrFromAssetPath = [](AtNode* node, const AtString paramName, const SdfAssetPath& v) {
-    AiNodeSetStr(
-        node, paramName,
-        v.GetResolvedPath().empty() ? AtString(v.GetAssetPath().c_str()) : AtString(v.GetResolvedPath().c_str()));
-};
-
 const std::vector<HdInterpolation> primvarInterpolations{
     HdInterpolationConstant, HdInterpolationUniform,     HdInterpolationVarying,
     HdInterpolationVertex,   HdInterpolationFaceVarying, HdInterpolationInstance,
@@ -801,39 +689,6 @@ inline bool _TokenStartsWithToken(const TfToken& t0, const TfToken& t1)
 
 inline bool _CharStartsWithToken(const char* c, const TfToken& t) { return strncmp(c, t.GetText(), t.size()) == 0; }
 
-// We are using function pointers instead of template arguments to deduct the function type, because
-// Arnold's AiNodeSetXXX functions have overrides in the form of, void (*) (AtNode*, const char*, T v) and
-// void (*) (AtNode*, AtString, T v), so the compiler is unable to deduct which function to use.
-// Using function pointers to force deduction is the easiest way, yet lambdas are still inlined.
-// This way, we can still use AiNodeSetXXX functions where possible, and we only need to create a handful
-// of functions to wrap the more complex type conversions.
-template <typename T>
-inline bool _SetFromValueOrArray(
-    AtNode* node, const AtString& paramName, const VtValue& value, void (*f)(AtNode*, const AtString, T))
-{
-    using CT = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
-    if (value.IsHolding<CT>()) {
-        f(node, paramName, value.UncheckedGet<CT>());
-    } else if (value.IsHolding<VtArray<CT>>()) {
-        const auto& arr = value.UncheckedGet<VtArray<CT>>();
-        if (!arr.empty()) {
-            f(node, paramName, arr[0]);
-        }
-    } else {
-        return false;
-    }
-    return true;
-}
-
-template <typename T0, typename... T>
-inline bool _SetFromValueOrArray(
-    AtNode* node, const AtString& paramName, const VtValue& value, void (*f0)(AtNode*, const AtString, T0),
-    void (*... fs)(AtNode*, const AtString, T))
-{
-    return _SetFromValueOrArray<T0>(node, paramName, value, std::forward<decltype(f0)>(f0)) ||
-           _SetFromValueOrArray<T...>(node, paramName, value, std::forward<decltype(fs)>(fs)...);
-}
-
 inline size_t _ExtrapolatePositions(
     AtNode* node, const AtString& paramName, HdArnoldSampledType<VtVec3fArray>& xf, const HdArnoldRenderParam* param,
     int deformKeys, const HdArnoldPrimvarMap* primvars)
@@ -1075,8 +930,12 @@ void HdArnoldSetTransform(const std::vector<AtNode*>& nodes, HdSceneDelegate* sc
 void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValue& value, 
     HdArnoldRenderDelegate *renderDelegate)
 {
+    if (value.IsEmpty())
+        return;
+
     const auto paramName = AiParamGetName(pentry);
     const auto paramType = AiParamGetType(pentry);
+
     if (paramType == AI_TYPE_ARRAY) {
         auto* defaultParam = AiParamGetDefault(pentry);
         if (defaultParam->ARRAY() == nullptr) {

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -49,6 +49,7 @@
 #include "render_delegate.h"
 
 #include <type_traits>
+#include <parameters_utils.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -1205,66 +1206,65 @@ void HdArnoldSetParameter(AtNode* node, const AtParamEntry* pentry, const VtValu
     }
     switch (paramType) {
         case AI_TYPE_BYTE:
-            _SetFromValueOrArray<uint8_t, int, unsigned char, long, unsigned int>(
-                node, paramName, value, AiNodeSetByte, nodeSetByteFromInt, nodeSetByteFromUChar, nodeSetByteFromLong,
-                nodeSetByteFromUInt);
+            AiNodeSetByte(node, paramName, VtValueGetByte(value));
             break;
         case AI_TYPE_INT:
-            _SetFromValueOrArray<int, long, unsigned int>(
-                node, paramName, value, AiNodeSetInt, nodeSetIntFromLong, nodeSetIntFromUInt);
+            AiNodeSetInt(node, paramName, VtValueGetInt(value));
             break;
         case AI_TYPE_UINT:
         case AI_TYPE_USHORT:
-            _SetFromValueOrArray<unsigned int, int>(node, paramName, value, AiNodeSetUInt, nodeSetUIntFromInt);
+            AiNodeSetUInt(node, paramName, VtValueGetUInt(value));
             break;
         case AI_TYPE_BOOLEAN:
-            _SetFromValueOrArray<bool, int, unsigned int, long>(
-                node, paramName, value, AiNodeSetBool, nodeSetBoolFromInt, nodeSetBoolFromUInt, nodeSetBoolFromLong);
+            AiNodeSetBool(node, paramName, VtValueGetBool(value));
             break;
         case AI_TYPE_FLOAT:
         case AI_TYPE_HALF:
-            _SetFromValueOrArray<float, GfHalf, double>(
-                node, paramName, value, AiNodeSetFlt, nodeSetFltFromHalf, nodeSetFltFromDouble);
+            AiNodeSetFlt(node, paramName, VtValueGetFloat(value));
             break;
-        case AI_TYPE_RGB:
-            if (!_SetFromValueOrArray<const GfVec3f&, const GfVec3h&, const GfVec3d&>(
-                node, paramName, value, nodeSetRGBFromVec3, nodeSetRGBFromVec3h, nodeSetRGBFromVec3d)) {
-
-                _SetFromValueOrArray<const GfVec4f&, const GfVec4d&>(
-                    node, paramName, value, nodeSetRGBFromVec4, nodeSetRGBFromVec4d);
+        case AI_TYPE_RGB: {
+            GfVec3f vec = VtValueGetVec3f(value);
+            AiNodeSetRGB(node, paramName, vec[0], vec[1], vec[2]);
+            break;
+        }
+        case AI_TYPE_RGBA: {
+            GfVec4f vec = VtValueGetVec4f(value);
+            AiNodeSetRGBA(node, paramName, vec[0], vec[1], vec[2], vec[3]);
+            break;
+        }
+        case AI_TYPE_VECTOR: {
+            GfVec3f vec = VtValueGetVec3f(value);
+            AiNodeSetVec(node, paramName, vec[0], vec[1], vec[2]);
+            break;
+        }
+        case AI_TYPE_VECTOR2: {
+            GfVec2f vec = VtValueGetVec2f(value);
+            AiNodeSetVec2(node, paramName, vec[0], vec[1]);
+            break;
+        }
+        case AI_TYPE_ENUM:
+            if (value.IsHolding<int>()) {
+                AiNodeSetInt(node, paramName, value.UncheckedGet<int>());
+                break;
+            } else if (value.IsHolding<long>()) {
+                AiNodeSetInt(node, paramName, value.UncheckedGet<long>());
+                break;
             }
+            // Enums can be strings, so we don't break here.
+        case AI_TYPE_STRING: {
+            std::string str = VtValueGetString(value);
+            AiNodeSetStr(node, paramName, AtString(str.c_str()));
             break;
-        case AI_TYPE_RGBA:
-            if (!_SetFromValueOrArray<const GfVec4f&, const GfVec4h&, const GfVec4d&>(
-                node, paramName, value, nodeSetRGBAFromVec4, nodeSetRGBAFromVec4h, nodeSetRGBAFromVec4d)) {
-
-                _SetFromValueOrArray<const GfVec3f&, const GfVec3d&>(
-                    node, paramName, value, nodeSetRGBAFromVec3, nodeSetRGBAFromVec3d);
-            }
-            break;
-        case AI_TYPE_VECTOR:
-            _SetFromValueOrArray<const GfVec3f&, const GfVec3h&, const GfVec3d&>(
-                node, paramName, value, nodeSetVecFromVec3, nodeSetVecFromVec3h, nodeSetVecFromVec3d);
-            break;
-        case AI_TYPE_VECTOR2:
-            _SetFromValueOrArray<const GfVec2f&, const GfVec2h&, const GfVec2d&>(
-                node, paramName, value, nodeSetVec2FromVec2, nodeSetVec2FromVec2h, nodeSetVec2FromVec2d);
-            break;
-        case AI_TYPE_STRING:
-            _SetFromValueOrArray<TfToken, const SdfAssetPath&, const std::string&>(
-                node, paramName, value, nodeSetStrFromToken, nodeSetStrFromAssetPath, nodeSetStrFromStdStr);
-            break;
+        }
         case AI_TYPE_POINTER:
         case AI_TYPE_NODE:
             break; // TODO(pal): Should be in the relationships list.
-        case AI_TYPE_MATRIX:
-            _SetFromValueOrArray<const GfMatrix4d&, const GfMatrix4f&>(
-                node, paramName, value, nodeSetMatrixFromMatrix4d, nodeSetMatrixFromMatrix4f);
+        case AI_TYPE_MATRIX: {
+            AtMatrix aiMat;
+            if (VtValueGetMatrix(value, aiMat))
+                AiNodeSetMatrix(node, paramName, aiMat);
             break;
-        case AI_TYPE_ENUM:
-            _SetFromValueOrArray<int, long, TfToken, const std::string&>(
-                node, paramName, value, AiNodeSetInt, nodeSetIntFromLong, nodeSetStrFromToken, nodeSetStrFromStdStr);
-            break;
+        }
         case AI_TYPE_CLOSURE:
             break; // Should be in the relationships list.
         default:

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -64,6 +64,65 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 
 namespace {
 
+auto nodeSetStrFromToken = [](AtNode* node, const AtString paramName, TfToken v) {
+    AiNodeSetStr(node, paramName, AtString(v.GetText()));
+};
+auto nodeSetStrFromStdStr = [](AtNode* node, const AtString paramName, const std::string& v) {
+    AiNodeSetStr(node, paramName, AtString(v.c_str()));
+};
+auto nodeSetFltFromHalf = [](AtNode* node, const AtString paramName, GfHalf v) {
+    AiNodeSetFlt(node, paramName, static_cast<float>(v));
+};
+auto nodeSetFltFromDouble = [](AtNode* node, const AtString paramName, double v) {
+    AiNodeSetFlt(node, paramName, static_cast<float>(v));
+};
+auto nodeSetRGBFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
+    AiNodeSetRGB(node, paramName, v[0], v[1], v[2]);
+};
+auto nodeSetRGBAFromVec4 = [](AtNode* node, const AtString paramName, const GfVec4f& v) {
+    AiNodeSetRGBA(node, paramName, v[0], v[1], v[2], v[3]);
+};
+auto nodeSetVecFromVec3 = [](AtNode* node, const AtString paramName, const GfVec3f& v) {
+    AiNodeSetVec(node, paramName, v[0], v[1], v[2]);
+};
+auto nodeSetVec2FromVec2 = [](AtNode* node, const AtString paramName, const GfVec2f& v) {
+    AiNodeSetVec2(node, paramName, v[0], v[1]);
+};
+auto nodeSetRGBFromVec3h = [](AtNode* node, const AtString paramName, const GfVec3h& v) {
+    AiNodeSetRGB(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+};
+auto nodeSetRGBAFromVec4h = [](AtNode* node, const AtString paramName, const GfVec4h& v) {
+    AiNodeSetRGBA(
+        node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]),
+        static_cast<float>(v[3]));
+};
+auto nodeSetVecFromVec3h = [](AtNode* node, const AtString paramName, const GfVec3h& v) {
+    AiNodeSetVec(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+};
+auto nodeSetVec2FromVec2h = [](AtNode* node, const AtString paramName, const GfVec2h& v) {
+    AiNodeSetVec2(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]));
+};
+auto nodeSetRGBFromVec3d = [](AtNode* node, const AtString paramName, const GfVec3d& v) {
+    AiNodeSetRGB(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+};
+auto nodeSetRGBAFromVec4d = [](AtNode* node, const AtString paramName, const GfVec4d& v) {
+    AiNodeSetRGBA(
+        node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]),
+        static_cast<float>(v[3]));
+};
+auto nodeSetVecFromVec3d = [](AtNode* node, const AtString paramName, const GfVec3d& v) {
+    AiNodeSetVec(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+};
+auto nodeSetVec2FromVec2d = [](AtNode* node, const AtString paramName, const GfVec2d& v) {
+    AiNodeSetVec2(node, paramName, static_cast<float>(v[0]), static_cast<float>(v[1]));
+};
+
+auto nodeSetStrFromAssetPath = [](AtNode* node, const AtString paramName, const SdfAssetPath& v) {
+    AiNodeSetStr(
+        node, paramName,
+        v.GetResolvedPath().empty() ? AtString(v.GetAssetPath().c_str()) : AtString(v.GetResolvedPath().c_str()));
+};
+
 const std::vector<HdInterpolation> primvarInterpolations{
     HdInterpolationConstant, HdInterpolationUniform,     HdInterpolationVarying,
     HdInterpolationVertex,   HdInterpolationFaceVarying, HdInterpolationInstance,


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR removes the delegate's specific conversion functions, and uses instead the VtValueGet* functions.
It's a first step to factorize even more both code paths (e.g. the whole HdArnoldSetParameter function)

**Issues fixed in this pull request**
Fixes #1767
