### PR TITLE
Fix prims visibility during procedural updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [usd#1908](https://github.com/Autodesk/arnold-usd/issues/1908) - Read deform_keys independently of the primvar interpolation
 - [usd#1903](https://github.com/Autodesk/arnold-usd/issues/1903) - USD Writer should skip materials when the shader mask is disabled
 - [usd#1906](https://github.com/Autodesk/arnold-usd/issues/1906) - Fix light filters assignment order in the render delegate to make it consistent with the procedural.
+- [usd#1912](https://github.com/Autodesk/arnold-usd/issues/1912) - Procedural interactive updates don't consider primitives visibility
 
 ## [7.3.1.0] - 2024-03-27
 

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -1273,8 +1273,9 @@ bool UsdArnoldReaderContext::GetPrimVisibility(const UsdPrim &prim, float frame)
         return false;
     UsdArnoldReader *reader = _threadContext->GetReader();
     // Only compute the visibility when processing the dangling connections,
-    // otherwise we return true to avoid costly computation.
-    if (reader->GetReadStep() == UsdArnoldReader::READ_DANGLING_CONNECTIONS) {
+    // or when updating a specific primitive.
+    // Otherwise we return true to avoid costly computation.
+    if (reader->GetReadStep() == UsdArnoldReader::READ_DANGLING_CONNECTIONS || reader->IsUpdating()) {
         return IsPrimVisible(prim, reader, frame);
     }
     


### PR DESCRIPTION
**Changes proposed in this pull request**
During procedural interactive updates, we were always returning true in GetPrimVisiblity, because of a previous optimization.
This PR just ensures that we call the procedural function IsPrimVisible function when we're in update mode. This fixes internal ticket MAXTOA-1777

**Issues fixed in this pull request**
Fixes #1912
