### PR TITLE
Fix compilation against older USD cuts

### DIFF
--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -41,7 +41,9 @@
 #else
 #include <pxr/usd/usdLux/light.h>
 #endif
+#if PXR_VERSION >= 2302
 #include <pxr/usd/usdLux/lightAPI.h>
+#endif
 
 #include <constant_strings.h>
 #include <shape_utils.h>

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -35,8 +35,12 @@
 #include <pxr/base/gf/rotation.h>
 #include <pxr/base/gf/transform.h>
 #include <pxr/base/tf/stringUtils.h>
+#if PXR_VERSION >= 2111
 #include <pxr/usd/usdLux/nonboundableLightBase.h>
 #include <pxr/usd/usdLux/boundableLightBase.h>
+#else
+#include <pxr/usd/usdLux/light.h>
+#endif
 #include <pxr/usd/usdLux/lightAPI.h>
 
 #include <constant_strings.h>
@@ -1388,10 +1392,15 @@ AtNode* UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderCo
         // There are currently different ways of having light primitives in USD.
         // Typed schemas can derive from UsdLuxBoundableLightBase or UsdLuxNonboundableLightBase.
         // But the LightAPI schema can also be applied to any primitive
-        if (protoPrim.IsA<UsdLuxBoundableLightBase>() || 
+        if (
+#if PXR_VERSION >= 2111
+            protoPrim.IsA<UsdLuxBoundableLightBase>() || 
             protoPrim.IsA<UsdLuxNonboundableLightBase>() 
 #if PXR_VERSION >= 2302
             || protoPrim.HasAPI(_tokens->LightAPI)
+#endif
+#else
+            protoPrim.IsA<UsdLuxLight>()      
 #endif
             ) {
             


### PR DESCRIPTION
We need to put some more ifdefs on the lights translator code, to support older versions of USD