### PR TITLE
Replace arnold:matrix with a usd transform in the tests

### DIFF
--- a/testsuite/test_0043/README
+++ b/testsuite/test_0043/README
@@ -4,4 +4,3 @@ See #354
 
 author: sebastien ortega
 
-PARAMS: {'hydra': False}

--- a/testsuite/test_0043/data/proc.usd
+++ b/testsuite/test_0043/data/proc.usd
@@ -1,13 +1,20 @@
 #usda 1.0
+(
+    endTimeCode = 1
+    startTimeCode = -1
+)
 
 def ArnoldUsd "usdProc"
 {
     string arnold:filename = "sphere.usd"
-    matrix4d[] arnold:matrix.timeSamples = {
-        -0.5: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (-0.5, 0, 0, 1) )],
-        0: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )],
-        0.5: [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0.5, 0, 0, 1) )],
-    }
-    float arnold:motion_start = -0.5
     float arnold:motion_end = 0.5
+    float arnold:motion_start = -0.5
+    double3 xformOp:translate = (0.5, 0, 0)
+    double3 xformOp:translate.timeSamples = {
+        -0.5: (-0.5, 0, 0),
+        0: (0, 0, 0),
+        0.5: (0.5, 0, 0),
+    }
+    uniform token[] xformOpOrder = ["xformOp:translate"]
 }
+

--- a/testsuite/test_0161/data/nested_proc.usda
+++ b/testsuite/test_0161/data/nested_proc.usda
@@ -5,11 +5,13 @@ def "transform1"
     def ArnoldUsd "correctStandinTransform"
     {
         string arnold:filename = "cube.usda"
-        matrix4d[] arnold:matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
+
         string primvars:dcc_name = "correctStandinTransform" (
             elementSize = 1
             interpolation = "constant"
         )
+        double3 xformOp:translate = (2.5, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
     }
 }
 

--- a/testsuite/test_0162/data/nested_proc.usda
+++ b/testsuite/test_0162/data/nested_proc.usda
@@ -5,11 +5,12 @@ def "transform1"
     def ArnoldUsd "correctStandinTransform"
     {
         string arnold:filename = "sphere.usda"
-        matrix4d[] arnold:matrix = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]
         string primvars:dcc_name = "correctStandinTransform" (
             elementSize = 1
             interpolation = "constant"
         )
+        double3 xformOp:translate = (5, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
     }
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- replace arnold:matrix with a usd transform in the tests
- This makes test_0043 pass the hydra testsuite.

**Issues fixed in this pull request**
Fixes #2065

