### PR TITLE
Extend the WriteUsdStageCache API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [usd#1758](https://github.com/Autodesk/arnold-usd/issues/1758) - Return a default value when an attribute type is not recognized
 - [usd#1759](https://github.com/Autodesk/arnold-usd/issues/1759) - Remove GeometryLight usd imaging adapter
 - [usd#1705](https://github.com/Autodesk/arnold-usd/issues/1705) - Support Point instancers having lights as prototypes
+- [usd#1806](https://github.com/Autodesk/arnold-usd/issues/1806) - Extend the WriteUsdStageCache API
 
 ### Bug fixes
 - [usd#1756](https://github.com/Autodesk/arnold-usd/issues/1756) - Registry should declare filenames as assets in GetTypeAsSdfType 

--- a/libs/translator/writer/writer.h
+++ b/libs/translator/writer/writer.h
@@ -219,7 +219,7 @@ private:
     std::unordered_set<std::string> _exportedNodes; // List of node names that were exported (including material scope)
     std::unordered_set<const AtNode *> _exportedShaders; // list of shader nodes that were exported
     std::string _scope;                // scope in which the primitives must be written
-    std::string _mtlScope;             // specific scope for materials (on top of the eventual generic scope)
+    std::string _mtlScope = "/mtl";    // specific scope for materials (on top of the eventual generic scope)
     std::string _stripHierarchy;       // When writing out a primitive, strip a given hierarchy from the arnold node name
     bool _allAttributes;               // write all attributes to usd prims, even if they're left to default
     UsdTimeCode _time;                 // current time required by client code

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -304,10 +304,8 @@ extern "C"
                 writer.SetScope(std::string(scope.c_str()));
 
             AtString mtlScope;
-            if (!AiParamValueMapGetStr(params, str::mtl_scope, &mtlScope))
-                mtlScope = AtString("/mtl");
-
-            writer.SetMtlScope(std::string(mtlScope.c_str()));
+            if (AiParamValueMapGetStr(params, str::mtl_scope, &mtlScope))
+                writer.SetMtlScope(std::string(mtlScope.c_str()));
 
             AtString defaultPrim;
             if (AiParamValueMapGetStr(params, str::defaultPrim, &defaultPrim))
@@ -461,10 +459,8 @@ scene_write
             writer->SetScope(std::string(scope.c_str()));
 
         AtString mtlScope;
-        if (!AiParamValueMapGetStr(params, str::mtl_scope, &mtlScope))
-            mtlScope = AtString("/mtl");
-
-        writer->SetMtlScope(std::string(mtlScope.c_str()));
+        if (AiParamValueMapGetStr(params, str::mtl_scope, &mtlScope))
+            writer->SetMtlScope(std::string(mtlScope.c_str()));
 
         AtString defaultPrim;
         if (AiParamValueMapGetStr(params, str::defaultPrim, &defaultPrim))

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -274,7 +274,7 @@ std::string USDLibraryPath()
 
 extern "C"
 {
-    DLLEXPORT void WriteUsdStageCache ( int cacheId, bool defaultFrame, float frame )
+    DLLEXPORT void WriteUsdStageCache ( int cacheId, const AtParamValueMap* params )
     {
         // Get the UsdStageCache, it's common to all libraries linking against the same USD libs
         UsdStageCache &stageCache = UsdUtilsStageCache::Get();
@@ -289,8 +289,35 @@ extern "C"
         UsdArnoldWriter writer;
         writer.SetUsdStage(stage); 
 
-        if (!defaultFrame)
-            writer.SetFrame(frame);
+        if (params) {
+            // eventually check the input param map in case we have an entry for "frame"
+            float frame = 0.f;
+            if (AiParamValueMapGetFlt(params, str::frame, &frame))
+                writer.SetFrame(frame);
+            
+            int mask = AI_NODE_ALL;
+            if (AiParamValueMapGetInt(params, str::mask, &mask))
+                writer.SetMask(mask);
+            
+            AtString scope;
+            if (AiParamValueMapGetStr(params, str::scope, &scope))
+                writer.SetScope(std::string(scope.c_str()));
+
+            AtString mtlScope;
+            if (!AiParamValueMapGetStr(params, str::mtl_scope, &mtlScope))
+                mtlScope = AtString("/mtl");
+
+            writer.SetMtlScope(std::string(mtlScope.c_str()));
+
+            AtString defaultPrim;
+            if (AiParamValueMapGetStr(params, str::defaultPrim, &defaultPrim))
+                writer.SetDefaultPrim(std::string(defaultPrim.c_str()));
+
+            bool allAttributes;
+            if (AiParamValueMapGetBool(params, str::all_attributes, &allAttributes))
+                writer.SetWriteAllAttributes(allAttributes);
+        }
+            
         writer.Write(nullptr);
     }
 };


### PR DESCRIPTION
The WriteUsdStageCache API isn't exercised yet, it's meant to be used by MtoA and MAXtoA to avoid linking against USD.
It just had a "frame" argument hardcoded, but we actually want to extend it to have roughly the same set of optional parameters as `scene_write` . For that we use now a `AtParamValueMap` so that any argument can be added without changing the API signature. Since this isn't exercised yet, it might not be useful to add a note in the changelog