### PR TITLE
Support arnold cameras in hydra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [usd#2061](https://github.com/Autodesk/arnold-usd/issues/2061) - Support arnold light groups in Hydra
 - [usd#2067](https://github.com/Autodesk/arnold-usd/issues/2067) - Do not author useless "normals" user data in meshes/curves through the procedural
 - [usd#1118](https://github.com/Autodesk/arnold-usd/issues/1118) - Add profile/stats settings to the Render Settings
+- [usd#2082](https://github.com/Autodesk/arnold-usd/issues/2082) - Support arnold cameras in hydra
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -88,6 +88,7 @@ ASTR2(stats_file, "stats:file");
 ASTR2(stats_mode, "stats:mode");
 ASTR2(outputs_color, "outputs:color");
 ASTR2(outputs_out, "outputs:out");
+ASTR2(primvars_arnold_camera, "primvars:arnold:camera");
 ASTR2(primvars_arnold_light_shaders, "primvars:arnold:light:shaders");
 ASTR2(primvars_arnold_shaders, "primvars:arnold:shaders");
 ASTR2(primvars_arnold_smoothing, "primvars:arnold:smoothing");

--- a/libs/render_delegate/camera.h
+++ b/libs/render_delegate/camera.h
@@ -84,11 +84,11 @@ protected:
     /// @param dirtyBits 
     void UpdatePerspectiveParams(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits);
 
-    /// @brief Update the orthographic camera parameters
+    /// @brief Update generic camera parameters
     /// @param sceneDelegate 
     /// @param renderParam 
     /// @param dirtyBits 
-    void UpdateOrthographicParams(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits);
+    void UpdateGenericParams(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits);
 
     void SetClippingPlanes(HdSceneDelegate* sceneDelegate);
     

--- a/libs/translator/reader/read_camera.cpp
+++ b/libs/translator/reader/read_camera.cpp
@@ -55,6 +55,14 @@ AtNode* UsdArnoldReadCamera::Read(const UsdPrim &prim, UsdArnoldReaderContext &c
         return nullptr;
     }
 
+    UsdAttribute camTypeAttr = prim.GetAttribute(str::t_primvars_arnold_camera);
+    if (camTypeAttr && camTypeAttr.HasAuthoredValue()) {
+        VtValue camTypeValue;
+        if (camTypeAttr.Get(&camTypeValue, time.frame)) {
+            camType = VtValueGetString(camTypeValue);
+        }
+    }
+
     AtNode *node = context.CreateArnoldNode(camType.c_str(), prim.GetPath().GetText());
     ReadMatrix(prim, node, time, context);
 

--- a/libs/translator/writer/registry.cpp
+++ b/libs/translator/writer/registry.cpp
@@ -60,6 +60,13 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
 
         RegisterWriter("persp_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_PERSPECTIVE));
         RegisterWriter("ortho_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_ORTHOGRAPHIC));
+        RegisterWriter("fisheye_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_CUSTOM));
+        RegisterWriter("cyl_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_CUSTOM));
+        RegisterWriter("spherical_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_CUSTOM));
+        RegisterWriter("vr_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_CUSTOM));
+        RegisterWriter("uv_camera", new UsdArnoldWriteCamera(UsdArnoldWriteCamera::CAMERA_CUSTOM));
+
+
         RegisterWriter("options", new UsdArnoldWriteOptions());
         RegisterWriter("driver_exr", new UsdArnoldWriteDriver());
         RegisterWriter("driver_tiff", new UsdArnoldWriteDriver());

--- a/libs/translator/writer/write_camera.cpp
+++ b/libs/translator/writer/write_camera.cpp
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "write_camera.h"
+#include <constant_strings.h>
 
 #include <ai.h>
 
@@ -51,10 +52,12 @@ void UsdArnoldWriteCamera::Write(const AtNode *node, UsdArnoldWriter &writer)
     } else if (_type == CAMERA_ORTHOGRAPHIC) {
         projection = TfToken("orthographic");
     } else {
-        AiMsgError("[usd] Invalid camera type %s", nodeName.c_str());
-        return; // invalid camera type
+        UsdAttribute cameraTypeAttr = prim.CreateAttribute(str::t_primvars_arnold_camera, SdfValueTypeNames->Token, false);
+        TfToken cameraType(AiNodeEntryGetName(AiNodeGetNodeEntry(node)));
+        writer.SetAttribute(cameraTypeAttr, VtValue(cameraType));
     }
-    writer.SetAttribute(cam.CreateProjectionAttr(), projection);
+    if (!projection.IsEmpty())
+        writer.SetAttribute(cam.CreateProjectionAttr(), projection);
     
     if (persp) {
         AtNode *options = AiUniverseGetOptions(writer.GetUniverse());

--- a/libs/translator/writer/write_camera.h
+++ b/libs/translator/writer/write_camera.h
@@ -31,7 +31,11 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 class UsdArnoldWriteCamera : public UsdArnoldPrimWriter {
 public:
-    enum CameraType { CAMERA_PERSPECTIVE = 0, CAMERA_ORTHOGRAPHIC = 1 };
+    enum CameraType {
+        CAMERA_PERSPECTIVE = 0, 
+        CAMERA_ORTHOGRAPHIC = 1,
+        CAMERA_CUSTOM
+    };
 
     UsdArnoldWriteCamera(UsdArnoldWriteCamera::CameraType t = CAMERA_PERSPECTIVE) : UsdArnoldPrimWriter(), _type(t) {}
 

--- a/testsuite/test_0054/README
+++ b/testsuite/test_0054/README
@@ -2,5 +2,4 @@ Fisheye camera and background shader
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
-# Disabled in hydra as fisheye camera is not supported yet
+PARAMS: {'resaved':'usda'}

--- a/testsuite/test_0106/README
+++ b/testsuite/test_0106/README
@@ -2,5 +2,4 @@ VR Camera
 
 author: sebastien ortega
 
-PARAMS: {'resaved':'usda', 'hydra': False}
-# Disabled in hydra as VR cameras are not supported yet
+PARAMS: {'resaved':'usda'}


### PR DESCRIPTION
**Changes proposed in this pull request**
We were previously relying on arnold schemas for cameras (spherical, cylindrical, fisheye, etc..), which isn't supported in hydra.
Instead of adding usdImaging support for these schemas, we choose instead to rely on the builtin camera primitives, and add an attribute specifying the arnold camera type in the prim. Then, all the arnold attributes are already authored with the arnold namespace so there's not much to change. This PR does the required changes in :
- the usd writer, when e.g. a spherical_camera is authored to usd, it's now saved as a usd builtin cam
- the usd reader, when a usd camera is loaded, we check the attribute `primvars:arnold:camera` to check the camera name
- the render delegate, we also check the arnold camera attribute, to determine which node to create. 

This allows to add tests 54 and 106 to the hydra testsuite

**Issues fixed in this pull request**
Fixes #2082
