### PR TITLE
Check if the VtValue is empty before doing a UncheckedGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [usd#1923](https://github.com/Autodesk/arnold-usd/issues/1923) - Fix instance primvar indices 
 with multiple prototypes
 - [usd#1929](https://github.com/Autodesk/arnold-usd/issues/1929) - Ensure subdiv_iterations is not set uselessly during procedural updates
+- [usd#1932](https://github.com/Autodesk/arnold-usd/issues/1932) - Fix a crash when the number of elements in a primvar should be equal to the number of points but is not.
 
 ## [7.3.2.0] - 2024-05-22
 

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -104,14 +104,16 @@ struct _ConvertValueToArnoldParameter<UsdType, ArnoldType, HdArnoldSampledPrimva
         if (samples.count == 0 || samples.values.empty() || !samples.values[0].IsHolding<VtArray<UsdType>>()) {
             return;
         }
-
         const VtArray<UsdType> *v0 = nullptr;
         if (requiredValues) {
             for (const auto& value : samples.values) {
-                const auto& array = value.UncheckedGet<VtArray<UsdType>>();
-                if (array.size() == *requiredValues) {
-                    v0 = &array;
-                    break;
+                // Looking for the correct buffer by size.
+                if (!value.IsEmpty()) {
+                    const auto& array = value.UncheckedGet<VtArray<UsdType>>();
+                    if (array.size() == *requiredValues) {
+                        v0 = &array;
+                        break;
+                    }
                 }
             }
         }
@@ -442,8 +444,8 @@ void HdArnoldMesh::Sync(
                 } else if (primvar.first == HdTokens->normals) {
                     if (desc.value.IsEmpty()) {
                         HdArnoldIndexedSampledPrimvarType sample;
-                        sceneDelegate->SampleIndexedPrimvar(id, primvar.first, &sample);
                         sample.count = _numberOfPositionKeys;
+                        sceneDelegate->SampleIndexedPrimvar(id, primvar.first, &sample);
                         _ConvertFaceVaryingPrimvarToBuiltin<GfVec3f, AI_TYPE_VECTOR, HdArnoldSampledPrimvarType>(
                             GetArnoldNode(), sample, sample.indices.empty() ? VtIntArray{} : sample.indices[0],
                             str::nlist, str::nidxs, &_vertexCounts, &_vertexCountSum);


### PR DESCRIPTION
**Changes proposed in this pull request**
When we convert some primvar we might expect the same number of elements as the points. If the number of values is incorrect the iteration end up extracting an empty VtValue with an UncheckedGet which leads to a crash.
 This patch just make sure the VtValue is not empty before calling UncheckedGet.

**Issues fixed in this pull request**
Fixes #1932

