### PR TITLE
Read shaders and imagers with masks (WIP)

### DIFF
--- a/libs/translator/reader/read_shader.h
+++ b/libs/translator/reader/read_shader.h
@@ -33,7 +33,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 class UsdArnoldReadShader : public UsdArnoldPrimReader {
 
 public:
-    UsdArnoldReadShader() : UsdArnoldPrimReader(AI_NODE_SHADER) {}
+    UsdArnoldReadShader() : UsdArnoldPrimReader(AI_NODE_SHADER | AI_NODE_IMAGER) {}
     AtNode* Read(const UsdPrim &prim, UsdArnoldReaderContext &context) override;
     static void ReadShaderInputs(const UsdPrim& prim, UsdArnoldReaderContext& context, 
     	AtNode* node);

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -1130,8 +1130,11 @@ AtNode *UsdArnoldReaderThreadContext::CreateArnoldNode(const char *type, const c
             return node;
         }
     }
-
-    if (!(AiNodeEntryGetType(AiNodeEntryLookUp(AtString(type))) & _reader->GetMask())) {
+    const AtNodeEntry *typeEntry = AiNodeEntryLookUp(AtString(type));
+    if (!typeEntry) {
+        return nullptr;
+    }
+    if (!(AiNodeEntryGetType(typeEntry) & _reader->GetMask())) {
         return nullptr;
     }
 

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -1131,6 +1131,10 @@ AtNode *UsdArnoldReaderThreadContext::CreateArnoldNode(const char *type, const c
         }
     }
 
