### PR TITLE
Typo: Fix missing semicolon

### DIFF
--- a/libs/render_delegate/config.cpp
+++ b/libs/render_delegate/config.cpp
@@ -94,7 +94,7 @@ TF_DEFINE_ENV_SETTING(
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_interactive_fps_min, "5.0", "Minimum fps for progressive rendering.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_profile_file, "", "Output file for profiling information.")
+TF_DEFINE_ENV_SETTING(HDARNOLD_profile_file, "", "Output file for profiling information.");
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_texture_searchpath, "", "Texture search path.");
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Fix missing semicolon

**Issues fixed in this pull request**

Admittedly my C++ knowledge is limited and I'm not even sure whether this would be a bug originally or it just ends up being 'cosmetics'. I suspect at the very least that not having a semicolon there might have unexpected behavior - so this at least matches things cosmetically.
