### PR TITLE
Imagers should be applied to all drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [usd#2061](https://github.com/Autodesk/arnold-usd/issues/2061) - Support arnold light groups in Hydra
 - [usd#2067](https://github.com/Autodesk/arnold-usd/issues/2067) - Do not author useless "normals" user data in meshes/curves through the procedural
 - [usd#1118](https://github.com/Autodesk/arnold-usd/issues/1118) - Add profile/stats settings to the Render Settings
+- [usd#2084](https://github.com/Autodesk/arnold-usd/issues/2084) - Imagers should be applied to all drivers
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/common/rendersettings_utils.cpp
+++ b/libs/common/rendersettings_utils.cpp
@@ -537,6 +537,9 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
         // Needed further down
         const std::string driverType(AiNodeEntryGetName(AiNodeGetNodeEntry(driver)));
 
+        // Set imager in the driver
+        UsdArnoldNodeGraphConnection(driver, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->aovGlobalImager), "input", context, time);
+
         // Render Products have a list of Render Vars, which correspond to an AOV.
         // For each Render Var, we will need one element in options.outputs
         UsdRelationship renderVarsRel = renderProduct.GetOrderedVarsRel();
@@ -783,10 +786,6 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
     UsdArnoldNodeGraphConnection(options, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->aovGlobalAtmosphere), "atmosphere", context, time);
     UsdArnoldNodeGraphConnection(options, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->aovGlobalBackground), "background", context, time);
     UsdArnoldNodeGraphAovConnection(options, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->aovGlobalAovs), "aov_shaders", context, time);
-
-    for (auto driver: beautyDrivers) {
-        UsdArnoldNodeGraphConnection(driver, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->aovGlobalImager), "input", context, time);
-    }
 
     // Setup color manager
     AtNode* colorManager = nullptr;

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -792,9 +792,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                         "%s %s %s %s", aovName, arnoldTypes.outputString, filterName, AiNodeGetName(buffer.driver))
                         .c_str()};
 
-                if (!strcmp(aovName, "RGBA")) {
-                    AiNodeSetPtr(buffer.driver, str::input, imager);
-                }
+                AiNodeSetPtr(buffer.driver, str::input, imager);
 
             }
             outputs.push_back(output);
@@ -923,6 +921,7 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                     AiNodeSetArray(customProduct.driver, str::layer_enable_filtering, enableFilteringArray);
                     AiNodeSetArray(customProduct.driver, str::layer_half_precision, halfPrecisionArray);
                 }
+                AiNodeSetPtr(customProduct.driver, str::input, imager);
                 _customProducts.push_back(std::move(customProduct));
             }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
In the past we used to assign imagers only to the beauty driver. This was changed at some point, they should be assigned to all drivers, and the attribute "layer_selection" can eventually filter out which AOVs are affected by this imager.

The code in the procedural, as well as the render delegate was still using the previous logic, and this was causing problems when rendering through husk with an arnold product type.

**Issues fixed in this pull request**
Fixes #2084 
