### PR TITLE
Writer skips materials when the shader mask is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 - [usd#1900](https://github.com/Autodesk/arnold-usd/issues/1900) - Fix transform hierarchies for Arnold non-xformable primitives
+- [usd#1903](https://github.com/Autodesk/arnold-usd/issues/1903) - USD Writer should skip materials when the shader mask is disabled
 
 ## [7.3.1.0] - 2024-03-27
 

--- a/libs/translator/writer/prim_writer.cpp
+++ b/libs/translator/writer/prim_writer.cpp
@@ -1231,7 +1231,7 @@ void UsdArnoldPrimWriter::_WriteMaterialBinding(
     const AtNode* node, UsdPrim& prim, UsdArnoldWriter& writer, AtArray* shidxsArray)
 {
 
-    if (!writer.GetWriteMaterialBindings())
+    if (!writer.GetWriteMaterialBindings() || !(writer.GetMask() & AI_NODE_SHADER))
         return;
 
     _exportedAttrs.insert("shader");


### PR DESCRIPTION
**Changes proposed in this pull request**
Before we author materials, we verify if the shader mask is enabled. This is needed to add an option in mayaUSD to skip shaders export. 
Since this is changing the behaviour, in a way that skips some nodes when usd files are authored, I'm not considering it for the fix branch

**Issues fixed in this pull request**
Fixes #1903
