### PR TITLE
Restore previous testsuite behaviour with abort on license fail

### DIFF
--- a/testsuite/test_0038/data/test.cpp
+++ b/testsuite/test_0038/data/test.cpp
@@ -12,7 +12,8 @@ int main(int argc, char **argv)
     AtUniverse *proc_universe = AiUniverse();
     AtUniverse *render_universe = AiUniverse();
     AtRenderSession *render_session = AiRenderSession(render_universe);
-
+    AiNodeSetBool(AiUniverseGetOptions(render_universe), AtString("abort_on_license_fail"), false);
+        
     AiSceneLoad(render_universe, "scene.ass", nullptr);
     // load the usd procedural (containing a sphere) in a separate universe
     AtNode *proc_a = AiNode(proc_universe, "usd", "usd_proc_a");

--- a/testsuite/test_0142/data/test.cpp
+++ b/testsuite/test_0142/data/test.cpp
@@ -27,6 +27,7 @@ int main(int argc, char **argv)
     AiProceduralViewport(proc, render_universe, AI_PROC_POLYGONS);
 
     AiUniverseDestroy(proc_universe);
+    AiNodeSetBool(AiUniverseGetOptions(render_universe), AtString("abort_on_license_fail"), false);    
     AiRender(render_session);
     AiRenderSessionDestroy(render_session);
     AiUniverseDestroy(render_universe);

--- a/testsuite/test_0161/data/test.cpp
+++ b/testsuite/test_0161/data/test.cpp
@@ -25,6 +25,7 @@ int main(int argc, char **argv)
     AiProceduralViewport(proc2, render_universe, AI_PROC_POLYGONS);
 
     AiUniverseDestroy(proc_universe);
+    AiNodeSetBool(AiUniverseGetOptions(render_universe), AtString("abort_on_license_fail"), false);
     AiRender(render_session);
     AiRenderSessionDestroy(render_session);
     AiUniverseDestroy(render_universe);

--- a/testsuite/test_0162/data/test.cpp
+++ b/testsuite/test_0162/data/test.cpp
@@ -23,6 +23,7 @@ int main(int argc, char **argv)
     AiProceduralViewport(proc, render_universe, AI_PROC_POINTS, params);
 
     AiUniverseDestroy(proc_universe);
+    AiNodeSetBool(AiUniverseGetOptions(render_universe), AtString("abort_on_license_fail"), false);
     AiRender(render_session);
     AiRenderSessionDestroy(render_session);
     AiUniverseDestroy(render_universe);

--- a/testsuite/test_0168/data/test.cpp
+++ b/testsuite/test_0168/data/test.cpp
@@ -22,6 +22,7 @@ int main(int argc, char **argv)
     AiProceduralViewport(proc_a, render_universe, AI_PROC_POLYGONS);
 
     AiUniverseDestroy(proc_universe);
+    AiNodeSetBool(AiUniverseGetOptions(render_universe), AtString("abort_on_license_fail"), false);
     AiRender(render_session);
 
     AiRenderSessionDestroy(render_session);

--- a/testsuite/test_0180/data/test.cpp
+++ b/testsuite/test_0180/data/test.cpp
@@ -34,6 +34,8 @@ int main(int argc, char **argv)
             AiMsgError("Wrong outputs : %s, %s", val1.c_str(), val2.c_str());
         }
     }
+    AiNodeSetBool(AiUniverseGetOptions(nullptr), AtString("abort_on_license_fail"), false);
+    
     if (success)
         AiRender(nullptr);
     AiEnd();

--- a/testsuite/test_1346/README
+++ b/testsuite/test_1346/README
@@ -4,5 +4,5 @@ See #1346
 
 author: cyril.pichard@autodesk.com 
 
-PARAMS: {'script':'kick test.usda -dw -dp -v 6', 'scene':'test.usda', 'reference_image':'ref/reference.jpg', 'output_image':"sphere.jpg"}
+PARAMS: {'script':'kick test.usda -dw -sl -dp -v 6', 'scene':'test.usda', 'reference_image':'ref/reference.jpg', 'output_image':"sphere.jpg"}
 

--- a/tools/utils/regression_test.py
+++ b/tools/utils/regression_test.py
@@ -90,7 +90,7 @@ class Test:
 
    # This function is called when the script was not especified (self.script is null)
    def generate_command_line(self, test_dir):
-      params = ['-dw', '-r 160 120', '-sm lambert', '-bs 16']
+      params = ['-dw', '-r 160 120', '-sm lambert', '-bs 16', '-sl']
       
       params += {
          '.exr' : ['-o %s' % self.output_image],


### PR DESCRIPTION
abort_on_license_fail now defaults to true. This PR sets it back to the previous behaviour during the testsuite.