### PR TITLE
Fix crash in the procedural cleanup

### DIFF
--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -187,7 +187,7 @@ procedural_cleanup
     ProceduralReader *data = reinterpret_cast<ProceduralReader *>(user_ptr);
     // For interactive procedurals, we don't want to delete the ProceduralReader 
     // when the render finishes, as we will need it later on, during procedural_update
-    if (!data->GetInteractive())
+    if (data && !data->GetInteractive())
         delete data;
     return 1;
 }


### PR DESCRIPTION
It appears that the user_ptr can be null in `procedural_cleanup`, meaning that we didn't go through `procedural_init`. This is causing crashes in the plugins integration. 
We just need to test against null pointers, as it's already done in other procedural functions