### PR TITLE
Update light attribute names in several tests

### DIFF
--- a/testsuite/test_0042/data/sphere.usd
+++ b/testsuite/test_0042/data/sphere.usd
@@ -11,8 +11,8 @@ def Sphere "sphere"
 
 def RectLight "quad"
 {
-  color3f color = (1, 1, 1)
-  prepend color3f color.connect = </cc2.outputs:out>
+  color3f inputs:color = (1, 1, 1)
+  prepend color3f inputs:color.connect = </cc2.outputs:out>
 
  float inputs:intensity=5
  float inputs:width = 20

--- a/testsuite/test_0181/data/test.usda
+++ b/testsuite/test_0181/data/test.usda
@@ -58,17 +58,12 @@ def Xform "pointLight1"(apiSchemas = ["CollectionAPI:lightLink", "CollectionAPI:
         float inputs:diffuse = 1
         float inputs:exposure = 0
         float inputs:intensity = 64
-        color3f color = (1, 1, 1)
-        float diffuse = 5
-        float exposure = 2
-        float intensity = 14
         vector3f[] primvars:arnold:position = [(0, 0, 0)]
         string primvars:dcc_name = "pointLightShape1" (
             elementSize = 1
             interpolation = "constant"
         )
         float inputs:specular = 1
-        float specular = 5
         bool treatAsPoint = 1
         matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 6.294501781463623, 3.448580503463745, 1) )
         uniform token[] xformOpOrder = ["xformOp:transform"]
@@ -92,21 +87,19 @@ def Xform "transform1"
 {
     def RectLight "aiAreaLight"
     {
-        color3f color = (0, 1, 0)
-        float diffuse = 1
-        float exposure = 0
+        color3f inputs:color = (0, 1, 0)
+        float inputs:diffuse = 1
+        float inputs:exposure = 0
         float inputs:height = 2
-        float height = 20
-        float intensity = 64
-        bool normalize = 1
+        float inputs:intensity = 64
+        bool inputs:normalize = 1
         string[] primvars:arnold:filters = ["defaultLightDecay"]
         vector3f[] primvars:arnold:vertices = [(1, -1, 0), (-1, -1, 0), (-1, 1, 0), (1, 1, 0)]
         string primvars:dcc_name = "aiAreaLight" (
             elementSize = 1
             interpolation = "constant"
         )
-        float specular = 1
-        float width = 15
+        float inputs:specular = 1
         float inputs:width = 2
         matrix4d xformOp:transform = ( (0.95982426404953, 0.28060176968574524, 0, 0), (0.012077394872903824, -0.0413118451833725, -0.999073326587677, 0), (-0.2803417146205902, 0.9589348435401917, -0.04304105043411255, 0), (0, 6.185134410858154, 0, 1) )
         uniform token[] xformOpOrder = ["xformOp:transform"]
@@ -132,17 +125,15 @@ def Xform "transform2"
     {
         color3f inputs:color = (1, 1, 1)
         prepend color3f inputs:color.connect = </ramp1.outputs:out>
-        color3f color = (0.5, 0.5, 0.5)
-        prepend color3f color.connect = </ramp2.outputs:out>
-        float diffuse = 1
-        float exposure = 0
-        float intensity = 1
+        float inputs:diffuse = 1
+        float inputs:exposure = 0
+        float inputs:intensity = 1
         int primvars:arnold:samples = 4
         string primvars:dcc_name = "aiSkyDomeLight" (
             elementSize = 1
             interpolation = "constant"
         )
-        float specular = 1
+        float inputs:specular = 1
         token texture:format = "latlong"
         uniform token collection:lightLink:expansionRule = "expandPrims"
         uniform bool collection:lightLink:includeRoot = 0

--- a/testsuite/test_0192/README
+++ b/testsuite/test_0192/README
@@ -4,4 +4,4 @@ See #987
 
 author: sebastien ortega
 
-PARAMS: {'scene':'scene.usda', 'hydra': False}
+PARAMS: {'scene':'scene.usda'}

--- a/testsuite/test_0192/data/scene.usda
+++ b/testsuite/test_0192/data/scene.usda
@@ -185,20 +185,20 @@ def Scope "lights" (
                     uniform token collection:shadowLink:expansionRule = "expandPrims"
                     uniform bool collection:shadowLink:includeRoot = 0
                     rel collection:shadowLink:includes = </cube1>
-                    color3f color = (1, 1, 1)
-                    float diffuse = 1
-                    bool enableColorTemperature = 0
-                    float exposure = 5
-                    rel filters = None
+                    color3f inputs:color = (1, 1, 1)
+                    float inputs:diffuse = 1
+                    bool inputs:enableColorTemperature = 0
+                    float inputs:exposure = 5
+                    rel inputs:filters = None
                     custom float houdini:guidescale = 1
-                    float intensity = 1
-                    bool normalize = 1
+                    float inputs:intensity = 1
+                    bool inputs:normalize = 1
                     custom string[] primvars:arnold:filters = []
                     float primvars:arnold:radius = 0 (
                         interpolation = "constant"
                     )
-                    float specular = 1
                     bool treatAsPoint = 1
+                    float inputs:specular = 1
                     matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 5.076481996015048, 0.7203046320388973, 1) )
                     uniform token[] xformOpOrder = ["xformOp:transform"]
 

--- a/testsuite/test_0193/README
+++ b/testsuite/test_0193/README
@@ -4,4 +4,4 @@ See #945
 
 author: sebastien ortega
 
-PARAMS: {'scene':'scene.usda', 'hydra': False}
+PARAMS: {'scene':'scene.usda'}

--- a/testsuite/test_0193/data/scene.usda
+++ b/testsuite/test_0193/data/scene.usda
@@ -200,21 +200,21 @@ def Scope "lights" (
                     prepend apiSchemas = ["ShadowAPI"]
                 )
                 {
-                    color3f color = (1, 1, 1)
-                    float diffuse = 1
-                    bool enableColorTemperature = 0
-                    float exposure = 5
-                    rel filters = None
+                    color3f inputs:color = (1, 1, 1)
+                    float inputs:diffuse = 1
+                    bool inputs:enableColorTemperature = 0
+                    float inputs:exposure = 5
+                    rel inputs:filters = None
                     custom float houdini:guidescale = 1
                     color3f inputs:shadow:color = (1, 0, 0)
                     bool inputs:shadow:enable = 1
-                    float intensity = 1
-                    bool normalize = 1
+                    float inputs:intensity = 1
+                    bool inputs:normalize = 1
                     custom string[] primvars:arnold:filters = []
                     float primvars:arnold:radius = 0 (
                         interpolation = "constant"
                     )
-                    float specular = 1
+                    float inputs:specular = 1
                     bool treatAsPoint = 1
                     matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 8.076481996015048, 5.720304632038897, 1) )
                     uniform token[] xformOpOrder = ["xformOp:transform"]


### PR DESCRIPTION
Several tests were still relying on the old formatting (without the inputs namespace), this PR updates some of them. 
tests 192 and 193 are now succeeding in hydra mode (hydra doesn't support the old format)