### PR TITLE
Write spot and photometric lights as UsdLux schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [usd#2000](https://github.com/Autodesk/arnold-usd/issues/2000) - Write light filters through node graphs so they can be rendered in Hydra
 - [usd#1997](https://github.com/Autodesk/arnold-usd/issues/1997) - Apply correct amount of transform keys when xformOp is set on parent prims
 - [usd#2003](https://github.com/Autodesk/arnold-usd/issues/2003) - Choose render settings primitive through hydra scene loader
+- [usd#2008](https://github.com/Autodesk/arnold-usd/issues/2008) - Write spot and photometric lights as UsdLux schemas
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/translator/writer/registry.cpp
+++ b/libs/translator/writer/registry.cpp
@@ -54,6 +54,8 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
         RegisterWriter("cylinder_light", new UsdArnoldWriteCylinderLight());
         RegisterWriter("point_light", new UsdArnoldWriteSphereLight());
         RegisterWriter("quad_light", new UsdArnoldWriteRectLight());
+        RegisterWriter("spot_light", new UsdArnoldWriteSpotLight());
+        RegisterWriter("photometric_light", new UsdArnoldWritePhotometricLight());
         RegisterWriter("mesh_light", new UsdArnoldWriteGeometryLight());
 
         RegisterWriter("persp_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_PERSPECTIVE));

--- a/libs/translator/writer/write_light.h
+++ b/libs/translator/writer/write_light.h
@@ -37,3 +37,5 @@ REGISTER_PRIM_WRITER(UsdArnoldWriteSphereLight);
 REGISTER_PRIM_WRITER(UsdArnoldWriteRectLight);
 REGISTER_PRIM_WRITER(UsdArnoldWriteCylinderLight);
 REGISTER_PRIM_WRITER(UsdArnoldWriteGeometryLight);
+REGISTER_PRIM_WRITER(UsdArnoldWriteSpotLight);
+REGISTER_PRIM_WRITER(UsdArnoldWritePhotometricLight);

--- a/testsuite/test_0075/README
+++ b/testsuite/test_0075/README
@@ -2,4 +2,4 @@ Photometric lights
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0092/README
+++ b/testsuite/test_0092/README
@@ -2,4 +2,4 @@ Spot light roundness
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of authoring spot & photometric lights to USD as ArnoldSpotLight and ArnoldPhotometricLight schemas (which aren't supported in hydra), we author them as Sphere lights with ShapingAPI

This allows to run tests 75 and 92 in hydra mode

**Issues fixed in this pull request**
Fixes #2008 
