### PR TITLE
Enable the use of half aovs in the render delegate when rendering custom products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## Pending next bugfix release
+- [usd#1989](https://github.com/Autodesk/arnold-usd/issues/1989) - Support mixed half/float channels when using the render delegate in batch mode with husk.
+
+
 ## Pending feature release
 
 ### Feature

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -895,6 +895,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                     auto* enableFiltering = static_cast<bool*>(AiArrayMap(enableFilteringArray));
                     auto* halfPrecisionArray = AiArrayAllocate(numRenderVars, 1, AI_TYPE_BOOLEAN);
                     auto* halfPrecision = static_cast<bool*>(AiArrayMap(halfPrecisionArray));
+                    const bool isDeepExrDriver = AiNodeIs(customProduct.driver, str::driver_deepexr);
                     for (const auto& renderVar : product.renderVars) {
                         CustomRenderVar customRenderVar;
                         *tolerance =
@@ -938,6 +939,9 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                             if (!renderVar.name.empty() && renderVar.name != renderVar.sourceName) {
                                 output += TfStringPrintf(" %s", renderVar.name.c_str());
                             }
+                            if (arnoldTypes.isHalf && !isDeepExrDriver) {
+                                output += " HALF";
+                            }
                             customRenderVar.output = AtString{output.c_str()};
                         }
                         tolerance += 1;
@@ -950,7 +954,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                     AiArrayUnmap(halfPrecisionArray);
 
                     // FIXME do we still need to do a special case for deep exr or should we generalize this ? #1422
-                    if (AiNodeIs(customProduct.driver, str::driver_deepexr)) {
+                    if (isDeepExrDriver) {
                         AiNodeSetArray(customProduct.driver, str::layer_tolerance, toleranceArray);
                         AiNodeSetArray(customProduct.driver, str::layer_enable_filtering, enableFilteringArray);
                         AiNodeSetArray(customProduct.driver, str::layer_half_precision, halfPrecisionArray);


### PR DESCRIPTION
Changes proposed in this pull request

To enable the half float we add HALF at the end of the output aov line.

Fixes #1989