### PR TITLE
Fixes for imager node type

### DIFF
--- a/libs/common/common_utils.h
+++ b/libs/common/common_utils.h
@@ -32,6 +32,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// Older versions of Arnold had imagers defined as drivers
+#if ARNOLD_VERSION_NUM < 70301
+static const int AI_NODE_IMAGER = AI_NODE_DRIVER;
+#endif
+
 // convert from "snake_case" to "camelCase"
 // ignores the capitalization of input strings: letters are only capitalized
 // if they follow an underscore

--- a/libs/common/parameters_utils.cpp
+++ b/libs/common/parameters_utils.cpp
@@ -30,6 +30,7 @@
 
 #include <constant_strings.h>
 #include "parameters_utils.h"
+#include <common_utils.h>
 #include "api_adapter.h"
 //-*************************************************************************
 
@@ -117,13 +118,7 @@ void _ReadAttributeConnection(
     // if it's an imager then use a CONNECTION_PTR
 
     context.AddConnection(node, arnoldAttr, connection.GetPrimPath().GetText(),
-                          AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == 
-#if ARNOLD_VERSION_NUM > 70300
-                          AI_NODE_IMAGER 
-#else
-                          AI_NODE_DRIVER
-#endif
-                          ?
+                          AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_IMAGER ?
                           ArnoldAPIAdapter::CONNECTION_PTR : ArnoldAPIAdapter::CONNECTION_LINK,
                           outputElement);
 
@@ -334,11 +329,7 @@ void ReadAttribute(
             }
         }
         // check if there are connections to this attribute
-#if ARNOLD_VERSION_NUM > 70300
         bool isImager = AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_IMAGER;
-#else
-        bool isImager = AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_DRIVER;
-#endif
         if ((paramType != AI_TYPE_NODE || isImager) && !attr.connection.IsEmpty())
             _ReadAttributeConnection(attr.connection, node, arnoldAttr, time, context, paramType);
     }

--- a/plugins/ndr/utils.cpp
+++ b/plugins/ndr/utils.cpp
@@ -41,6 +41,7 @@
 
 #include <ai.h>
 #include <constant_strings.h>
+#include <common_utils.h>
 #include <unordered_map>
 #include <iostream>
 
@@ -406,7 +407,7 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
                 }
             }
         }
-    } else if (AiNodeEntryGetType(nodeEntry) == AI_NODE_DRIVER) {
+    } else if (AiNodeEntryGetType(nodeEntry) == AI_NODE_IMAGER) {
         // create an output type for imagers
         prim.CreateAttribute(_tokens->output, SdfValueTypeNames->String, false);
     }
@@ -565,7 +566,7 @@ UsdStageRefPtr NdrArnoldGetShaderDefs()
 #endif
         }
 
-        auto* nodeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHADER | AI_NODE_DRIVER);
+        auto* nodeIter = AiUniverseGetNodeEntryIterator(AI_NODE_SHADER | AI_NODE_IMAGER);
 
         while (!AiNodeEntryIteratorFinished(nodeIter)) {
 
@@ -573,7 +574,7 @@ UsdStageRefPtr NdrArnoldGetShaderDefs()
             auto* nodeEntry = AiNodeEntryIteratorGetNext(nodeIter);
             static const AtString s_subtype("subtype");
             AtString subtype;
-            if ((AiNodeEntryGetType(nodeEntry) == AI_NODE_DRIVER))
+            if ((AiNodeEntryGetType(nodeEntry) == AI_NODE_IMAGER))
             {
                 if (!AiMetaDataGetStr(nodeEntry, AtString(), s_subtype, &subtype) || strcmp(subtype.c_str(), "imager"))
                     continue;


### PR DESCRIPTION
In order to solve all the occurrences of AI_NODE_DRIVER referring to imagers, we're defining AI_NODE_IMAGER for older versions of Arnold