### PR TITLE
Set root transform & node id in the hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [usd#2000](https://github.com/Autodesk/arnold-usd/issues/2000) - Write light filters through node graphs so they can be rendered in Hydra
 - [usd#1997](https://github.com/Autodesk/arnold-usd/issues/1997) - Apply correct amount of transform keys when xformOp is set on parent prims
 - [usd#2003](https://github.com/Autodesk/arnold-usd/issues/2003) - Choose render settings primitive through hydra scene loader
+- [usd#2017](https://github.com/Autodesk/arnold-usd/issues/2017) - Set root transform and node id in the hydra procedural
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -516,6 +516,8 @@ public:
     /// @param mask as an integer, combining the different bits for node types (e.g. AI_NODE_SHAPE, AI_NODE_SHADER, etc...)
     void SetMask(int mask) {_mask = mask;}
 
+    void SetNodeId(int id) {_nodeId = id;}
+
 #if PXR_VERSION >= 2108
     /// Get the descriptors for the commands supported by this render delegate.
     HDARNOLD_API
@@ -534,6 +536,12 @@ public:
     AtNode * CreateArnoldNode(const AtString &nodeType, const AtString &nodeName) {
         AtNode *node = AiNode(GetUniverse(), nodeType, nodeName, _procParent);
         if (_procParent) {
+
+            // All shape nodes should have an id parameter if we're coming from a parent procedural
+            if (AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE) {
+                AiNodeSetUInt(node, str::id, _nodeId);
+            }
+            
             std::lock_guard<std::mutex> lock(_nodesMutex);
             _nodes.push_back(node);
         }
@@ -723,7 +731,7 @@ private:
     // resolution as returned from the render settings
     GfVec2i _resolution = GfVec2i(0, 0);
     float _pixelAspectRatio = 1.f;
-    
+    int _nodeId = 0;
     /// Top level render context using Hydra. Ie. Hydra, Solaris, Husk.
     TfToken _context;
     bool _isBatch = false; // are we in a batch rendering context (e.g. Husk)

--- a/testsuite/test_0176/README
+++ b/testsuite/test_0176/README
@@ -4,4 +4,4 @@ See usd#730
 
 author: Pal Mezei
 
-PARAMS: {'hydra': False}
+PARAMS: {'diff_hardfail':0.07}


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR, when a procedural is used in hydra mode, we check its transform matrix, and apply it to the imaging delegate as a root transform. 
Also, when a shape node is created, we apply the same logic as the usd translator and propagate the node id integer to all children.

Both these changes allow test_0176 to pass in hydra mode

**Issues fixed in this pull request**
Fixes #2017 

