### PR TITLE
Support visiblity updates in interactive procedural changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [usd#1837](https://github.com/Autodesk/arnold-usd/issues/1837) - Fix motion blur of instanced skinned geometry with animated parent matrix
 - [usd#2037](https://github.com/Autodesk/arnold-usd/issues/2027) - Improve instances and objects motion blur coherence.
 - [usd#2078](https://github.com/Autodesk/arnold-usd/issues/2078) - Ensure the hydra render callback is always invoked
+- [usd#2092](https://github.com/Autodesk/arnold-usd/issues/2092) - Fix interactive update issue when prims visibility is tweaked in the procedural
 
 ### Build
 - [usd#1969](https://github.com/Autodesk/arnold-usd/issues/1969) - Remove support for USD versions older than 21.05


### PR DESCRIPTION
**Changes proposed in this pull request**
In the procedural, we need to handle in a particular way the primitives that were previously visible and that are interactively modified to become hidden. In general, when a primitive is hidden we prune it along with its children and skip the export.
But in this case, we must ensure the primitive is re-exported so that the visibility (and eventual other attributes) can be properly updated in the arnold side. 
In order to apply this logic to all geometry types, I realized it would cause yet another lot of duplication, so I did instead some code factorization through a function `_ReadGenericShape` containing a list of steps that are common to all shapes (apart from the instancer which is a bit different).

**Issues fixed in this pull request**
Fixes #2092
