### PR TITLE
Support procedural updates in hydra mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [usd#2084](https://github.com/Autodesk/arnold-usd/issues/2084) - Imagers should be applied to all drivers
 - [usd#2086](https://github.com/Autodesk/arnold-usd/issues/2086) - Compute FOV in the procedural and hydra in a similar manner
 - [usd#2047](https://github.com/Autodesk/arnold-usd/issues/2047) - Shaders exports should be bound to a material
+- [usd#2107](https://github.com/Autodesk/arnold-usd/issues/2107) - Support procedural updates in hydra mode
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -34,7 +34,7 @@ public:
     void SetPurpose(const std::string &p) override;
     void SetId(unsigned int id) override;
     void SetRenderSettings(const std::string &renderSettings) override;
-
+    void Update() override;
     void CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) override {}; // Do we need to create a registry with hydra ???
 
     void WriteDebugScene(const std::string &debugScene) const;
@@ -50,4 +50,9 @@ private:
     HdRenderDelegate *_renderDelegate;
     AtUniverse *_universe = nullptr;
     bool _universeCreated = false;
+    HdRenderPassSharedPtr _syncPass;
+    HdRprimCollection _collection;
+    GfVec2f _shutter;
+    HdTaskSharedPtrVector _tasks;
+    HdTaskContext _taskContext;
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
We need to define the Update function of the render delegate reader.
Inside, we call ApplyPendingUpdates of the imaging delegate and we sync the scene.
To do that, I'm moving some Hydra structures as members of the reader class, so that they're kept around during the IPR session.

**Issues fixed in this pull request**
Fixes #2107 

**Additional context**
Add any other context or screenshots about the pull request here.
