### PR TITLE
Allow scons compilation without USD_BIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [usd#1769](https://github.com/Autodesk/arnold-usd/issues/1769) - Fix curve uvs when they are vertex interpolated.
 - [usd#1784](https://github.com/Autodesk/arnold-usd/issues/1784) - The aov layer name is now correctly taken into account when rendering exrs with husk and using the arnold productType.
 
+### Build
+- [usd#1793](https://github.com/Autodesk/arnold-usd/issues/1793) - Enable compiling arnold-usd without USD_BIN.
 
 ## [7.2.5.0] - 2023-12-13
 

--- a/SConstruct
+++ b/SConstruct
@@ -78,7 +78,7 @@ vars.AddVariables(
     PathVariable('USD_PATH', 'USD installation root', os.getenv('USD_PATH', None)),
     PathVariable('USD_INCLUDE', 'Where to find USD includes', os.path.join('$USD_PATH', 'include'), PathVariable.PathIsDir),
     PathVariable('USD_LIB', 'Where to find USD libraries', os.path.join('$USD_PATH', 'lib'), PathVariable.PathIsDir),
-    PathVariable('USD_BIN', 'Where to find USD binaries', os.path.join('$USD_PATH', 'bin'), PathVariable.PathIsDir),   
+    StringVariable('USD_BIN', 'Where to find USD binaries', os.path.join('$USD_PATH', 'bin')),   
     EnumVariable('USD_BUILD_MODE', 'Build mode of USD libraries', 'monolithic', allowed_values=('shared_libs', 'monolithic', 'static')),
     StringVariable('USD_LIB_PREFIX', 'USD library prefix', 'lib'),
     BoolVariable('INSTALL_USD_PLUGIN_RESOURCES', 'Also install the content $USD_PATH/plugin/usd', False),


### PR DESCRIPTION
**Changes proposed in this pull request**
- Replace USD_BIN PathVariable by a StringVariable which won't check if the path exists.

**Issues fixed in this pull request**
Fixes #1793 
