### PR TITLE
Fix failing Materialx tests on hydra testsuite 

### DIFF
--- a/libs/common/api_adapter.h
+++ b/libs/common/api_adapter.h
@@ -137,7 +137,7 @@ public:
 
     // Ideally GetPrimvars shouldn't be here
     virtual const std::vector<UsdGeomPrimvar> &GetPrimvars() const = 0;
-
+#if ARNOLD_VERSION_NUM > 70203
     const AtNodeEntry * GetCachedMtlxNodeEntry(const std::string &nodeEntryKey, const char *nodeDefinition, AtParamValueMap *params) {
         // First we check if the nodeType is an arnold shader
         std::lock_guard<AtMutex> lock(_nodeEntrymutex);
@@ -151,7 +151,8 @@ public:
         }
         return shaderNodeEntryIt->second;
     };
-
+#endif
+#if ARNOLD_VERSION_NUM >= 70104
     AtString GetCachedOslCode(const std::string &oslCodeKey, const char *nodeDefinition, AtParamValueMap *params) {
         std::lock_guard<AtMutex> lock(_oslCodeCacheMutex);
         const auto oslCodeIt = _oslCodeCache.find(oslCodeKey);
@@ -164,17 +165,21 @@ public:
         }
         return _oslCodeCache[oslCodeKey];
     }
-
+#endif
 protected:
     std::vector<Connection> _connections;
 
     // We cache the shader's node entry and the osl code returned by the AiMaterialXxxx functions as
     // those are too costly/slow to be called for each shader prim.
     // We might want to get rid of this optimization once those functions are optimized.
+#if ARNOLD_VERSION_NUM > 70203
     AtMutex _nodeEntrymutex;
     std::unordered_map<std::string, const AtNodeEntry *> _shaderNodeEntryCache;
+#endif
+#if ARNOLD_VERSION_NUM >= 70104
     AtMutex _oslCodeCacheMutex;
     std::unordered_map<std::string, AtString> _oslCodeCache;
+#endif
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/libs/common/materials_utils.cpp
+++ b/libs/common/materials_utils.cpp
@@ -521,6 +521,10 @@ AtNode* ReadMtlxOslShader(const std::string& nodeName,
     // The "params" argument was added to AiMaterialxGetOslShader in 7.2.0.0
 #if ARNOLD_VERSION_NUM > 70104
     std::string shaderKey(shaderId.GetString());
+    const AtString &pxrMtlxPath = context.GetPxrMtlxPath();
+    if (!pxrMtlxPath.empty()) {
+        shaderKey += pxrMtlxPath.c_str();
+    }
     for (const auto& attrIt : inputAttrs) {
         if(!attrIt.second.connection.IsEmpty()) {
             // Only the key is used, so we set an empty string for the value
@@ -659,15 +663,16 @@ AtNode* ReadShader(const std::string& nodeName, const TfToken& shaderId,
     if (!pxrMtlxPath.empty()) {
         AiParamValueMapSetStr(params, str::MATERIALX_NODE_DEFINITIONS, pxrMtlxPath);
     }
-    const char* shaderIdStr = shaderId.GetText();
 
 #if ARNOLD_VERSION_NUM > 70203
-    std::string shaderKey = shaderIdStr + pxrMtlxPath.empty() ? "" : pxrMtlxPath.c_str();
-    const AtNodeEntry* shaderNodeEntry = context.GetCachedMtlxNodeEntry(shaderKey, shaderIdStr, params);
+    std::string shaderKey = shaderId.GetString();
+    shaderKey += pxrMtlxPath.empty() ? "" : std::string(pxrMtlxPath.c_str());
+    const AtNodeEntry* shaderNodeEntry = context.GetCachedMtlxNodeEntry(shaderKey, shaderId.GetText(), params);
 #else
     // arnold backwards compatibility. We used to rely on the nodedef prefix to identify 
     // the shader type
     AtString shaderEntryStr;
+    const char* shaderIdStr = shaderId.GetText();
     if (shaderId == str::t_ND_standard_surface_surfaceshader)
         shaderEntryStr = str::standard_surface;
     else if (strncmp(shaderIdStr, "ND_", 3) == 0)


### PR DESCRIPTION
**Changes proposed in this pull request**
- Since https://github.com/Autodesk/arnold-usd/pull/1819 some hydra tests are failing (test_1538, test_1333, test_1181), this PR fixes those issues by correctly creating the key for the materialx node entry cache.

