### PR TITLE
Support points with empty widths

### DIFF
--- a/libs/render_delegate/points.cpp
+++ b/libs/render_delegate/points.cpp
@@ -49,11 +49,6 @@ void HdArnoldPoints::Sync(
         transformDirtied = true;
     }
 
-    if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->widths)) {
-        param.Interrupt();
-        HdArnoldSetRadiusFromPrimvar(GetArnoldNode(), id, sceneDelegate);
-    }
-
     CheckVisibilityAndSidedness(sceneDelegate, id, dirtyBits, param);
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
@@ -115,6 +110,11 @@ void HdArnoldPoints::Sync(
         param.Interrupt();
         HdArnoldSetPositionFromPrimvar(
             GetArnoldNode(), id, sceneDelegate, str::points, param(), GetDeformKeys(), &_primvars);
+    }
+    // Ensure we set radius after the positions, as we might need to check the amount of points #2015
+    if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->widths)) {
+        param.Interrupt();
+        HdArnoldSetRadiusFromPrimvar(GetArnoldNode(), id, sceneDelegate);
     }
 
     SyncShape(*dirtyBits, sceneDelegate, param, transformDirtied);

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -572,6 +572,14 @@ void HdArnoldSetRadiusFromPrimvar(AtNode* node, const SdfPath& id, HdSceneDelega
     HdArnoldSampledType<VtFloatArray> xf;
     HdArnoldUnboxSample(sample, xf);
     if (xf.count == 0) {
+        AtArray *pointsArray = AiNodeGetArray(node, str::points);
+        unsigned int pointsCount = pointsArray ? AiArrayGetNumElements(pointsArray) : 0;
+        if (pointsCount > 0) {
+            // USD accepts empty width attributes, or a constant width for all points,
+            // but arnold fails in that case. So we need to generate a dedicated array
+            std::vector<float> radiusVec(pointsCount, 0.f);
+            AiNodeSetArray(node, str::radius, AiArrayConvert(pointsCount, 1, AI_TYPE_FLOAT, &radiusVec[0]));
+        }
         return;
     }
 

--- a/testsuite/test_0185/README
+++ b/testsuite/test_0185/README
@@ -4,4 +4,4 @@ see #928
 
 author: sebastien.ortega
 
-PARAMS: {'scene':'scene.usd', 'hydra': False}
+PARAMS: {'scene':'scene.usd'}


### PR DESCRIPTION
**Changes proposed in this pull request**
We need to port the logic from the usd procedural to hydra. If we find widths as an empty array, we need to create in arnold an array of the same size as the amount of points, with a value of 0. This way, renders don't error out.
This solves test_0185 in hydra mode

**Issues fixed in this pull request**
Fixes #2015
