### PR TITLE
Fix slowness in the render delegate due to scene update when the camera moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 
 ## [fix-7.2.5]
 
+### Bug fixes
+- [usd#1854](https://github.com/Autodesk/arnold-usd/issues/1854) - Fix unnecessary updating of the scene in the render delegate when the camera is moving. This improves the interactivity in Solaris.
+
 ## [7.2.5.2]
 
 ### Bug fixes
-- [usd#1854](https://github.com/Autodesk/arnold-usd/issues/1854) - Fix unnecessary updating of the scene in the render delegate when the camera is moving. This improves the interactivity in Solaris.
 - [usd#1808](https://github.com/Autodesk/arnold-usd/issues/1808) - Fix the error "Cannot load _htoa_pygeo library required for volume rendering in Solaris" in Houdini 19.5+.
 - [usd#1812](https://github.com/Autodesk/arnold-usd/issues/1812) - Improve Material network creation by caching the node entries and the osl code.
 - [usd#1781](https://github.com/Autodesk/arnold-usd/issues/1781) - Fix a crash happening in a aiStandin usd when scrolling the timeline in maya.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [fix-7.2.5]
 
 ### Bug fixes
-
+- [usd#1854](https://github.com/Autodesk/arnold-usd/issues/1854) - Fix unnecessary updating of the scene in the render delegate when the camera is moving. This improves the interactivity in Solaris.
 - [usd#1808](https://github.com/Autodesk/arnold-usd/issues/1808) - Fix the error "Cannot load _htoa_pygeo library required for volume rendering in Solaris" in Houdini 19.5+.
 - [usd#1812](https://github.com/Autodesk/arnold-usd/issues/1812) - Improve Material network creation by caching the node entries and the osl code.
 - [usd#1781](https://github.com/Autodesk/arnold-usd/issues/1781) - Fix a crash happening in a aiStandin usd when scrolling the timeline in maya.

--- a/libs/render_delegate/camera.cpp
+++ b/libs/render_delegate/camera.cpp
@@ -272,7 +272,7 @@ void HdArnoldCamera::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 
         // Check if the user changed the projection type
         if (isPersp) {
-            if (AtString(AiNodeEntryGetTypeName(AiNodeGetNodeEntry(_camera))) != str::persp_camera) {
+            if (!AiNodeIs(_camera, str::persp_camera)) {
                  // the name might be the same ??
                 AtNode *newCamera = _delegate->CreateArnoldNode(str::persp_camera, AtString(GetId().GetText()));
                 SetCamera(newCamera);
@@ -282,7 +282,7 @@ void HdArnoldCamera::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
             const auto fov = static_cast<float>(GfRadiansToDegrees(atan(1.0 / projMatrix[0][0]) * 2.0));
             AiNodeSetFlt(_camera, str::fov, fov);
         } else if (isOrtho) {
-            if (AtString(AiNodeEntryGetTypeName(AiNodeGetNodeEntry(_camera))) != str::ortho_camera) {
+            if (!AiNodeIs(_camera, str::ortho_camera)) {
                 AtNode *newCamera = _delegate->CreateArnoldNode(str::ortho_camera, AtString(GetId().GetText()));
                 SetCamera(newCamera);
                 AiNodeSetStr(newCamera, str::name, AtString(GetId().GetText()));


### PR DESCRIPTION
**Changes proposed in this pull request**
- We are testing if the camera is a perspective or ortho camera in the render delegate camera sync. Unfortunately the test was incorrect as the type returned by the function AiNodeEntryGetTypeName is the generic type "camera" and not the specific type of the camera persp_camera or ortho_camera. A new arnold camera was created everytime there was a change in parameter, thus forcing an update of the scene.

**Issues fixed in this pull request**
Fixes #1854

