### PR TITLE
Fix Broken Links

### DIFF
--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -8,7 +8,7 @@ Special pages, such as this one, can be created as .dox files. This also
 implies the documentation is version controlled along with the code. Doxygen
 can then automatically generate HTML files, LaTeX, CHM files or other formats.
 
-Please refer to the [Doxygen manual](http://www.doxygen.org/manual.html) for
+Please refer to the [Doxygen manual](https://www.doxygen.nl/manual/index.html) for
 details about Doxygen tags and syntax.
 
 ### Doxygen conventions

--- a/tools/scons/scons-README
+++ b/tools/scons/scons-README
@@ -38,7 +38,7 @@ LATEST VERSION
 Before going further, you can check for the latest version of the
 scons-local package, or any SCons package, at the SCons download page:
 
-        http://www.scons.org/download.html
+        https://scons.org/pages/download.html
 
 
 EXECUTION REQUIREMENTS

--- a/tools/scons/scons-README
+++ b/tools/scons/scons-README
@@ -163,7 +163,7 @@ The SCons project welcomes bug reports and feature requests.
 Please make sure you send email with the problem or feature request to
 the SCons users mailing list, which you can join via the link below:
 
-        http://two.pairlist.net/mailman/listinfo/scons-users
+        https://pairlist2.pair.net/mailman/listinfo/scons-users
 
 Once you have discussed your issue on the users mailing list and the
 community has confirmed that it is either a new bug or a duplicate of an

--- a/tools/scons/scons-README
+++ b/tools/scons/scons-README
@@ -187,7 +187,7 @@ or comments to the list at:
 
 You may subscribe to the scons-users mailing list at:
 
-        http://two.pairlist.net/mailman/listinfo/scons-users
+        https://pairlist2.pair.net/mailman/listinfo/scons-users
 
 An active mailing list for developers of SCons is available.  You may
 send questions or comments to the list at:

--- a/tools/scons/scons-README
+++ b/tools/scons/scons-README
@@ -136,7 +136,7 @@ package:
 
 Additional documentation for SCons is available at:
 
-        http://www.scons.org/doc.html
+        https://scons.org/documentation.html
 
 
 LICENSING


### PR DESCRIPTION
There are multiple broken links in the documentation of this project. Here is what I have fixed:

http://www.scons.org/download.html --> https://scons.org/pages/download.html

http://www.scons.org/doc.html --> https://scons.org/documentation.html

http://two.pairlist.net/mailman/listinfo/scons-users --> https://pairlist2.pair.net/mailman/listinfo/scons-users

http://www.doxygen.org/manual.html --> https://www.doxygen.nl/manual/index.html

I found these links using a tool I created called [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐

I have also applied to the [Intern, Front End Developer](https://autodesk.wd1.myworkdayjobs.com/en-US/Ext/job/Intern--Front-End-Developer_24WD74757) position at your company. If you could put a word in for me, it would be greatly appreciated.