### PR TITLE
Fix test_0208 to work in hydra mode

### DIFF
--- a/testsuite/test_0208/README
+++ b/testsuite/test_0208/README
@@ -3,4 +3,4 @@ See #1067
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0208/data/scene.ass
+++ b/testsuite/test_0208/data/scene.ass
@@ -228,6 +228,7 @@ standard_surface
 {
  name aiStandard3
  base_color checker
+ specular_color place2dTexture1
 }
 checkerboard
 {
@@ -316,10 +317,12 @@ uv_transform
  rotate 0
 }
 
-standard
+standard_surface
 {
  name aiStandard5
- Kd_color 0 0 1
+ base_color 0 0 1
+ specular_color place2dTexture2
+
 }
 
 range

--- a/testsuite/test_0208/data/test.cpp
+++ b/testsuite/test_0208/data/test.cpp
@@ -30,19 +30,26 @@ int main(int argc, char **argv)
                                             "/mtl/aiStandard5displacementShader3/displacementShader3",
                                             "/mtl/aiStandard5displacementShader3/checker1_cc",
                                             "/mtl/aiStandard5displacementShader3/checker1",
-                                            "/place2dTexture1_u",
-                                            "/place2dTexture1_v",
-                                            "/place2dTexture1",
-                                            "/place2dTexture1_passthrough",
-                                            "/place2dTexture2_u",
-                                            "/place2dTexture2_v",
-                                            "/place2dTexture2",
-                                            "/place2dTexture2_passthrough",
+                                            "/mtl/aiStandard3/place2dTexture1_u",
+                                            "/mtl/aiStandard3/place2dTexture1_v",
+                                            "/mtl/aiStandard3/place2dTexture1",
+                                            "/mtl/aiStandard3/place2dTexture1_passthrough",
+                                            "/mtl/aiStandard5/place2dTexture2_u",
+                                            "/mtl/aiStandard5/place2dTexture2_v",
+                                            "/mtl/aiStandard5/place2dTexture2",
+                                            "/mtl/aiStandard5/place2dTexture2_passthrough",
                                         };
 
     AiBegin();
     bool success = true;
     AiSceneLoad(nullptr, "scene.usda", nullptr);
+
+    
+    params = AiParamValueMap();
+    AiParamValueMapSetBool(params, AtString("binary"), false);
+    AiSceneWrite(nullptr, "scene_resaved.ass", params);
+    AiParamValueMapDestroy(params);
+
 
     for (auto &testName : includeList) {
         std::string name = "/beautiful/scope" + testName;

--- a/testsuite/test_0208/data/test.cpp
+++ b/testsuite/test_0208/data/test.cpp
@@ -44,13 +44,6 @@ int main(int argc, char **argv)
     bool success = true;
     AiSceneLoad(nullptr, "scene.usda", nullptr);
 
-    
-    params = AiParamValueMap();
-    AiParamValueMapSetBool(params, AtString("binary"), false);
-    AiSceneWrite(nullptr, "scene_resaved.ass", params);
-    AiParamValueMapDestroy(params);
-
-
     for (auto &testName : includeList) {
         std::string name = "/beautiful/scope" + testName;
         if (!AiNodeLookUpByName(nullptr, name.c_str())) {


### PR DESCRIPTION
This PR modifies test_0208 so that it can work in hydra mode.
The difference between usd and hydra is that the later filters out the materials that are not assigned to any geometry. This c++ test was relying on some unconnected shaders from being loaded, so I connected them and adapted their name.