### PR TITLE
Pr/2061

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - [usd#2057](https://github.com/Autodesk/arnold-usd/issues/2057) - Add Ginstance support in hydra and fix a data race issue.
 - [usd#2055](https://github.com/Autodesk/arnold-usd/issues/2055) - Support animated curves orientations in hydra
 - [usd#2053](https://github.com/Autodesk/arnold-usd/issues/2053) - Visibility and sidedness attributes not supported in Arnold native hydra prims
-
+- [usd#2061](https://github.com/Autodesk/arnold-usd/issues/2061) - Support arnold light groups in Hydra
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/basis_curves.cpp
+++ b/libs/render_delegate/basis_curves.cpp
@@ -193,6 +193,10 @@ void HdArnoldBasisCurves::Sync(
             AiNodeSetPtr(GetArnoldNode(), str::shader, GetRenderDelegate()->GetFallbackSurfaceShader());
         }
     }
+    if (*dirtyBits & HdChangeTracker::DirtyCategories) {
+        param.Interrupt();
+        GetRenderDelegate()->ApplyLightLinking(sceneDelegate, GetArnoldNode(), id);
+    }
 
     if (dirtyPrimvars) {
         _visibilityFlags.ClearPrimvarFlags();

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -359,6 +359,10 @@ void HdArnoldMesh::Sync(
             node, subdivTags.GetCornerIndices(), subdivTags.GetCornerWeights(),
             subdivTags.GetCreaseIndices(), subdivTags.GetCreaseLengths(), subdivTags.GetCreaseWeights());
     }
+    if (*dirtyBits & HdChangeTracker::DirtyCategories) {
+        param.Interrupt();
+        _renderDelegate->ApplyLightLinking(sceneDelegate, node, id);
+    }
 
     auto materialsAssigned = false;
     auto assignMaterials = [&]() {

--- a/libs/render_delegate/native_rprim.cpp
+++ b/libs/render_delegate/native_rprim.cpp
@@ -39,6 +39,12 @@ void HdArnoldNativeRprim::Sync(
     HdArnoldRenderParamInterrupt param(renderParam);
     const auto& id = GetId();
 
+    if (*dirtyBits & HdChangeTracker::DirtyCategories) {
+        param.Interrupt();
+        _renderDelegate->ApplyLightLinking(sceneDelegate, GetArnoldNode(), GetId());
+    }
+
+
     int defaultVisibility = AI_RAY_ALL;
     // Sync any built-in parameters.
     if (*dirtyBits & ArnoldUsdRprimBitsParams && Ai_likely(_paramList != nullptr)) {
@@ -107,12 +113,7 @@ void HdArnoldNativeRprim::Sync(
         const auto visibility = _visibilityFlags.Compose();
         AiNodeSetByte(node, str::visibility, visibility);
     }
-
-    if (*dirtyBits & HdChangeTracker::DirtyCategories) {
-        param.Interrupt();
-        _renderDelegate->ApplyLightLinking(sceneDelegate, node, GetId());
-    }
-
+    
     // NOTE: HdArnoldSetTransform must be set after the primvars as, at the moment, we might rewrite the transform in the
     // primvars and it doesn't take into account the inheritance.
     bool transformDirtied = false;

--- a/libs/render_delegate/points.cpp
+++ b/libs/render_delegate/points.cpp
@@ -48,6 +48,10 @@ void HdArnoldPoints::Sync(
         HdArnoldSetTransform(GetArnoldNode(), sceneDelegate, GetId());
         transformDirtied = true;
     }
+    if (*dirtyBits & HdChangeTracker::DirtyCategories) {
+        param.Interrupt();
+        GetRenderDelegate()->ApplyLightLinking(sceneDelegate, GetArnoldNode(), GetId());
+    }
 
     CheckVisibilityAndSidedness(sceneDelegate, id, dirtyBits, param);
 

--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -50,10 +50,7 @@ void HdArnoldShape::Sync(
         param.Interrupt();
         _SetPrimId(rprim->GetPrimId());
     }
-    if (dirtyBits & HdChangeTracker::DirtyCategories) {
-        param.Interrupt();
-        _renderDelegate->ApplyLightLinking(sceneDelegate, _shape, id);
-    }
+    
     // If render tags are empty, we are displaying everything.
     if (dirtyBits & HdChangeTracker::DirtyRenderTag) {
         param.Interrupt();

--- a/testsuite/test_0065/README
+++ b/testsuite/test_0065/README
@@ -2,4 +2,4 @@ Light-linking
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
+PARAMS: {'resaved':'usda'}


### PR DESCRIPTION
**Changes proposed in this pull request**
We need to ensure ApplyLightLinking is called before the primvars are translated. This way we first apply the hydra light linking, and then eventually set the arnold specific attributes on top of it, so that arnold attributes can override the usd ones.

ApplyLightLinking was originally called in `HdArnoldShape::Sync` which is itself invoked by `SyncShape`. And this function is called at the end of shape's Sync functions.
A first solution I tried was to move `SyncShape` to be invoked before the primvars translation loops, but this causes other issues as `SyncShape` also deals with instances and we need that to be called at the end (so that the visibility of instance prototypes can be turned off properly).

Therefore I removed the light linking line from shape.cpp and instead put it in the desired place in the different Sync functions. It's a bit of a duplication and we could totally move this to a HdArnoldShape function, although it's really just a couple of lines so it might not be so bad. I do see a lot of duplicated code in all those Sync functions that we'll want to factorize in the future.

This allows to render test_0065 in hydra mode



**Issues fixed in this pull request**
Fixes #2061
