### PR TITLE
Fix build error with older versions of arnold

### DIFF
--- a/libs/common/common_utils.h
+++ b/libs/common/common_utils.h
@@ -18,6 +18,7 @@
 /// @file common_utils.h
 ///
 /// Common utils.
+#pragma once
 #include <string>
 
 #include <pxr/pxr.h>

--- a/libs/translator/reader/read_shader.h
+++ b/libs/translator/reader/read_shader.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-
+#include <common_utils.h>
 #include "prim_reader.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE


### PR DESCRIPTION
In a recent commit we've started using the value AI_NODE_IMAGER which didn't exist before Arnold 7.3.0