### PR TITLE
Ensure subdiv_iterations is not set uselessly during procedural updates

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -82,6 +82,8 @@ ASTR2(primvars_arnold, "primvars:arnold");
 ASTR2(primvars_arnold_light, "primvars:arnold:light");
 ASTR2(log_file, "log:file");
 ASTR2(log_verbosity, "log:verbosity");
+ASTR2(primvars_arnold_smoothing, "primvars:arnold:smoothing");
+ASTR2(primvars_arnold_subdiv_iterations, "primvars:arnold:subdiv_iterations");
 ASTR2(primvars_arnold_subdiv_type, "primvars:arnold:subdiv_type");
 ASTR2(primvars_arnold_normalize, "primvars:arnold:normalize");
 ASTR2(renderPassAOVDriver, "HdArnoldRenderPass_aov_driver");

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -255,9 +255,9 @@ AtNode* UsdArnoldReadMesh::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
     staticTime.motionBlur = false;
 
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
-
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, true);
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, true);
 
     // Get mesh.
     UsdGeomMesh mesh(prim);
@@ -393,8 +393,10 @@ AtNode* UsdArnoldReadMesh::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
 
     _ReadSidedness(mesh, node, frame);
 
-    // reset subdiv_iterations to 0, it might be set in readArnoldParameter
-    AiNodeSetByte(node, str::subdiv_iterations, 0);
+    // reset subdiv_iterations to 0, unless primvars:arnold:subdiv_iterations is 
+    // explicitely set, in which case it would be applied during readArnoldParameter #1929
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_subdiv_iterations))
+        AiNodeSetByte(node, str::subdiv_iterations, 0);
     
     MeshPrimvarsRemapper primvarsRemapper(meshOrientation);
     ReadPrimvars(prim, node, time, context, &primvarsRemapper);
@@ -670,7 +672,8 @@ AtNode* UsdArnoldReadCube::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
     float frame = time.frame;
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, false);
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, false);
     
     static const VtIntArray numVerts { 4, 4, 4, 4, 4, 4 };
     static const VtIntArray verts { 0, 1, 2, 3,
@@ -722,7 +725,8 @@ AtNode* UsdArnoldReadSphere::Read(const UsdPrim &prim, UsdArnoldReaderContext &c
     float frame = time.frame;
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, true);
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, true);
     
     static const VtIntArray numVerts{
         3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 
@@ -891,7 +895,9 @@ AtNode* UsdArnoldReadCylinder::Read(const UsdPrim &prim, UsdArnoldReaderContext 
     float frame = time.frame;
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, true);
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, true);
+
     static const VtIntArray numVerts{ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
                                       4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
                                       3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
@@ -956,7 +962,9 @@ AtNode* UsdArnoldReadCone::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
     float frame = time.frame;
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, true);
+    
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, true);
     
     static const VtIntArray numVerts{ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
                                       4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
@@ -1014,7 +1022,9 @@ AtNode* UsdArnoldReadCapsule::Read(const UsdPrim &prim, UsdArnoldReaderContext &
     float frame = time.frame;
     AtNode *node = context.CreateArnoldNode("polymesh", prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
-    AiNodeSetBool(node, str::smoothing, true);
+
+    if (!HasAuthoredAttribute(prim, str::t_primvars_arnold_smoothing))
+        AiNodeSetBool(node, str::smoothing, true);
     
     // slices are segments around the mesh
     static constexpr int _capsuleSlices = 10;


### PR DESCRIPTION
During procedural updates of usd geometries, we were always setting smoothing and subdiv_iterations back to the desired default value, before the attributes were eventually set explicitely during ReadArnoldParameters.

This PR only resets the attribute values if we find that they're not explicitely set as primvars:arnold:subdiv_iterations and primvars:arnold:smoothing, in which case the attributes would be set during ReadArnoldParameters

**Issues fixed in this pull request**
Fixes #1929 
