### PR TITLE
Support purpose in the hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [usd#2000](https://github.com/Autodesk/arnold-usd/issues/2000) - Write light filters through node graphs so they can be rendered in Hydra
 - [usd#1997](https://github.com/Autodesk/arnold-usd/issues/1997) - Apply correct amount of transform keys when xformOp is set on parent prims
 - [usd#2003](https://github.com/Autodesk/arnold-usd/issues/2003) - Choose render settings primitive through hydra scene loader
+- [usd#2019](https://github.com/Autodesk/arnold-usd/issues/2019) - Support purpose in the hydra procedural
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -160,6 +160,10 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
     SdfPathVector _excludedPrimPaths; // excluding nothing
     SdfPath rootPath = (path.empty()) ? SdfPath::AbsoluteRootPath() : SdfPath(path.c_str());
     _imagingDelegate->Populate(stage->GetPrimAtPath(rootPath), _excludedPrimPaths);
+    // These calls don't seem to have any effect, but I'm setting them anyway for safety    
+    _imagingDelegate->SetDisplayRender(_purpose == UsdGeomTokens->render);
+    _imagingDelegate->SetDisplayProxy(_purpose == UsdGeomTokens->proxy);
+    _imagingDelegate->SetDisplayGuides(_purpose == UsdGeomTokens->guide);
 
     // Not sure about the meaning of collection geometry -- should that be extended ?
     HdRprimCollection collection(HdTokens->geometry, HdReprSelector(HdReprTokens->hull));
@@ -202,6 +206,15 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
 
     arnoldRenderDelegate->ProcessConnections();
     
+    // We want to render the purpose that this reader was assigned to.
+    // We must also support the purpose "default". Also, when no
+    // purpose is set in the usd file, it seems to shows as "geometry", so we need to support that too
+    TfTokenVector purpose;
+    purpose.push_back(UsdGeomTokens->default_);
+    purpose.push_back(_purpose);
+    purpose.push_back(HdTokens->geometry);
+    arnoldRenderDelegate->SetRenderTags(purpose);
+
     // The scene might not be up to date, because of light links, etc, that were generated during the first sync.
     // ShouldSkipIteration updates the dirtybits for a resync, this is how it works in our hydra render pass.
     while (arnoldRenderDelegate->ShouldSkipIteration(_renderIndex, shutter)) {

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1653,10 +1653,8 @@ void HdArnoldRenderDelegate::ClearDependencies(const SdfPath& source)
 
 void HdArnoldRenderDelegate::TrackRenderTag(AtNode* node, const TfToken& tag)
 {
-    if (!IsBatchContext()) {
-        AiNodeSetDisabled(node, std::find(_renderTags.begin(), _renderTags.end(), tag) == _renderTags.end());
-        _renderTagTrackQueue.push({node, tag});
-    }
+    AiNodeSetDisabled(node, std::find(_renderTags.begin(), _renderTags.end(), tag) == _renderTags.end());
+    _renderTagTrackQueue.push({node, tag});
 }
 
 void HdArnoldRenderDelegate::UntrackRenderTag(AtNode* node) { _renderTagUntrackQueue.push(node); }

--- a/testsuite/test_0167/README
+++ b/testsuite/test_0167/README
@@ -3,5 +3,3 @@ Support purpose in the procedural
 Fixes #188
 
 author: sebastien ortega
-
-PARAMS: {'hydra': False}


### PR DESCRIPTION
**Changes proposed in this pull request**
The hydra reader must call SetRenderTags on the render delegate with the expected purpose ("render" by default), so that e.g. proxy geometries are skipped from the render. For some reason, primitives with a default purpose don't show with a "default" render tag, but "geometry", so I need to add this value to the expected render tags.

Also, TrackRenderTag was doing nothing in "batch" context, and this check was added in the first draft of the hydra procedural, so I'm assuming we can reintroduce it back given the hydra testsuite is working as expected. 

This allows to run test_0167 in hydra mode

**Issues fixed in this pull request**
Fixes #2019 
