### PR TITLE
Author animated shader attributes in a way that they can render in hydra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [usd#2061](https://github.com/Autodesk/arnold-usd/issues/2061) - Support arnold light groups in Hydra
 - [usd#2067](https://github.com/Autodesk/arnold-usd/issues/2067) - Do not author useless "normals" user data in meshes/curves through the procedural
 - [usd#1118](https://github.com/Autodesk/arnold-usd/issues/1118) - Add profile/stats settings to the Render Settings
+- [usd#2080](https://github.com/Autodesk/arnold-usd/issues/2080) - Author animated shader attributes in a way that they can render in hydra
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/testsuite/test_0063/README
+++ b/testsuite/test_0063/README
@@ -3,5 +3,4 @@ Motion blurred projections
 See #369
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
-# Disabled in hydra as animated shaders aren't supported yet
+PARAMS: {'resaved':'usda'}


### PR DESCRIPTION
In this PR, when a shader array attributes is authored to USD with multiple keys, we author all the values (elements * keys) in a single time sample. Currently, the only arnold shader supporting animated values is matrix_interpolate  for attribute attribute "matrix". It renders all array values independantly of them being keys or elements, so there's nothing to do on the reader side.

This allows to render test_0063 in hydra mode.

**Issues fixed in this pull request**
Fixes #2080 
