### PR TITLE
Use batch session for single-frame husk renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Feature
 - [usd#1814](https://github.com/Autodesk/arnold-usd/issues/1814) - Support skinning on USD curves and points
+- [usd#1918](https://github.com/Autodesk/arnold-usd/issues/1918) - Use batch render sessions for husk renders
 
 ### Bug fixes
 - [usd#1861](https://github.com/Autodesk/arnold-usd/issues/1861) - Fix BasisCurves disappearing on interactive updates

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -110,7 +110,8 @@ public:
 class HdArnoldRenderDelegate final : public HdRenderDelegate {
 public:
     HDARNOLD_API
-    HdArnoldRenderDelegate(bool isBatch, const TfToken &context, AtUniverse *universe); ///< Constructor for the Render Delegate.
+    HdArnoldRenderDelegate(bool isBatch, const TfToken &context, 
+        AtUniverse *universe = nullptr, AtSessionMode sessionTtype = AI_SESSION_INTERACTIVE); ///< Constructor for the Render Delegate.
     HDARNOLD_API
     ~HdArnoldRenderDelegate() override; ///< Destuctor for the Render Delegate.
     /// Returns an instance of HdArnoldRenderParam.

--- a/plugins/render_delegate/renderer_plugin.cpp
+++ b/plugins/render_delegate/renderer_plugin.cpp
@@ -41,18 +41,22 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 // clang-format off
 TF_DEFINE_PRIVATE_TOKENS(_tokens,
-     ((houdini_renderer, "houdini:renderer")));
+    ((houdini_renderer, "houdini:renderer"))
+    (batchCommandLine)
+    );
+
 // clang-format on
 
 // Register the Ai plugin with the renderer plugin system.
 TF_REGISTRY_FUNCTION(TfType) { HdRendererPluginRegistry::Define<HdArnoldRendererPlugin>(); }
 
-HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate() { return new HdArnoldRenderDelegate(false, str::t_hydra, nullptr); }
+HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate() { return new HdArnoldRenderDelegate(false, str::t_hydra, nullptr, AI_SESSION_INTERACTIVE); }
 
 HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate(const HdRenderSettingsMap& settingsMap)
 {
     TfToken context = str::t_hydra;
     bool isBatch = false;
+    AtSessionMode sessionType = AI_SESSION_INTERACTIVE;    
     const auto* houdiniRenderer = TfMapLookupPtr(settingsMap, _tokens->houdini_renderer);
     if (houdiniRenderer != nullptr &&
         ((houdiniRenderer->IsHolding<TfToken>() && houdiniRenderer->UncheckedGet<TfToken>() == str::t_husk) ||
@@ -60,8 +64,34 @@ HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate(const HdRenderSet
           houdiniRenderer->UncheckedGet<std::string>() == str::t_husk.GetString()))) {
         context = str::t_husk;
         isBatch = true;
+        // We set the session type to batch since we're batch rendering.
+        // However, the husk command line can specify an amount of frames with the -n argument, 
+        // in which case the session is only created once and each new frame is treated as
+        // being interactive changes. Therefore, if the -n argument is used to render multiple frames
+        // we roll back to an interactive session
+        sessionType = AI_SESSION_BATCH;
+        for (const auto& setting : settingsMap) {
+            if (setting.first != _tokens->batchCommandLine) 
+                continue;
+            if (setting.second.IsHolding<VtStringArray>()) {
+                const VtStringArray &commandLine = setting.second.UncheckedGet<VtArray<std::string>>();
+                for (unsigned int i = 0; i < commandLine.size(); ++i) {
+                    if ((commandLine[i] == "-n") 
+                            && i < commandLine.size() - 2) {
+                        int numFrames = std::atoi(commandLine[++i].c_str());
+                        if (numFrames > 1) {
+                            // We need an interactive session since we're rendering 
+                            // multiple frames in a single render session
+                            sessionType = AI_SESSION_INTERACTIVE;                    
+                        }
+                        break;                    
+                    }
+                }
+            }
+        }
     }
-    auto* delegate = new HdArnoldRenderDelegate(isBatch, context, nullptr);
+    
+    auto* delegate = new HdArnoldRenderDelegate(isBatch, context, nullptr, sessionType);
     for (const auto& setting : settingsMap) {
         delegate->SetRenderSetting(setting.first, setting.second);
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
For batch renders of the render delegate we now use a batch render session instead of an interactive one, in order to optimize memory consumption.
We do an exception when the husk command line is executed with the -n argument that triggers the rendering of multiple frames in the same render session, which forces us to have an interactive session

**Issues fixed in this pull request**
Fixes #1918 
