### PR TITLE
Remove hydra warning subdiv_iterations: use type BYTE, not INT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [usd#1837](https://github.com/Autodesk/arnold-usd/issues/1837) - Fix motion blur of instanced skinned geometry with animated parent matrix
 - [usd#2037](https://github.com/Autodesk/arnold-usd/issues/2027) - Improve instances and objects motion blur coherence.
 - [usd#2078](https://github.com/Autodesk/arnold-usd/issues/2078) - Ensure the hydra render callback is always invoked
+- [usd#2102](https://github.com/Autodesk/arnold-usd/issues/2102) - Remove hydra warning subdiv_iterations: use type BYTE, not INT 
 
 ### Build
 - [usd#1969](https://github.com/Autodesk/arnold-usd/issues/1969) - Remove support for USD versions older than 21.05

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -230,9 +230,11 @@ HdArnoldMesh::HdArnoldMesh(HdArnoldRenderDelegate* renderDelegate, const SdfPath
 {
     // The default value is 1, which won't work well in a Hydra context.
     AiNodeSetByte(GetArnoldNode(), str::subdiv_iterations, 0);
-    // polymesh smoothing is disabled by default in arnold core, 
-    // but we actually want it to default to true as in the arnold plugins
+    // Before Arnold 7.2.0.0, polymesh smoothing was disabled by default.
+    // But we actually want it to default to true as in the arnold plugins
+#if ARNOLD_VERSION_NUM < 70200    
     AiNodeSetBool(GetArnoldNode(), str::smoothing, true);
+#endif
 }
 
 HdArnoldMesh::~HdArnoldMesh() {
@@ -538,7 +540,7 @@ void HdArnoldMesh::Sync(
     
         // As it's done in the procedural for #679, we want to disable subdivision
         // if subdiv iterations is equal to 0
-        if (AiNodeGetInt(node, str::subdiv_iterations) == 0) {
+        if (AiNodeGetByte(node, str::subdiv_iterations) == 0) {
             AiNodeSetStr(node, str::subdiv_type, str::none);
         }        
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
We were trying to get the subdiv_iterations attribute explicitely as an integer, which isn't correct as it's a BYTE attribute.
This removes the spurious warning in hydra.
Also, I saw we were still forcing polymesh "smoothing" to true when a new mesh is created. While this is not incorrect, it's not needed anymore since Arnold 7.2.0.0, when smoothing has been enabled by default

**Issues fixed in this pull request**
Fixes #2102