+    if (!(AiNodeEntryGetType(AiNodeEntryLookUp(AtString(type))) & _reader->GetMask())) {
+        return nullptr;
+    }
+
     AtNode *node = AiNode(_reader->GetUniverse(), AtString(type), AtString(name), _reader->GetProceduralParent());
     // All shape nodes should have an id parameter if we're coming from a parent procedural
     if (_reader->GetProceduralParent() && AiNodeEntryGetType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE) {

--- a/testsuite/test_2072.1/README
+++ b/testsuite/test_2072.1/README
@@ -6,6 +6,3 @@ This test create an arnold scene, saves only the imagers (mask=AI_NODE_IMAGER).
 The it reloads the usd scene and check the number of imagers is equal to the number of imagers exported.
 
 author: cyril.pichard@autodesk.com
-
-# Hydra doesn't work yet, we would have to save the inagers inside a node graph.
-PARAMS: {'hydra': False}

--- a/testsuite/test_2072.1/README
+++ b/testsuite/test_2072.1/README
@@ -1,0 +1,11 @@
+Imager nodes masked read/write round trip
+
+see #2072
+
+This test create an arnold scene, saves only the imagers (mask=AI_NODE_IMAGER).
+The it reloads the usd scene and check the number of imagers is equal to the number of imagers exported.
+
+author: cyril.pichard@autodesk.com
+
+# Hydra doesn't work yet, we would have to save the inagers inside a node graph.
+PARAMS: {'hydra': False}

--- a/testsuite/test_2072.1/data/test.cpp
+++ b/testsuite/test_2072.1/data/test.cpp
@@ -1,0 +1,104 @@
+#include <ai.h>
+
+//#define LOG_FLAGS AI_LOG_ALL
+#define LOG_FLAGS AI_LOG_WARNINGS | AI_LOG_ERRORS
+
+int imager_export(const char* path)
+{
+   AiBegin(AI_SESSION_INTERACTIVE);
+   AtUniverse* universe = AiUniverse();
+   AiMsgSetConsoleFlags(universe, LOG_FLAGS);
+
+   // create scene
+   {
+      AtNode* driver = AiNode(universe, AtString("driver_jpeg"), AtString("mydriver"));
+      AtNode* filter = AiNode(universe, AtString("gaussian_filter"), AtString("myfilter"));
+      AtNode* options = AiUniverseGetOptions(universe);
+      AtArray* outputs = AiArrayAllocate(1, 1, AI_TYPE_STRING);
+      AiArraySetStr(outputs, 0, "RGBA RGBA myfilter mydriver");
+      AiNodeSetArray(options, AtString("outputs"), outputs);
+
+      AtNode* color_correct = AiNode(universe, AtString("imager_color_correct"), AtString("imager1"));
+      AtNode* exposure = AiNode(universe, AtString("imager_exposure"), AtString("imager2"));
+      AtNode* tonemap = AiNode(universe, AtString("imager_tonemap"), AtString("imager3"));
+
+      AiNodeSetPtr(exposure, AtString("input"), tonemap);
+      AiNodeSetPtr(color_correct, AtString("input"), exposure);
+      AiNodeSetPtr(driver, AtString("input"), color_correct);
+   }
+
+   // export imagers
+   AtParamValueMap* params = AiParamValueMap();
+   AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_IMAGER|AI_NODE_DRIVER);
+   bool success = AiSceneWrite(universe, path, params);
+   AiParamValueMapDestroy(params);
+
+   if (!success)
+   {
+      AiEnd();
+      return -1;
+   }
+
+   AiEnd();
+   printf("exported 3 imagers\n");
+   return 3;
+}
+
+int imager_import(const char* path)
+{
+   AiBegin(AI_SESSION_INTERACTIVE);
+   AtUniverse* universe = AiUniverse();
+   AiMsgSetConsoleFlags(universe, LOG_FLAGS);
+
+   AtParamValueMap* params = AiParamValueMap();
+   AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_IMAGER);
+   bool success = AiSceneLoad(universe, path, params);
+   AiParamValueMapDestroy(params);
+
+   if (!success)
+   {
+      AiEnd();
+      return -1;
+   }
+
+   // collect the imager nodes
+   int numImagers = 0;
+   AtNodeIterator* aiNodeIterator = AiUniverseGetNodeIterator(universe, AI_NODE_IMAGER);
+   while (!AiNodeIteratorFinished(aiNodeIterator))
+   {
+      AtNode* imager = AiNodeIteratorGetNext(aiNodeIterator);
+      printf(" imported %s (%s)\n", AiNodeGetName(imager), AiNodeEntryGetName(AiNodeGetNodeEntry(imager)));
+      numImagers++;
+   }
+   AiNodeIteratorDestroy(aiNodeIterator);
+
+   AiEnd();
+
+   printf("read %d imagers\n", numImagers);
+   return numImagers;
+}
+
+int main(int, char**)
+{
+   AiMsgSetConsoleFlags(nullptr, LOG_FLAGS);
+
+   printf("IMAGER EXPORT\n");
+   int exportedImagers = imager_export("imager_test.usda");
+   if (!exportedImagers)
+   {
+      printf("[ERROR] Failed to export imagers\n");
+      return 1;
+   }
+
+   printf("\n");
+
+   printf("IMAGER IMPORT\n");
+   int importedImagers = imager_import("imager_test.usda");
+	if (importedImagers != exportedImagers)
+   {
+      printf("[ERROR] Failed to import imagers %d %d\n", importedImagers, exportedImagers);
+      return 1;
+   }
+
+   return 0;
+}

--- a/testsuite/test_2072.2/README
+++ b/testsuite/test_2072.2/README
@@ -1,0 +1,11 @@
+Imager nodes masked read/write round trip
+
+see #2072
+
+This test create an arnold scene, saves only the imagers (mask=AI_NODE_IMAGER).
+The it reloads the usd scene with a AI_NODE_SHADER mask and check the number of imagers is 0.
+
+author: cyril.pichard@autodesk.com
+
+# Hydra doesn't work yet, we would have to save the inagers inside a node graph.
+PARAMS: {'hydra': False}

--- a/testsuite/test_2072.2/README
+++ b/testsuite/test_2072.2/README
@@ -6,6 +6,3 @@ This test create an arnold scene, saves only the imagers (mask=AI_NODE_IMAGER).
 The it reloads the usd scene with a AI_NODE_SHADER mask and check the number of imagers is 0.
 
 author: cyril.pichard@autodesk.com
-
-# Hydra doesn't work yet, we would have to save the inagers inside a node graph.
-PARAMS: {'hydra': False}

