### PR TITLE
Tests resaving to a .ass file should save in ascii format for proper debugging

### DIFF
--- a/tools/utils/regression_test.py
+++ b/tools/utils/regression_test.py
@@ -111,7 +111,7 @@ class Test:
       if self.resaved:
          resaved_extension = self.resaved if isinstance(self.resaved, str) else 'ass'
          forceexpand = '-forceexpand' if self.forceexpand else ''
-         self.script = 'kick %s %s -resave test_resaved.%s\n' % (self.scene, forceexpand, resaved_extension) + ' '.join(['kick test_resaved.{}'.format(resaved_extension)] + params)
+         self.script = 'kick %s %s -resave test_resaved.%s -db\n' % (self.scene, forceexpand, resaved_extension) + ' '.join(['kick test_resaved.{}'.format(resaved_extension)] + params)
       else:
          renderer = 'kick'
          self.script = ' '.join(['%s %s' % (renderer, self.scene)] + params)


### PR DESCRIPTION
Tiny PR, that is just for internal testsuite execution. Some tests resave usd data to arnold .ass files, but by default this is saved as binary .ass files, which is not great for debugging when we want to debug hydra tests VS usd tests