### PR TITLE
Enable MSVC_USE_SCRIPT Scons option to override default MSVC_VERSION detection

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -139,6 +139,10 @@ vars.AddVariables(
 
 if IS_WINDOWS:
     vars.Add(('MSVC_VERSION', 'Version of MS Visual C++ Compiler to use', '14.2'))
+    # If explicitely provided in the command line, MSVC_USE_SCRIPT will override the MSVC_VERSION.
+    # MSVC_USE_SCRIPT should point to a "vcvars*.bat" script
+    if 'MSVC_USE_SCRIPT' in ARGUMENTS:
+        vars.Add(('MSVC_USE_SCRIPT', 'Script which overrides the MSVC_VERSION detection', ARGUMENTS.get('MSVC_USE_SCRIPT')))
 else:
     vars.Add(BoolVariable('RPATH_ADD_ARNOLD_BINARIES', 'Add Arnold binaries to the RPATH', False))
 


### PR DESCRIPTION
This PR enables a built-in option in SCons ([`MSVC_USE_SCRIPT`](https://scons.org/doc/production/HTML/scons-man.html#cv-MSVC_USE_SCRIPT)) in order to override the default detection from [`MSVC_VERSION`](https://scons.org/doc/production/HTML/scons-man.html#cv-MSVC_VERSION)