### PR TITLE
Fix transform hierarchies for non-xformable primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Feature
 - [usd#1894](https://github.com/Autodesk/arnold-usd/issues/1894) - Write cylinder lights as UsdLuxCylinderLight primitives
 
+### Bug fixes
+- [usd#1900](https://github.com/Autodesk/arnold-usd/issues/1900) - Fix transform hierarchies for Arnold non-xformable primitives
+
 ## [7.3.1.0] - 2024-03-27
 
 ### Feature

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1619,12 +1619,11 @@ AtNode* UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderCo
 
             // use the proper matrix, that was computed either with/without the proto's xform.
             // It depends on whether the prototype is a child usd proc or a simple geometry
-            const double *matrixArray = (mixedProtos && nodesChildProcs[protoIndices[i]]) ? 
-                excludedXformsArray[t][i].GetArray() : xformsArray[t][i].GetArray();
-            AtMatrix &matrix = instance_matrices[i + t * numInstances];
-            for (int i = 0; i < 4; ++i)
-                for (int j = 0; j < 4; ++j, matrixArray++)
-                    matrix[i][j] = (float)*matrixArray;
+            const GfMatrix4d& inputMtx = (mixedProtos && nodesChildProcs[protoIndices[i]]) ? 
+                excludedXformsArray[t][i] : xformsArray[t][i];
+            AtMatrix &outMtx = instance_matrices[i + t * numInstances];
+            ConvertValue(outMtx, inputMtx);
+            
         }
         instanceIdxs[i] = protoIndices[i];
     }


### PR DESCRIPTION
**Changes proposed in this pull request**

In a specific use case (where a primitive is not recognized as a xformable schema), we were not applying the transform hierarchy properly. We need to switch the parent & local matrices in the multiplication.

While debugging this, I realized that we were calculating the matrices for all primitive types, including shaders and all. The reason for that is that some primitives are not known as xformables by USD, but still expect a matrix. Since we don't have a fully reliable way to distinguish those, I just added a quick & simple check that skips this calculation for UsdShadeShaders, which are probably the most frequent prim type in usd scenes, and that definitely don't need a useless matrix computation.

I cannot add a test for this since the problem only happened when no schemas are present, and this really depends on the usd installation

**Issues fixed in this pull request**
Fixes #1900
