### PR TITLE
Ensure polymesh topology attributes are not written to USD when not set

### DIFF
--- a/libs/translator/writer/write_geometry.cpp
+++ b/libs/translator/writer/write_geometry.cpp
@@ -48,7 +48,7 @@ void UsdArnoldWriteMesh::Write(const AtNode *node, UsdArnoldWriter &writer)
     writer.SetAttribute(mesh.GetOrientationAttr(), UsdGeomTokens->rightHanded);    
     AtArray *vidxs = AiNodeGetArray(node, AtString("vidxs"));
     VtArray<int> vtArrIdxs;
-    bool exportVertices = true;
+    bool exportVertices = false;
 
     if (vidxs) {
         unsigned int nelems = AiArrayGetNumElements(vidxs);


### PR DESCRIPTION
We were taking into account the use case where the vertex attributes had a nullptr array pointer, but we must also consider the use case where they have a zero-element array, as Arnold seems to be setting this kind of arrays by default. This is needed to handle maxUSD exports in a better way

**Issues fixed in this pull request**
Fixes #1914 
