### PR TITLE
Read deform_keys independantly of the primvar interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 - [usd#1900](https://github.com/Autodesk/arnold-usd/issues/1900) - Fix transform hierarchies for Arnold non-xformable primitives
-- [usd#1908](https://github.com/Autodesk/arnold-usd/issues/1908) - Read deform_keys independantly of the primvar interpolation
+- [usd#1908](https://github.com/Autodesk/arnold-usd/issues/1908) - Read deform_keys independently of the primvar interpolation
 - [usd#1903](https://github.com/Autodesk/arnold-usd/issues/1903) - USD Writer should skip materials when the shader mask is disabled
 
 ## [7.3.1.0] - 2024-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 - [usd#1900](https://github.com/Autodesk/arnold-usd/issues/1900) - Fix transform hierarchies for Arnold non-xformable primitives
+- [usd#1908](https://github.com/Autodesk/arnold-usd/issues/1908) - Read deform_keys independantly of the primvar interpolation
 
 ## [7.3.1.0] - 2024-03-27
 

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1476,7 +1476,7 @@ AtNode* UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderCo
     
     std::vector<UsdTimeCode> times;
     if (time.motionBlur) {
-        int numKeys = GetTimeSampleNumKeys(prim, time, TfToken("instance")); // to be coherent with the delegate
+        int numKeys = GetTimeSampleNumKeys(prim, time);
         if (numKeys > 1) {
             for (int i = 0; i < numKeys; ++i) {
                 times.push_back(time.frame + time.motionStart + i * (time.motionEnd - time.motionStart) / (numKeys-1));

--- a/libs/translator/reader/utils.cpp
+++ b/libs/translator/reader/utils.cpp
@@ -51,6 +51,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (ArnoldNodeGraph)
     ((PrimvarsArnoldFiltermap, "primvars:arnold:filtermap"))
     ((PrimvarsArnoldUvRemap, "primvars:arnold:uv_remap"))
+    ((PrimvarsArnoldDeformKeys, "primvars:arnold:deform_keys"))
 );
 
 
@@ -705,11 +706,11 @@ void ReadCameraShaders(const UsdPrim& prim, AtNode *node, UsdArnoldReaderContext
     }
 }
 
-int GetTimeSampleNumKeys(const UsdPrim &prim, const TimeSettings &time, TfToken interpolation) {
+int GetTimeSampleNumKeys(const UsdPrim &prim, const TimeSettings &time) {
     int numKeys = 2;
-    if (UsdAttribute deformKeysAttr = prim.GetAttribute(TfToken("primvars:arnold:deform_keys"))) {
+    if (UsdAttribute deformKeysAttr = prim.GetAttribute(_tokens->PrimvarsArnoldDeformKeys)) {
         UsdGeomPrimvar primvar(deformKeysAttr);
-        if (primvar && primvar.GetInterpolation() == interpolation) {
+        if (primvar) {
             int deformKeys = 0;
             if (deformKeysAttr.Get(&deformKeys, UsdTimeCode(time.frame))) {
                 numKeys = deformKeys > 0 ? deformKeys : 1;

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -128,4 +128,4 @@ inline TfToken GetNormalsInterpolation(const UsdGeomT &usdGeom) {
     return usdGeom.GetNormalsInterpolation();
 }
 
-int GetTimeSampleNumKeys(const UsdPrim &geom, const TimeSettings &tim, TfToken interpolation=UsdGeomTokens->constant);
+int GetTimeSampleNumKeys(const UsdPrim &geom, const TimeSettings &time);


### PR DESCRIPTION
**Changes proposed in this pull request**
When we read the amount of time keys (primvars:arnold:deform_keys), we no longer check the primvar interpolation.
This is now returning the same result as in the render delegate

**Issues fixed in this pull request**
Fixes #1908 
