### PR TITLE
Visibility and sidedness attributes not supported in Arnold native hydra prims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [usd#2025](https://github.com/Autodesk/arnold-usd/issues/2025) - Write imagers through node graphs for hydra support
 - [usd#2042](https://github.com/Autodesk/arnold-usd/issues/2042) - Follow hydra normals skinning behavior in the procedural.
 - [usd#1174](https://github.com/Autodesk/arnold-usd/issues/1174) - When the render errors or is aborted, husk will now exit with error code (houdini >= 20.5)
+- [usd#2053](https://github.com/Autodesk/arnold-usd/issues/2053) - Visibility and sidedness attributes not supported in Arnold native hydra prims
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/common/shape_utils.cpp
+++ b/libs/common/shape_utils.cpp
@@ -188,7 +188,7 @@ void ArnoldUsdCurvesData::SetOrientationFromValue(AtNode* node, const VtValue& v
 
 bool ArnoldUsdIgnoreUsdParameter(const TfToken& name)
 {
-    return name == _tokens->matrix || name == _tokens->disp_map || name == _tokens->visibility ||
+    return name == _tokens->matrix || name == _tokens->disp_map || 
            name == _tokens->name || name == _tokens->shader || name == _tokens->id;
 }
 

--- a/libs/render_delegate/native_rprim.cpp
+++ b/libs/render_delegate/native_rprim.cpp
@@ -56,9 +56,6 @@ void HdArnoldNativeRprim::Sync(
         }
     }
 
-    // The last argument means that we don't want to check the sidedness.
-    // The doubleSided attribute (off by default)  should not 
-    // affect arnold native prims. Visibility should be taken into account though
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         param.Interrupt();
         const auto materialId = sceneDelegate->GetMaterialId(id);

--- a/libs/render_delegate/native_rprim.h
+++ b/libs/render_delegate/native_rprim.h
@@ -50,6 +50,7 @@ public:
 private:
     /// List of parameters to query from the Hydra Primitive.
     const HdArnoldRenderDelegate::NativeRprimParamList* _paramList = nullptr;
+    HdArnoldRayFlags _visibilityFlags{AI_RAY_ALL}; ///< Visibility.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -372,8 +372,11 @@ bool ConvertPrimvarToBuiltinParameter(
     const auto* paramEntry = AiNodeEntryLookUpParameter(nodeEntry, AtString(paramName));
     if (paramEntry != nullptr) {
         HdArnoldSetParameter(node, paramEntry, value, renderDelegate);
+        return true;
     }
-    return true;
+    // This attribute hasn't been recognized, let's return false so that it can be treated
+    // as a user data eventually
+    return false;
 }
 
 void HdArnoldSetConstantPrimvar(

--- a/plugins/usd_imaging/shape_adapter.cpp
+++ b/plugins/usd_imaging/shape_adapter.cpp
@@ -73,7 +73,8 @@ VtValue UsdImagingArnoldShapeAdapter::Get(
         for (const auto& paramName : _paramNames) {
             const auto attribute = prim.GetAttribute(paramName.first);
             VtValue value;
-            if (attribute && attribute.Get(&value, time)) {
+            if (attribute && attribute.HasAuthoredValue() && attribute.Get(&value, time)) {
+                // We don't need to treat attributes that don't have any authored value ("Get" would still return true)
                 params.emplace_back(paramName.second, value);
             }
         }

--- a/testsuite/test_0090/README
+++ b/testsuite/test_0090/README
@@ -2,4 +2,4 @@ Procedurals instances visibility
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0100/README
+++ b/testsuite/test_0100/README
@@ -2,4 +2,4 @@ Name collisions in procedurals
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_1331/README
+++ b/testsuite/test_1331/README
@@ -4,5 +4,4 @@ Fixes #1331
 
 author: sebastien ortega
 
-PARAMS: {'scene':'test.usda', 'hydra': False }
-# Disabled in hydra as the skinning seems a bit different
+PARAMS: {'scene':'test.usda'}


### PR DESCRIPTION
**Changes proposed in this pull request**
The delegate code for native_rprims (used for arnold shapes, like ArnoldUsd, ArnoldProcedural, etc...) wasn't supporting properly some attributes, like visibility and sidedness. 
The code was a bit different than other parts of the code, and hadn't been touched for some time. I tried to make it consistent with our other prim types (mesh, procedural_custom, etc...). This fixes test_1331, test_0090 and test_0100

**Issues fixed in this pull request**
Fixes #2051 
Fixes #2053 
