### PR TITLE
Allow test 199 to work in hydra mode

### DIFF
--- a/testsuite/test_0199/README
+++ b/testsuite/test_0199/README
@@ -4,4 +4,4 @@ see #969
 
 author: sebastien.ortega
 
-PARAMS: {'scene':'test.usda', 'hydra': False}
+PARAMS: {'scene':'test.usda', 'diff_hardfail': 0.065}


### PR DESCRIPTION
test 199 needs a small threshold to work in hydra mode. I've been comparing the translated arnold scenes between usd and hydra and everything seems consistent. There is a tiny rounding difference in camera's focus distance, which could be the cause of the diff since the render shows a very bright sun from physical sky