### PR TITLE
Avoid creating the render delegate if ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL is set and  the license is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Feature
 - [usd#1814](https://github.com/Autodesk/arnold-usd/issues/1814) - Support skinning on USD curves and points
+- [usd#1950](https://github.com/Autodesk/arnold-usd/issues/1950) - Avoid creating a render delegate in batch mode when ARNOLD_FORCE_ARBORT_ON_LICENSE_FAIL is set and the license isn't found.
 
 ### Bug fixes
 - [usd#1861](https://github.com/Autodesk/arnold-usd/issues/1861) - Fix BasisCurves disappearing on interactive updates

--- a/plugins/render_delegate/renderer_plugin.cpp
+++ b/plugins/render_delegate/renderer_plugin.cpp
@@ -62,7 +62,7 @@ HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate(const HdRenderSet
         context = str::t_husk;
         isBatch = true;
     }
-    if (TfGetenv("ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL", "0") != "0" && !AiLicenseIsAvailable()) {
+    if (isBatch && TfGetenv("ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL", "0") != "0" && !AiLicenseIsAvailable()) {
         AiMsgError("Arborting: ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL is set and Arnold license not found");
         return nullptr;
     }

--- a/plugins/render_delegate/renderer_plugin.cpp
+++ b/plugins/render_delegate/renderer_plugin.cpp
@@ -36,6 +36,7 @@
 #include "render_delegate.h"
 
 #include <constant_strings.h>
+#include <pxr/base/tf/getEnv.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -60,6 +61,10 @@ HdRenderDelegate* HdArnoldRendererPlugin::CreateRenderDelegate(const HdRenderSet
           houdiniRenderer->UncheckedGet<std::string>() == str::t_husk.GetString()))) {
         context = str::t_husk;
         isBatch = true;
+    }
+    if (TfGetenv("ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL", "0") != "0" && !AiLicenseIsAvailable()) {
+        AiMsgError("Arborting: ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL is set and Arnold license not found");
+        return nullptr;
     }
     auto* delegate = new HdArnoldRenderDelegate(isBatch, context, nullptr);
     for (const auto& setting : settingsMap) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Before creating the render delegate we check is the environment variable ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL is set and if so we test if the license is available. We don't create the render delegate if the license is not found.


**Issues fixed in this pull request**
Fixes #1950

