### PR TITLE
Enable the use of half aovs in the render delegate when rendering custom products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored
 - [usd#1977](https://github.com/Autodesk/arnold-usd/issues/1977) - Aov shaders not set properly in hydra mode of the scene format
 - [usd#1984](https://github.com/Autodesk/arnold-usd/issues/1984) - Cylinder lights not taking normalization into account through USD
+- [usd#1989](https://github.com/Autodesk/arnold-usd/issues/1989) - Support mixed half/float channels when using the render delegate in batch mode with husk.
 
 ### Build
 - [usd#1969](https://github.com/Autodesk/arnold-usd/issues/1969) - Remove support for USD versions older than 21.05

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -854,6 +854,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                 auto* enableFiltering = static_cast<bool*>(AiArrayMap(enableFilteringArray));
                 auto* halfPrecisionArray = AiArrayAllocate(numRenderVars, 1, AI_TYPE_BOOLEAN);
                 auto* halfPrecision = static_cast<bool*>(AiArrayMap(halfPrecisionArray));
+                const bool isDeepExrDriver = AiNodeIs(customProduct.driver, str::driver_deepexr);
                 for (const auto& renderVar : product.renderVars) {
                     CustomRenderVar customRenderVar;
                     *tolerance =
@@ -897,6 +898,9 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                         if (!renderVar.name.empty() && renderVar.name != renderVar.sourceName) {
                             output += TfStringPrintf(" %s", renderVar.name.c_str());
                         }
+                        if (arnoldTypes.isHalf && !isDeepExrDriver) {
+                            output += " HALF";
+                        }
                         customRenderVar.output = AtString{output.c_str()};
                     }
                     tolerance += 1;
@@ -909,7 +913,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                 AiArrayUnmap(halfPrecisionArray);
 
                 // FIXME do we still need to do a special case for deep exr or should we generalize this ? #1422
-                if (AiNodeIs(customProduct.driver, str::driver_deepexr)) {
+                if (isDeepExrDriver) {
                     AiNodeSetArray(customProduct.driver, str::layer_tolerance, toleranceArray);
                     AiNodeSetArray(customProduct.driver, str::layer_enable_filtering, enableFilteringArray);
                     AiNodeSetArray(customProduct.driver, str::layer_half_precision, halfPrecisionArray);


### PR DESCRIPTION
**Changes proposed in this pull request**
- We add HALF at the end of the output aov line if the aov should be half float.

**Issues fixed in this pull request**
Fixes #1989

