### PR TITLE
Fix compilation warning in MAXtoA

### DIFF
--- a/libs/common/api_adapter.h
+++ b/libs/common/api_adapter.h
@@ -16,6 +16,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 // For example we might want to wrap the AiNode call and add mutex, or store the nodes dependending on the context.
 class ArnoldAPIAdapter {
 public:
+
+    ArnoldAPIAdapter() {}
+    virtual ~ArnoldAPIAdapter() {}
+    
     // Type of connection between 2 nodes
     enum ConnectionType {
         CONNECTION_LINK = 0,


### PR DESCRIPTION
This PR fixes a compilation warning happening in MAXtoA. Since the class `ArnoldApiAdapter` has virtual methods, we need to add a virtual destructor.