### PR TITLE
Set GI transmission depth to 8 by default

### DIFF
--- a/libs/render_delegate/config.cpp
+++ b/libs/render_delegate/config.cpp
@@ -74,6 +74,8 @@ TF_DEFINE_ENV_SETTING(HDARNOLD_GI_diffuse_depth, 1, "Diffuse ray depth by defaul
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_GI_specular_depth, 1, "Diffuse ray depth by default.");
 
+TF_DEFINE_ENV_SETTING(HDARNOLD_GI_transmission_depth, 8, "Transmission ray depth by default.");
+
 TF_DEFINE_ENV_SETTING(HDARNOLD_enable_progressive_render, true, "Enable progressive render.");
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_progressive_min_AA_samples, -4, "Minimum AA samples for progressive rendering.");
@@ -123,6 +125,7 @@ HdArnoldConfig::HdArnoldConfig()
     GI_volume_samples = std::max(0, TfGetEnvSetting(HDARNOLD_GI_volume_samples));
     GI_diffuse_depth = std::max(0, TfGetEnvSetting(HDARNOLD_GI_diffuse_depth));
     GI_specular_depth = std::max(0, TfGetEnvSetting(HDARNOLD_GI_specular_depth));
+    GI_transmission_depth = std::max(0, TfGetEnvSetting(HDARNOLD_GI_transmission_depth));
     enable_progressive_render = TfGetEnvSetting(HDARNOLD_enable_progressive_render);
     progressive_min_AA_samples = TfGetEnvSetting(HDARNOLD_progressive_min_AA_samples);
     enable_adaptive_sampling = TfGetEnvSetting(HDARNOLD_enable_adaptive_sampling);

--- a/libs/render_delegate/config.h
+++ b/libs/render_delegate/config.h
@@ -119,6 +119,10 @@ struct HdArnoldConfig {
     ///
     int GI_specular_depth; ///< Initial setting for Specular Depth.
 
+    /// Use HDARNOLD_GI_transmission_depth to set the value.
+    ///
+    int GI_transmission_depth; ///< Initial setting for Transmission Depth.
+
     /// Use HDARNOLD_enable_progressive_render to set the value.
     ///
     bool enable_progressive_render; ///< Enables progressive rendering.

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -304,7 +304,7 @@ const SupportedRenderSettings& _GetSupportedRenderSettings()
         {str::t_auto_transparency_depth, {"Auto Transparency Depth"}},
         {str::t_GI_diffuse_depth, {"Diffuse Depth", config.GI_diffuse_depth}},
         {str::t_GI_specular_depth, {"Specular Depth", config.GI_specular_depth}},
-        {str::t_GI_transmission_depth, {"Transmission Depth"}},
+        {str::t_GI_transmission_depth, {"Transmission Depth", config.GI_transmission_depth}},
         {str::t_GI_volume_depth, {"Volume Depth"}},
         {str::t_GI_total_depth, {"Total Depth"}},
         // Ignore settings


### PR DESCRIPTION
Arnold plugins force the options GI_transmission_depth parameter to be 8 by default (which is often needed for e.g. a glass rendering), although it's different from the Arnold core default (2).

This PR sets this default value to 8, to match what HtoA or MtoA expose in the UI