### PR TITLE
Set a proper name to skydome image node in Hydra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [usd#1547](https://github.com/Autodesk/arnold-usd/issues/1547) - Fix mesh lights shutoff when there is a light link in the scene.
 - [usd#1859](https://github.com/Autodesk/arnold-usd/issues/1859) - Support PointInstancer invisibleIDs for lights 
 - [usd#1881](https://github.com/Autodesk/arnold-usd/issues/1881) - Support UDIM and relative paths on mtlx image shaders
+- [usd#1884](https://github.com/Autodesk/arnold-usd/issues/1884) - Set a proper name to skydome image node in Hydra
 
 ## Next minor release - 5454a9e
 

--- a/libs/render_delegate/light.cpp
+++ b/libs/render_delegate/light.cpp
@@ -743,7 +743,10 @@ void HdArnoldGenericLight::SetupTexture(const VtValue& value)
     if (path.empty()) {
         return;
     }
-    _texture = _delegate->CreateArnoldNode(str::image, AtString(""));
+
+    std::string imageName(AiNodeGetName(_light));
+    imageName += "/texture_file";    
+    _texture = _delegate->CreateArnoldNode(str::image, AtString(imageName.c_str()));
     AiNodeSetStr(_texture, str::filename, AtString(path.c_str()));
     if (hasShader) {
         AiNodeSetPtr(_light, str::shader, _texture);


### PR DESCRIPTION
When a Dome primitive has a texture filename, we create an image node in the arnold scene.
In Hydra it creates an image node with an empty name though, which can cause problems, e.g. when saving out .ass files. This PR follows the same naming as in the translator code.