--- a/testsuite/test_2072.2/data/test.cpp
+++ b/testsuite/test_2072.2/data/test.cpp
@@ -1,0 +1,104 @@
+#include <ai.h>
+
+//#define LOG_FLAGS AI_LOG_ALL
+#define LOG_FLAGS AI_LOG_WARNINGS | AI_LOG_ERRORS
+
+int imager_export(const char* path)
+{
+   AiBegin(AI_SESSION_INTERACTIVE);
+   AtUniverse* universe = AiUniverse();
+   AiMsgSetConsoleFlags(universe, LOG_FLAGS);
+
+   // create scene
+   {
+      AtNode* driver = AiNode(universe, AtString("driver_jpeg"), AtString("mydriver"));
+      AtNode* filter = AiNode(universe, AtString("gaussian_filter"), AtString("myfilter"));
+      AtNode* options = AiUniverseGetOptions(universe);
+      AtArray* outputs = AiArrayAllocate(1, 1, AI_TYPE_STRING);
+      AiArraySetStr(outputs, 0, "RGBA RGBA myfilter mydriver");
+      AiNodeSetArray(options, AtString("outputs"), outputs);
+
+      AtNode* color_correct = AiNode(universe, AtString("imager_color_correct"), AtString("imager1"));
+      AtNode* exposure = AiNode(universe, AtString("imager_exposure"), AtString("imager2"));
+      AtNode* tonemap = AiNode(universe, AtString("imager_tonemap"), AtString("imager3"));
+
+      AiNodeSetPtr(exposure, AtString("input"), tonemap);
+      AiNodeSetPtr(color_correct, AtString("input"), exposure);
+      AiNodeSetPtr(driver, AtString("input"), color_correct);
+   }
+
+   // export imagers
+   AtParamValueMap* params = AiParamValueMap();
+   AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_IMAGER);
+   bool success = AiSceneWrite(universe, path, params);
+   AiParamValueMapDestroy(params);
+
+   if (!success)
+   {
+      AiEnd();
+      return -1;
+   }
+
+   AiEnd();
+   printf("exported 3 imagers\n");
+   return 3;
+}
+
+int imager_import(const char* path)
+{
+   AiBegin(AI_SESSION_INTERACTIVE);
+   AtUniverse* universe = AiUniverse();
+   AiMsgSetConsoleFlags(universe, LOG_FLAGS);
+
+   AtParamValueMap* params = AiParamValueMap();
+   AiParamValueMapSetInt(params, AtString("mask"), AI_NODE_SHADER);
+   bool success = AiSceneLoad(universe, path, params);
+   AiParamValueMapDestroy(params);
+
+   if (!success)
+   {
+      AiEnd();
+      return -1;
+   }
+
+   // collect the imager nodes
+   int numImagers = 0;
+   AtNodeIterator* aiNodeIterator = AiUniverseGetNodeIterator(universe, AI_NODE_IMAGER);
+   while (!AiNodeIteratorFinished(aiNodeIterator))
+   {
+      AtNode* imager = AiNodeIteratorGetNext(aiNodeIterator);
+      printf(" imported %s (%s)\n", AiNodeGetName(imager), AiNodeEntryGetName(AiNodeGetNodeEntry(imager)));
+      numImagers++;
+   }
+   AiNodeIteratorDestroy(aiNodeIterator);
+
+   AiEnd();
+
+   printf("read %d imagers\n", numImagers);
+   return numImagers;
+}
+
+int main(int, char**)
+{
+   AiMsgSetConsoleFlags(nullptr, LOG_FLAGS);
+
+   printf("IMAGER EXPORT\n");
+   int exportedImagers = imager_export("imager_test.usda");
+   if (!exportedImagers)
+   {
+      printf("[ERROR] Failed to export imagers\n");
+      return 1;
+   }
+
+   printf("\n");
+
+   printf("IMAGER IMPORT\n");
+   int importedImagers = imager_import("imager_test.usda");
+	if (importedImagers != 0)
+   {
+      printf("[ERROR] Failed to import imagers %d %d\n", importedImagers, exportedImagers);
+      return 1;
+   }
+
+   return 0;
+}


### PR DESCRIPTION
**Changes proposed in this pull request**
This is a work in progress, it does not work with hydra as we should store the shaders and imagers under NodeGraph or Materials.

- let the shader reader read the imagers
- avoid the creation of nodes that are not compatible with the read mask.

**Issues fixed in this pull request**
Fixes #2072
