### PR TITLE
Choose render settings primitive through hydra scene loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [usd#1979](https://github.com/Autodesk/arnold-usd/issues/1979) - Support treatAsPoint in Hydra photometric lights
 - [usd#1987](https://github.com/Autodesk/arnold-usd/issues/1987) - Author familyName and familyType in GeomSubsets written as USD
 - [usd#1997](https://github.com/Autodesk/arnold-usd/issues/1997) - Apply correct amount of transform keys when xformOp is set on parent prims
+- [usd#2003](https://github.com/Autodesk/arnold-usd/issues/2003) - Choose render settings primitive through hydra scene loader
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/common/rendersettings_utils.cpp
+++ b/libs/common/rendersettings_utils.cpp
@@ -472,6 +472,13 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
     }
 
     // Get the camera used for rendering, this is needed in arnold
+    if (cameraPath.IsEmpty()) {
+        UsdRelationship cameraRel = renderSettings.GetCameraRel();
+        SdfPathVector camTargets;
+        cameraRel.GetTargets(&camTargets);
+        if (!camTargets.empty())
+            cameraPath = camTargets[0];
+    }
     UsdPrim camera = renderSettingsPrim.GetStage()->GetPrimAtPath(cameraPath);
     // just supporting a single camera for now
     if (camera)

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -133,14 +133,12 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
         }
 
         TimeSettings timeSettings;
-        std::string renderSettingsPath;
-        ChooseRenderSettings(stage, renderSettingsPath, timeSettings);
-        if (!renderSettingsPath.empty()) {
-            auto renderSettingsPrim = stage->GetPrimAtPath(SdfPath(renderSettingsPath));
+        ChooseRenderSettings(stage, _renderSettings, timeSettings);
+        if (!_renderSettings.empty()) {
+            UsdPrim renderSettingsPrim = stage->GetPrimAtPath(SdfPath(_renderSettings));
             ReadRenderSettings(renderSettingsPrim, arnoldRenderDelegate->GetAPIAdapter(), timeSettings, _universe, renderCameraPath);
         }
     } 
-
 
     if (arnoldRenderDelegate->GetProceduralParent() && universeCamera != nullptr) {
         // When we render this through a procedural, there is no camera prim

--- a/libs/translator/reader/read_options.cpp
+++ b/libs/translator/reader/read_options.cpp
@@ -44,14 +44,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 /// This function will read the RenderSettings and its dependencies, the linked RenderProduct and RenderVar primitives
 AtNode* UsdArnoldReadRenderSettings::Read(const UsdPrim &renderSettingsPrim, UsdArnoldReaderContext &context)
 {
-    UsdRenderSettings renderSettings(renderSettingsPrim);
-    UsdRelationship cameraRel = renderSettings.GetCameraRel();
-    SdfPathVector camTargets;
-    cameraRel.GetTargets(&camTargets);
-    SdfPath cameraPath;
-    if (!camTargets.empty())
-    	cameraPath = camTargets[0];
-
+	SdfPath cameraPath;
     return ReadRenderSettings(renderSettingsPrim, context, context.GetTimeSettings(), context.GetReader()->GetUniverse(), cameraPath);
 }
 

--- a/libs/translator/reader/read_options.cpp
+++ b/libs/translator/reader/read_options.cpp
@@ -44,7 +44,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 /// This function will read the RenderSettings and its dependencies, the linked RenderProduct and RenderVar primitives
 AtNode* UsdArnoldReadRenderSettings::Read(const UsdPrim &renderSettingsPrim, UsdArnoldReaderContext &context)
 {
-	SdfPath cameraPath;
+    SdfPath cameraPath;
     return ReadRenderSettings(renderSettingsPrim, context, context.GetTimeSettings(), context.GetReader()->GetUniverse(), cameraPath);
 }
 

--- a/testsuite/test_0203/README
+++ b/testsuite/test_0203/README
@@ -4,4 +4,3 @@ see #1016
 
 author: sebastien ortega
 
-PARAMS: {'hydra': False}


### PR DESCRIPTION
**Changes proposed in this pull request**
I'm moving the code from the translator option's reader to get the camera from the render settings, to the common code for render settings. 
Also, the hydra reader now calls `ChooseRenderSettings` with the render settings primitive set by the procedural. 
This allows to render test_0203 in hydra mode

**Issues fixed in this pull request**
Fixes #2003 
