### PR TITLE
Avoid memory duplication when using VtArrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [usd#1859](https://github.com/Autodesk/arnold-usd/issues/1859) - Support PointInstancer invisibleIDs for lights 
 - [usd#1881](https://github.com/Autodesk/arnold-usd/issues/1881) - Support UDIM and relative paths on mtlx image shaders
 - [usd#1884](https://github.com/Autodesk/arnold-usd/issues/1884) - Set a proper name to skydome image node in Hydra
+- [usd#1890](https://github.com/Autodesk/arnold-usd/issues/1890) - Reduce VtArray memory consumption, mostly in the instancer. 
 
 ## Next minor release - 5454a9e
 

--- a/libs/render_delegate/instancer.cpp
+++ b/libs/render_delegate/instancer.cpp
@@ -214,16 +214,15 @@ void HdArnoldInstancer::CalculateInstanceMatrices(HdArnoldRenderDelegate* render
     const float fps = 1.0f / (reinterpret_cast<HdArnoldRenderParam*>(renderDelegate->GetRenderParam())->GetFPS());
     const float fps2 = fps * fps;
     VtValue velValue = GetDelegate()->Get(instancerId, HdTokens->velocities);
-    VtVec3fArray velocities;
-    if (velValue.IsHolding<VtVec3fArray>()) {
-        velocities = velValue.UncheckedGet<VtVec3fArray>();
-    }
+    VtVec3fArray emptyVelocities;
+    const VtVec3fArray& velocities =
+        velValue.IsHolding<VtVec3fArray>() ? velValue.UncheckedGet<VtVec3fArray>() : emptyVelocities;
 
     VtValue accelValue = GetDelegate()->Get(instancerId, HdTokens->accelerations);
-    VtVec3fArray accelerations;
-    if (accelValue.IsHolding<VtVec3fArray>()) {
-        accelerations = accelValue.UncheckedGet<VtVec3fArray>();
-    }
+    VtVec3fArray emptyAccelerations;
+    const VtVec3fArray& accelerations =
+        accelValue.IsHolding<VtVec3fArray>() ? accelValue.UncheckedGet<VtVec3fArray>() : emptyAccelerations;
+
     const bool hasVelocities = velocities.size() > 0;
     const bool hasAccelerations = accelerations.size() > 0;
     const bool velBlur = hasAccelerations || hasVelocities;

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -748,7 +748,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         // Solaris-specific command line, it can have an argument "-o output.exr" to override
         // the output image. We might end up using this for arnold drivers
         if (value.IsHolding<VtStringArray>()) {
-            const VtStringArray commandLine = value.UncheckedGet<VtArray<std::string>>();
+            const VtStringArray &commandLine = value.UncheckedGet<VtArray<std::string>>();
             for (unsigned int i = 0; i < commandLine.size(); ++i) {
                 // husk argument for output image
                 if (commandLine[i] == "-o" && i < commandLine.size() - 2) {
@@ -790,10 +790,10 @@ void HdArnoldRenderDelegate::_ParseDelegateRenderProducts(const VtValue& value)
     if (!value.IsHolding<DataType>()) {
         return;
     }
-    auto products = value.UncheckedGet<DataType>();
+    const auto &products = value.UncheckedGet<DataType>();
     // For Render Delegate products, we want to eventually create arnold drivers
     // during batch rendering #1422
-    for (auto& productIter : products) {
+    for (const auto& productIter : products) {
         HdArnoldDelegateRenderProduct product;
         const auto* productType = TfMapLookupPtr(productIter, _tokens->productType);
 

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -89,16 +89,18 @@ inline size_t _ExtrapolatePositions(
     }
 
     // Check if primvars or positions exists. These arrays are COW.
-    VtVec3fArray velocities;
-    VtVec3fArray accelerations;
+    VtVec3fArray emptyVelocities;
+    VtVec3fArray emptyAccelerations;
     auto primvarIt = primvars->find(HdTokens->velocities);
-    if (primvarIt != primvars->end() && primvarIt->second.value.IsHolding<VtVec3fArray>()) {
-        velocities = primvarIt->second.value.UncheckedGet<VtVec3fArray>();
-    }
+    const VtVec3fArray& velocities = (primvarIt != primvars->end() && primvarIt->second.value.IsHolding<VtVec3fArray>())
+                                         ? primvarIt->second.value.UncheckedGet<VtVec3fArray>()
+                                         : emptyVelocities;
+
     primvarIt = primvars->find(HdTokens->accelerations);
-    if (primvarIt != primvars->end() && primvarIt->second.value.IsHolding<VtVec3fArray>()) {
-        accelerations = primvarIt->second.value.UncheckedGet<VtVec3fArray>();
-    }
+    const VtVec3fArray& accelerations =
+        (primvarIt != primvars->end() && primvarIt->second.value.IsHolding<VtVec3fArray>())
+            ? primvarIt->second.value.UncheckedGet<VtVec3fArray>()
+            : emptyAccelerations;
 
     // The positions in xf contain several several time samples, but the amount of vertices 
     // can change in each sample. We want to consider the positions at the proper time, so 

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1316,7 +1316,7 @@ static bool CopyArrayElement(VtValue &value, unsigned int index)
     if (!value.IsHolding<VtArray<T>>())
         return false;
 
-    VtArray<T> array = value.UncheckedGet<VtArray<T>>();
+    const VtArray<T> &array = value.UncheckedGet<VtArray<T>>();
     if (index < array.size()) {
         value = array[index];
     }

--- a/plugins/ndr/parser.cpp
+++ b/plugins/ndr/parser.cpp
@@ -145,7 +145,7 @@ void _ReadShaderAttribute(const UsdAttribute &attr, NdrPropertyUniquePtrVec &pro
     NdrOptionVec options;
     auto it = customData.find(_tokens->enumValues);
     if (it != customData.end()) {
-        VtStringArray enumValues = it->second.Get<VtStringArray>();
+        const VtStringArray &enumValues = it->second.Get<VtStringArray>();
         for (const auto &enumValue : enumValues) {
             TfToken enumValTf(enumValue.c_str());
             options.emplace_back(enumValTf, enumValTf);
@@ -285,7 +285,7 @@ NdrNodeUniquePtr NdrArnoldParserPlugin::Parse(const NdrNodeDiscoveryResult& disc
     // we now create them in the same order as they appeared in the AtParamIterator in _ReadArnoldShaderDef
     if (primCustomData.find(_tokens->attrsOrder) != primCustomData.end()) {
         VtValue attrsOrderVal = primCustomData[_tokens->attrsOrder];
-        VtArray<std::string> attrsOrder = attrsOrderVal.Get<VtArray<std::string>>();
+        const VtArray<std::string> &attrsOrder = attrsOrderVal.Get<VtArray<std::string>>();
         for (const auto &attrName: attrsOrder) {
             if (declaredAttributes.find(attrName) != declaredAttributes.end())
                 continue;


### PR DESCRIPTION
**Changes proposed in this pull request**
- use const reference as much as possible when calling VtValue::UncheckedGet and VtValue::Get

**Issues fixed in this pull request**
Fixes #1890

