### PR TITLE
Skip license check during testsuite

### DIFF
--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -155,6 +155,7 @@ def run_test(target, source, env):
    # (see #5658).
    local_env['ADCLMHUB_LOG_DIR']   = test_dir
    local_env['ADCLMHUB_LOG_LEVEL'] = 'T'
+   local_env['ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL'] = '0'
 
    # Disable ADP for the tests
    local_env['ARNOLD_ADP_DISABLE'] = '1'

--- a/tools/utils/regression_test.py
+++ b/tools/utils/regression_test.py
@@ -90,7 +90,7 @@ class Test:
 
    # This function is called when the script was not especified (self.script is null)
    def generate_command_line(self, test_dir):
-      params = ['-dw', '-r 160 120', '-sm lambert', '-bs 16']
+      params = ['-dw', '-r 160 120', '-sm lambert', '-bs 16', '-sl']
       
       params += {
          '.exr' : ['-o %s' % self.output_image],


### PR DESCRIPTION
This PR adds the skip_license_check argument to the testsuite kick command lines, as well as an environment variable to avoid aborting when no license is found