### PR TITLE
Pass the render error code to husk via the render stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [usd#2015](https://github.com/Autodesk/arnold-usd/issues/2015) - Support hydra points with empty widths
 - [usd#2008](https://github.com/Autodesk/arnold-usd/issues/2008) - Write spot and photometric lights as UsdLux schemas
 - [usd#2025](https://github.com/Autodesk/arnold-usd/issues/2025) - Write imagers through node graphs for hydra support
+- [usd#1174](https://github.com/Autodesk/arnold-usd/issues/1174) - When the render errors or is aborted, husk will now exit with error code (houdini >= 20.5)
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -90,6 +90,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (sourceType)
     (sourceName)
     (dataType)
+    (huskErrorStatus)
     ((format, "aovDescriptor.format"))
     ((clearValue, "aovDescriptor.clearValue"))
     ((multiSampled, "aovDescriptor.multiSampled"))
@@ -1049,6 +1050,13 @@ VtDictionary HdArnoldRenderDelegate::GetRenderStats() const
             // TODO do we want to check if the metadata is not a string ?
             stats[TfToken(metadataName)] = TfToken(metadataVal);
         }
+    }
+
+    // If we have a render error, we want to send it to husk which will exit with this error code.
+    // Husk will also display a message like "[15:16:41] Delegate fatal error (1) detected" 
+    auto errorCode = _renderParam->GetErrorCode();
+    if (errorCode != AI_SUCCESS) {
+        stats[_tokens->huskErrorStatus] = static_cast<int>(errorCode);
     }
     return stats;
 }

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -126,24 +126,24 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::Render()
     if (status == AI_RENDER_STATUS_FAILED) {
         _aborted.store(true, std::memory_order_release);
         _paused.store(false, std::memory_order_release);
-        const auto errorCode = AiRenderEnd(_delegate->GetRenderSession());
-        if (errorCode == AI_ABORT) {
+        _errorCode = AiRenderEnd(_delegate->GetRenderSession());
+        if (_errorCode == AI_ABORT) {
             TF_WARN("[arnold-usd] Render was aborted.");
-        } else if (errorCode == AI_ERROR_NO_CAMERA) {
+        } else if (_errorCode == AI_ERROR_NO_CAMERA) {
             TF_WARN("[arnold-usd] Camera not defined.");
-        } else if (errorCode == AI_ERROR_BAD_CAMERA) {
+        } else if (_errorCode == AI_ERROR_BAD_CAMERA) {
             TF_WARN("[arnold-usd] Bad camera data.");
-        } else if (errorCode == AI_ERROR_VALIDATION) {
+        } else if (_errorCode == AI_ERROR_VALIDATION) {
             TF_WARN("[arnold-usd] Usage not validated.");
-        } else if (errorCode == AI_ERROR_RENDER_REGION) {
+        } else if (_errorCode == AI_ERROR_RENDER_REGION) {
             TF_WARN("[arnold-usd] Invalid render region.");
-        } else if (errorCode == AI_INTERRUPT) {
+        } else if (_errorCode == AI_INTERRUPT) {
             TF_WARN("[arnold-usd] Render interrupted by user.");
-        } else if (errorCode == AI_ERROR_NO_OUTPUTS) {
+        } else if (_errorCode == AI_ERROR_NO_OUTPUTS) {
             TF_WARN("[arnold-usd] No rendering outputs.");
-        } else if (errorCode == AI_ERROR_UNAVAILABLE_DEVICE) {
+        } else if (_errorCode == AI_ERROR_UNAVAILABLE_DEVICE) {
             TF_WARN("[arnold-usd] Cannot create GPU context.");
-        } else if (errorCode == AI_ERROR) {
+        } else if (_errorCode == AI_ERROR) {
             TF_WARN("[arnold-usd] Generic error.");
         }
         return Status::Aborted;

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -145,6 +145,11 @@ public:
     /// @return elapsed render time in ms
     double GetElapsedRenderTime() const;
 
+    /// Returns the latest render error code.
+    ///
+    /// @return error code.
+    AtRenderErrorCode GetErrorCode() const {return _errorCode;};
+
 private:
     inline void ResetStartTimer()
     {
@@ -173,6 +178,8 @@ private:
     float _fps = 24.0f;
     /// optionally save out the arnold scene to a file, before it's rendered
     std::string _debugScene;
+    /// Arnold error code
+    AtRenderErrorCode _errorCode = AI_SUCCESS;
 };
 
 class HdArnoldRenderParamInterrupt {


### PR DESCRIPTION
**Changes proposed in this pull request**
- houdini 20.5 brings the ability to return an error code from husk when the render encounter an error or is aborted. This PR implements this feature by passing the render error code to husk via the render stats. 

**Issues fixed in this pull request**
Fixes #1174

