### PR TITLE
Support the shader_override render setting

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -462,6 +462,7 @@ ASTR(standard_surface);
 ASTR(standard_volume);
 ASTR(step_size);
 ASTR(subdiv_dicing_camera);
+ASTR(shader_override);
 ASTR(subdiv_frustum_culling);
 ASTR(subdiv_frustum_padding);
 ASTR(subdiv_iterations);

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -343,6 +343,8 @@ const SupportedRenderSettings& _GetSupportedRenderSettings()
         {str::t_subdiv_frustum_culling, {"Subdiv Frustum Culling"}},
         {str::t_subdiv_frustum_padding, {"Subdiv Frustum Padding"}},
 
+        {str::t_shader_override, {"Shader Override", std::string{}}},
+
         {str::t_background, {"Path to the background node graph.", std::string{}}},
         {str::t_atmosphere, {"Path to the atmosphere node graph.", std::string{}}},
         {str::t_aov_shaders, {"Path to the aov_shaders node graph.", std::string{}}},
@@ -738,6 +740,12 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             _subdiv_dicing_camera = p; 
             AiNodeSetPtr(_options, str::subdiv_dicing_camera, LookupNode(_subdiv_dicing_camera.GetText()));
         });
+    } else if (key == str::t_shader_override) {
+
+        ArnoldUsdCheckForSdfPathValue(value, [&](const SdfPath& p) {
+            _shader_override = p;
+            AiNodeSetPtr(_options, str::shader_override, LookupNode(_shader_override.GetText()));
+        });
     } else if (key == str::color_space_linear) {
         if (value.IsHolding<std::string>()) {
             AtNode* colorManager = getOrCreateColorManager(this, _options);
@@ -997,6 +1005,8 @@ VtValue HdArnoldRenderDelegate::GetRenderSetting(const TfToken& _key) const
         return VtValue(_imager.GetString());
     }  else if (key == str::t_subdiv_dicing_camera) {
         return VtValue(_subdiv_dicing_camera.GetString());
+    }  else if (key == str::t_shader_override) {
+        return VtValue(_shader_override.GetString());
     }
     const auto* nentry = AiNodeGetNodeEntry(_options);
     const auto* pentry = AiNodeEntryLookUpParameter(nentry, AtString(key.GetText()));

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -714,6 +714,7 @@ private:
     SdfPathVector _aov_shaders;  ///< Path to the aov shaders.
     SdfPath _imager;      ///< Path to the root imager node.
     SdfPath _subdiv_dicing_camera;  ///< Path to the subdiv dicing camera
+    SdfPath _shader_override;  ///< Path to the shader_override material
     AtUniverse* _universe = nullptr; ///< Universe used by the Render Delegate.
     AtRenderSession* _renderSession = nullptr; ///< Render session used by the Render Delegate.
     AtNode* _options = nullptr;          ///< Pointer to the Arnold Options Node.


### PR DESCRIPTION
- Sets shader_override on the options node if **arnold:global:shader_override** exists on the render settings
- _WIP - this doesn't work yet as the material doesn't exist to assign unless there's an existing material binding_


**Issues fixed in this pull request**
Fixes #2119

**Additional context**
Add any other context or screenshots about the pull request here.
