### PR TITLE
Replace ComputePointsAtTime with a manual extrapolation of positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [usd#1776](https://github.com/Autodesk/arnold-usd/issues/1776) - Fix incorrect PointInstancer instance orientations in the render delegate.
 - [usd#1769](https://github.com/Autodesk/arnold-usd/issues/1769) - Fix curve uvs when they are vertex interpolated.
 - [usd#1784](https://github.com/Autodesk/arnold-usd/issues/1784) - The aov layer name is now correctly taken into account when rendering exrs with husk and using the arnold productType.
+- [usd#1801](https://github.com/Autodesk/arnold-usd/issues/1801) - Fix velocities computation with USD 23.11
 
 ### Build
 - [usd#1795](https://github.com/Autodesk/arnold-usd/issues/1795) - Fix compilation issue on macOS with clang 15.0.7.


### PR DESCRIPTION
Instead of calling `UsdGeomPointBased::ComputePointsAtTime`, we are now extrapolating the positions manually based on velocities, and optionally accelerations. This is fixing the testsuite with USD 23.11

**Issues fixed in this pull request**
Fixes #1801 
