### PR TITLE
Ensure the render callback is always invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [usd#2027](https://github.com/Autodesk/arnold-usd/issues/2027) - Fix faceVarying normals interpolation in the procedural when the mesh is left handed.
 - [usd#1837](https://github.com/Autodesk/arnold-usd/issues/1837) - Fix motion blur of instanced skinned geometry with animated parent matrix
 - [usd#2037](https://github.com/Autodesk/arnold-usd/issues/2027) - Improve instances and objects motion blur coherence.
+- [usd#2078](https://github.com/Autodesk/arnold-usd/issues/2078) - Ensure the hydra render callback is always invoked
 
 ### Build
 - [usd#1969](https://github.com/Autodesk/arnold-usd/issues/1969) - Remove support for USD versions older than 21.05

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -224,8 +224,8 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
     arnoldRenderDelegate->SetRenderTags(purpose);
 
     // The scene might not be up to date, because of light links, etc, that were generated during the first sync.
-    // ShouldSkipIteration updates the dirtybits for a resync, this is how it works in our hydra render pass.
-    while (arnoldRenderDelegate->ShouldSkipIteration(_renderIndex, shutter)) {
+    // UpdateSceneChanges updates the dirtybits for a resync, this is how it works in our hydra render pass.
+    while (arnoldRenderDelegate->UpdateSceneChanges(_renderIndex, shutter)) {
         _renderIndex->SyncAll(&tasks, &taskContext);
     }
 }

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -327,17 +327,15 @@ public:
     HDARNOLD_API
     void ApplyLightLinking(HdSceneDelegate *delegate, AtNode* node, SdfPath const& id);
 
-    /// Tells whether or not the current convergence iteration should be skipped.
-    ///
-    /// This function can be used to skip calling the render function in HdRenderPass, so a sync step will be enforced
-    /// before the next iteration.
+    /// Updates the eventual changes that happened in the input scene
+    /// since the last iteration.
     ///
     /// @param renderIndex Pointer to the Hydra Render Index.
     /// @param shutterOpen Shutter Open value of the active camera.
     /// @param shutterClose Shutter Close value of the active camera.
-    /// @return True if the iteration should be skipped.
+    /// @return True if the iteration contains scene changes.
     HDARNOLD_API
-    bool ShouldSkipIteration(HdRenderIndex* renderIndex, const GfVec2f& shutter);
+    bool UpdateSceneChanges(HdRenderIndex* renderIndex, const GfVec2f& shutter);
 
     using DelegateRenderProducts = std::vector<HdArnoldDelegateRenderProduct>;
     /// Returns the list of available Delegate Render Products.

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -75,7 +75,7 @@ public:
     ///
     /// @return True if Arnold Core has finished converging.
     HDARNOLD_API
-    Status Render();
+    Status UpdateRender();
     /// Interrupts an ongoing render.
     ///
     /// Useful when there is new data to display, or the render settings have changed.

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -970,12 +970,10 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         clearBuffers(_renderBuffers);
     }
 
-    // We skip an iteration step if the render delegate tells us to do so, this is the easiest way to force
-    // a sync step before calling the render function. Currently, this is used to trigger light linking updates.
-    const auto shouldSkipIteration = _renderDelegate->ShouldSkipIteration(
+    _renderDelegate->UpdateSceneChanges(
         GetRenderIndex(),
         {AiNodeGetFlt(currentCamera, str::shutter_start), AiNodeGetFlt(currentCamera, str::shutter_end)});
-    const auto renderStatus = shouldSkipIteration ? HdArnoldRenderParam::Status::Converging : renderParam->Render();
+    const auto renderStatus = renderParam->UpdateRender();
     _isConverged = renderStatus != HdArnoldRenderParam::Status::Converging;
 
     // We need to set the converged status of the render buffers.


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR changes the ShouldSkipIteration function logic to be UpdateSceneChanges that will return true if the scene has changed. This function was previously returning the opposite value than what it was supposed to do. I'm thus updating the different parts of the code that are calling it.

Also, the previous logic was this if there was nothing updated in the scene, we would return "Converging" instead of calling Render(), but that's not correct. We need this callback to be invoked even if nothing has changed in the scene, as this function just checks the render status and does the necessary if the render has finished, is restarting, etc.... The reason it was working was precisely because the logic in ShouldSkipIteration was inverted, and  given the high amount of calls in this function where nothing has changed, we would end up calling Render() to do what's needed.
To clarify, I'm renaming the function `UpdateRender` and I'm putting everything under a switch of the render status, since that's what this function was supposed to do.

**Issues fixed in this pull request**
Fixes #2078 
