### PR TITLE
Fix compilation issue due to header incorrect name

### DIFF
--- a/plugins/render_delegate/renderer_plugin.cpp
+++ b/plugins/render_delegate/renderer_plugin.cpp
@@ -36,7 +36,7 @@
 #include "render_delegate.h"
 
 #include <constant_strings.h>
-#include <pxr/base/tf/getEnv.h>
+#include <pxr/base/tf/getenv.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- rename getEnv.h to getenv.h

