### PR TITLE
Fix the error "Cannot load _htoa_pygeo library required for volume rendering in Solaris" in houdini 19.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 - [usd#1776](https://github.com/Autodesk/arnold-usd/issues/1776) - Fix incorrect PointInstancer instance orientations in the render delegate.
 - [usd#1769](https://github.com/Autodesk/arnold-usd/issues/1769) - Fix curve uvs when they are vertex interpolated.
+- [usd#1808](https://github.com/Autodesk/arnold-usd/issues/1808) - Fix the error "Cannot load _htoa_pygeo library required for volume rendering in Solaris" in Houdini 19.5+.
 
 ## [7.2.5.0] - 2023-12-13
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Look into subfolders named against more recent version of python.
- This is not a future proof solution and we should find a better alternative with HTOA.

**Issues fixed in this pull request**
Fixes #1808

