### PR TITLE
Support treatAsPoint in spot light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [usd#2000](https://github.com/Autodesk/arnold-usd/issues/2000) - Write light filters through node graphs so they can be rendered in Hydra
 - [usd#1997](https://github.com/Autodesk/arnold-usd/issues/1997) - Apply correct amount of transform keys when xformOp is set on parent prims
 - [usd#2003](https://github.com/Autodesk/arnold-usd/issues/2003) - Choose render settings primitive through hydra scene loader
+- [usd#2010](https://github.com/Autodesk/arnold-usd/issues/2010) - Support TreatAsPoint in spot lights
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/light.cpp
+++ b/libs/render_delegate/light.cpp
@@ -193,7 +193,13 @@ AtString getLightType(HdSceneDelegate* delegate, const SdfPath& id)
 
 auto spotLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* nentry, const SdfPath& id,
                         HdSceneDelegate* sceneDelegate, HdArnoldRenderDelegate* renderDelegate) {
+    
     iterateParams(light, nentry, id, sceneDelegate, renderDelegate, spotParams);
+    const auto treatAsPointValue = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->treatAsPoint);
+    if (treatAsPointValue.IsHolding<bool>() && treatAsPointValue.UncheckedGet<bool>()) {
+        AiNodeResetParameter(light, str::radius);
+        AiNodeResetParameter(light, str::normalize);
+    }
     const auto hdAngle =
         sceneDelegate->GetLightParamValue(id, UsdLuxTokens->inputsShapingConeAngle).GetWithDefault(180.0f);
     const auto softness =
@@ -257,12 +263,11 @@ auto spotLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* nentr
 auto pointLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* nentry, const SdfPath& id,
                          HdSceneDelegate* sceneDelegate, HdArnoldRenderDelegate* renderDelegate) {
     TF_UNUSED(filter);
-    const auto treatAsPointValue = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->treatAsPoint);
+    iterateParams(light, nentry, id, sceneDelegate, renderDelegate, pointParams);
+    const VtValue treatAsPointValue = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->treatAsPoint);
     if (treatAsPointValue.IsHolding<bool>() && treatAsPointValue.UncheckedGet<bool>()) {
-        AiNodeSetFlt(light, str::radius, 0.0f);
-        AiNodeSetBool(light, str::normalize, true);
-    } else {
-        iterateParams(light, nentry, id, sceneDelegate, renderDelegate, pointParams);
+        AiNodeResetParameter(light, str::radius);
+        AiNodeResetParameter(light, str::normalize);
     }
     readUserData(light, id, sceneDelegate, renderDelegate);
 };

--- a/libs/translator/reader/read_light.cpp
+++ b/libs/translator/reader/read_light.cpp
@@ -194,7 +194,9 @@ void _ReadLightLinks(const UsdPrim &prim, AtNode *node, UsdArnoldReaderContext &
     UsdCollectionAPI lightLinkCollection = light.GetLightLinkCollectionAPI();
     if (lightLinkCollection) {
         VtValue lightIncludeRootValue;
-        bool lightIncludeRoot = (lightLinkCollection.GetIncludeRootAttr().Get(&lightIncludeRootValue)) ? VtValueGetBool(lightIncludeRootValue) : false;
+        UsdAttribute includeRootAttr = lightLinkCollection.GetIncludeRootAttr();
+        bool lightIncludeRoot = (includeRootAttr.HasAuthoredValue() && 
+            includeRootAttr.Get(&lightIncludeRootValue)) ? VtValueGetBool(lightIncludeRootValue) : false;
         UsdRelationship lightExcludeRel = lightLinkCollection.GetExcludesRel();
         if (!lightIncludeRoot  || lightExcludeRel.HasAuthoredTargets()) {
             // we have an explicit list of geometries for this light
@@ -205,7 +207,8 @@ void _ReadLightLinks(const UsdPrim &prim, AtNode *node, UsdArnoldReaderContext &
     UsdCollectionAPI shadowLinkCollection = light.GetShadowLinkCollectionAPI();
     if (shadowLinkCollection) {
         VtValue shadowIncludeRootValue;
-        bool shadowIncludeRoot = (shadowLinkCollection.GetIncludeRootAttr().Get(&shadowIncludeRootValue)) ? VtValueGetBool(shadowIncludeRootValue) : false;
+        UsdAttribute includeRootAttr = shadowLinkCollection.GetIncludeRootAttr();
+        bool shadowIncludeRoot = (includeRootAttr.HasAuthoredValue() && includeRootAttr.Get(&shadowIncludeRootValue)) ? VtValueGetBool(shadowIncludeRootValue) : false;
         UsdRelationship shadowExcludeRel = shadowLinkCollection.GetExcludesRel();
         if (!shadowIncludeRoot  || shadowExcludeRel.HasAuthoredTargets()) {
             // we have an explicit list of geometries for this light's shadows

--- a/testsuite/test_0116/README
+++ b/testsuite/test_0116/README
@@ -2,4 +2,4 @@ Toon Shader
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0190/README
+++ b/testsuite/test_0190/README
@@ -4,4 +4,4 @@ see #1019
 
 author: sebastien.ortega
 
-PARAMS: {'scene':'test.usda', 'hydra': False}
+PARAMS: {'scene':'test.usda'}


### PR DESCRIPTION
**Changes proposed in this pull request**
In the delegate, we were not taking into account treatAsPoint in spot lights. 
For point & photometric lights sets the radius to 0 and ignores the normalize attribute, so I'm porting the same thing for spot lights (which the usd procedural is already doing).

This enables test 190 and 116 in hydra mode

**Issues fixed in this pull request**
Fixes #2010
