### PR TITLE
Ensure options attributes are not set while a render is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 # Changelog
 
 ## Pending next bugfix release
+- [usd#2075](https://github.com/Autodesk/arnold-usd/issues/2075) - Ensure options attributes are not set while a hydra render is in progress
+
+## [7.3.3.1] - 2024-08-09
 - [usd#1989](https://github.com/Autodesk/arnold-usd/issues/1989) - Support mixed half/float channels when using the render delegate in batch mode with husk.
 - [usd#1610](https://github.com/Autodesk/arnold-usd/issues/1610) - Proper support of arnold:visibility primvar in hydra
 
-## Pending feature release
+## [7.3.3.0] - 2024-07-26
 
 ### Feature
 - [usd#1814](https://github.com/Autodesk/arnold-usd/issues/1814) - Support skinning on USD curves and points

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1620,8 +1620,11 @@ bool HdArnoldRenderDelegate::ShouldSkipIteration(HdRenderIndex* renderIndex, con
             }
         }
     }
-    if (!skip)
-        ProcessConnections();
+
+    // If we have connections in our stack, it means that some nodes were re-exported, 
+    // and therefore that the render was already interrupted
+    ProcessConnections();
+
     return skip;
 }
 

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -569,7 +569,11 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             _windowNDC = GfVec4f(0.f, 0.f, 1.f, 1.f);
         }
     }
-    AiNodeSetFlt(options, str::pixel_aspect_ratio, pixelAspectRatio);
+    float currentPixelAspectRatio = AiNodeGetFlt(options, str::pixel_aspect_ratio);
+    if (!GfIsClose(currentPixelAspectRatio, pixelAspectRatio, AI_EPSILON)) {
+        renderParam->Interrupt(true, false);
+        AiNodeSetFlt(options, str::pixel_aspect_ratio, pixelAspectRatio);
+    }    
 
     auto checkShader = [&] (AtNode* shader, const AtString& paramName) {
         auto* options = _renderDelegate->GetOptions();
@@ -597,10 +601,11 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
 
     // Eventually set the subdiv dicing camera in the options
     const AtNode *subdivDicingCamera = _renderDelegate->GetSubdivDicingCamera(GetRenderIndex());
-    if (subdivDicingCamera)
+    const AtNode *currentSubdivDicingCamera = (const AtNode*)AiNodeGetPtr(options, str::subdiv_dicing_camera);
+    if (currentSubdivDicingCamera != subdivDicingCamera) {
+        renderParam->Interrupt(true, false);
         AiNodeSetPtr(options, str::subdiv_dicing_camera, (void*)subdivDicingCamera);
-    else
-        AiNodeResetParameter(options, str::subdiv_dicing_camera);
+    }
 
     // We are checking if the current aov bindings match the ones we already created, if not,
     // then rebuild the driver setup.


### PR DESCRIPTION
When `_Execute` is being invoked over and over in the render delegate, even sometimes when a render is in progress without any real change, we need to check if specific things have changed, and if they do we make it so that the render is interrupted to update them. 
Here we were constantly setting a couple of options parameters (pixel_aspect_ratio and subdiv_camera) without even interrupting the render. Worse, with the default use case of no subdiv_camera, we were calling AiNodeResetParameter on it, which currently doesn't have all the checks we do in AiNodeSet*, so Arnold constantly thinks that the options have changed, even during iterations.

Finally, in ShouldSkipIteration I'm now calling ProcessConnections all the time, instead of checking the boolean value "skip". In a separate task, we need to rewrite this function completely as it's logic is completely inverted

**Issues fixed in this pull request**
Fixes #2075 
