### PR TITLE
Change HtoAConvertPrimVdbToArnold symbol lookup to htoaGeo lib

### DIFF
--- a/libs/render_delegate/volume.cpp
+++ b/libs/render_delegate/volume.cpp
@@ -119,28 +119,27 @@ struct HtoAFnSet {
         /// installed in a path containing `;` or `&`.
         constexpr auto convertVdbName = "HtoAConvertPrimVdbToArnold";
         const auto HOUDINI_PATH = ArchGetEnv("HOUDINI_PATH");
-        auto searchForPygeo = [&](const std::string& path) -> bool {
+        auto searchForLibHtoaGeo = [&](const std::string& path) -> bool {
             if (path == "&") {
                 return false;
             }
-            std::string dsoPath;
-            void* htoaPygeo = nullptr;
-#ifdef ARCH_OS_WINDOWS
-            std::string ext = ".dll";
+#if defined(ARCH_OS_WINDOWS)
+            constexpr const char* htoaGeoDso = "htoa_geo.dll";
+#elif defined(ARCH_OS_LINUX)
+            constexpr const char* htoaGeoDso = "libhtoa_geo.so";
+#elif defined(ARCH_OS_OSX)
+            constexpr const char* htoaGeoDso = "libhtoa_geo.dylib";
 #else
-            std::string ext = ".so";
+            TF_WARN("Error loading %s - unsupported architecture", convertVdbName);
+            return false;
 #endif
-            // TODO: we need to find a solution that doesn't require to add the future python version of houdini
-            std::array<std::string, 4> pythonVersions = {"2.7", "3.7", "3.9", "3.10"};
-            for (const auto &pyVer : pythonVersions) {
-                dsoPath = path + ARCH_PATH_SEP + "python" + pyVer + "libs" + ARCH_PATH_SEP + "_htoa_pygeo" + ext;
-                htoaPygeo = ArchLibraryOpen(dsoPath, ARCH_LIBRARY_NOW);
-                if (htoaPygeo) break;
-            }
-            if (!htoaPygeo) {
+
+            const std::string dsoPath = path + ARCH_PATH_SEP + "scripts" ARCH_PATH_SEP + "bin" + ARCH_PATH_SEP + htoaGeoDso;
+            void* htoaGeo = ArchLibraryOpen(dsoPath, ARCH_LIBRARY_NOW);
+            if (!htoaGeo) {
                 return false;
             }
-            convertPrimVdbToArnold = reinterpret_cast<HtoAConvertPrimVdbToArnold>(GETSYM(htoaPygeo, convertVdbName));
+            convertPrimVdbToArnold = reinterpret_cast<HtoAConvertPrimVdbToArnold>(GETSYM(htoaGeo, convertVdbName));
             if (convertPrimVdbToArnold == nullptr) {
                 TF_WARN("Error loading %s from %s", convertVdbName, dsoPath.c_str());
             }
@@ -148,14 +147,14 @@ struct HtoAFnSet {
         };
         const auto houdiniPaths = TfStringSplit(HOUDINI_PATH, ARCH_PATH_LIST_SEP);
         for (const auto& houdiniPath : houdiniPaths) {
-            if (searchForPygeo(houdiniPath)) {
+            if (searchForLibHtoaGeo(houdiniPath)) {
                 return;
             }
 #ifndef ARCH_OS_WINDOWS
             if (TfStringContains(houdiniPath, ";")) {
                 const auto subPaths = TfStringSplit(houdiniPath, ";");
                 for (const auto& subPath : subPaths) {
-                    if (searchForPygeo(subPath)) {
+                    if (searchForLibHtoaGeo(subPath)) {
                         return;
                     }
                 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- Changed HtoAConvertPrimVdbToArnold symbol lookup from pythonX.Xlibs/_htoa_pygeo lookup to scripts/bin/<htoa_geo dso> (the name differs per platform)
- This gives us the slight benefit of no longer needing to maintain the python versions table.
- I'll add a test to validate this in HtoA, so if it breaks again in the future we'll know.

Happy Windows teapot VDB:
![image](https://github.com/Autodesk/arnold-usd/assets/5022079/b4ed4ffc-2b59-4ba7-be94-b2d816b790a9)

**Issues fixed in this pull request**
Fixes [arnold-usd#1848](https://github.com/Autodesk/arnold-usd/issues/1848)

