### PR TITLE
Skip authoring useless "normals" user data on meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [usd#2055](https://github.com/Autodesk/arnold-usd/issues/2055) - Support animated curves orientations in hydra
 - [usd#2053](https://github.com/Autodesk/arnold-usd/issues/2053) - Visibility and sidedness attributes not supported in Arnold native hydra prims
 - [usd#2061](https://github.com/Autodesk/arnold-usd/issues/2061) - Support arnold light groups in Hydra
+- [usd#2067](https://github.com/Autodesk/arnold-usd/issues/2067) - Do not author useless "normals" user data in meshes/curves through the procedural
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -59,6 +59,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (LightAPI)
+    (normals)
     ((PrimvarsArnoldLightShaders, "primvars:arnold:light:shaders"))
 );
 
@@ -220,12 +221,20 @@ class MeshPrimvarsRemapper : public PrimvarsRemapper
 public:
     MeshPrimvarsRemapper(MeshOrientation &orientation) : _orientation(orientation) {}
     virtual ~MeshPrimvarsRemapper() {}
-
+    bool ReadPrimvar(const TfToken& primvar) override;  
     bool RemapIndexes(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 
         std::vector<unsigned int> &indexes) override;
 private:
     MeshOrientation &_orientation;
 };
+bool MeshPrimvarsRemapper::ReadPrimvar(const TfToken& primvar)
+{
+    // "normals" is translated as "nlist", we don't want to have it as user data
+    if (primvar == _tokens->normals)
+        return false;
+    return true;
+}
+
 bool MeshPrimvarsRemapper::RemapIndexes(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 
         std::vector<unsigned int> &indexes) 
 {
@@ -471,6 +480,7 @@ public:
     CurvesPrimvarsRemapper(bool remapValues, bool pinnedCurve, ArnoldUsdCurvesData &curvesData) : 
                     _remapValues(remapValues), _pinnedCurve(pinnedCurve), _curvesData(curvesData) {}
     virtual ~CurvesPrimvarsRemapper() {}
+    bool ReadPrimvar(const TfToken& primvar) override;
     bool RemapValues(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 
         VtValue &value) override;
     void RemapPrimvar(TfToken &name, std::string &interpolation) override;
@@ -478,6 +488,14 @@ private:
     bool _remapValues, _pinnedCurve;
     ArnoldUsdCurvesData &_curvesData;
 };
+bool CurvesPrimvarsRemapper::ReadPrimvar(const TfToken& primvar)
+{
+    // "normals" is translated as "orientations", we don't want to have it as user data
+    if (primvar == _tokens->normals)
+        return false;
+    return true;
+}
+
 bool CurvesPrimvarsRemapper::RemapValues(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 
     VtValue &value)
 {

--- a/libs/translator/reader/utils.cpp
+++ b/libs/translator/reader/utils.cpp
@@ -872,8 +872,11 @@ void ReadPrimvars(
             continue;
 
         // A remapper can eventually remap the interpolation (e.g. point instancer)
-        if (primvarsRemapper)
+        if (primvarsRemapper) {
+            if (!primvarsRemapper->ReadPrimvar(name))
+                continue;
             primvarsRemapper->RemapPrimvar(name, declaration);
+        }
 
         SdfValueTypeName typeName = primvar.GetTypeName();        
         std::string arnoldIndexName = name.GetText() + std::string("idxs");

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -52,6 +52,7 @@ public:
     PrimvarsRemapper() {}
     virtual ~PrimvarsRemapper() {}  
 
+    virtual bool ReadPrimvar(const TfToken& primvar) {return true;}
     virtual bool RemapValues(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 
         VtValue &value);
     virtual bool RemapIndexes(const UsdGeomPrimvar &primvar, const TfToken &interpolation, 


### PR DESCRIPTION
**Changes proposed in this pull request**
In order to skip the user data "normals" for meshes & curves in ReadPrimvars, I'm using the existing PrimvarsRemappers classes.
I'm adding a function to determine if a given primvar should be skipped. We're no longer getting the user data in resaved ass files, and it doesn't harm the testsuite

**Issues fixed in this pull request**
Fixes #2067 
