### PR TITLE
Ensure we don't register the TfNotice callback twice MAXTOA-1824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 # Changelog
 
 ## Pending next bugfix release
+- [usd#2089](https://github.com/Autodesk/arnold-usd/issues/2089) - Fixed crashes when registering the TfNotice callback multiple times
+
+## [7.3.4.0] - 2024-08-30
 - [usd#2075](https://github.com/Autodesk/arnold-usd/issues/2075) - Ensure options attributes are not set while a hydra render is in progress
 
 ## [7.3.3.1] - 2024-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Changelog
 
 ## Pending next bugfix release
-- [usd#2089](https://github.com/Autodesk/arnold-usd/issues/2089) - Fixed crashes when registering the TfNotice callback multiple times
+- [usd#2090](https://github.com/Autodesk/arnold-usd/issues/2090) - Fixed crashes when registering the TfNotice callback multiple times
 
 ## [7.3.4.0] - 2024-08-30
 - [usd#2075](https://github.com/Autodesk/arnold-usd/issues/2075) - Ensure options attributes are not set while a hydra render is in progress

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -568,9 +568,12 @@ void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
     // to be informed of the interactive changes happening in the UsdStage
     // (which must be kept in memory)    
     if (_interactive) {
-        _objectsChangedNoticeKey =
-            TfNotice::Register(TfCreateWeakPtr(&_listener),
+        // only register the callback if it wasn't already done
+        if (!_objectsChangedNoticeKey.IsValid()) {
+            _objectsChangedNoticeKey =
+                TfNotice::Register(TfCreateWeakPtr(&_listener),
                 &StageListener::_OnUsdObjectsChanged, _stage);
+        }
         // The eventual "root path" is needed, since we want to ignore changes
         // that aren't part of it
         _listener._rootPath = _hasRootPrim ? _rootPrim.GetPath() : SdfPath();


### PR DESCRIPTION
**Changes proposed in this pull request**

Before we register the TfNotice callback, we need to ensure we didn't already do it. Since we go through the same function at each procedural update, this could happen and end up causing crashes with MaxUSD. This fixes the internal ticket MAXTOA-1824