### PR TITLE
RectLight doesn't take width / height into account with scenes exported from Arnold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - [usd#2092](https://github.com/Autodesk/arnold-usd/issues/2092) - Fix interactive update issue when prims visibility is tweaked in the procedural
 - [usd#2102](https://github.com/Autodesk/arnold-usd/issues/2102) - Remove hydra warning subdiv_iterations: use type BYTE, not INT 
 - [usd#2105](https://github.com/Autodesk/arnold-usd/issues/2105) - Ensure the Arnold scene isn't modified after a Hydra batch render started
+- [usd#2122](https://github.com/Autodesk/arnold-usd/issues/2122) - RectLight doesn't take width / height into account with scenes exported from Arnold
 
 ### Build
 - [usd#1969](https://github.com/Autodesk/arnold-usd/issues/1969) - Remove support for USD versions older than 21.05

--- a/testsuite/test_2122/README
+++ b/testsuite/test_2122/README
@@ -1,0 +1,6 @@
+Don't author quad_light vertices if they're centered
+
+See #2122
+
+author: sebastien ortega
+

--- a/testsuite/test_2122/data/light.ass
+++ b/testsuite/test_2122/data/light.ass
@@ -1,0 +1,35 @@
+quad_light
+{
+ name /transform1/aiAreaLight
+ matrix
+ 0.959824264 0.28060177 0 0
+ 0.0120773949 -0.0413118452 -0.999073327 0
+ -0.280341715 0.958934844 -0.0430410504 0
+ 0 6.18513441 0 1
+ color 0 1 0
+ intensity 64
+ exposure 0
+ cast_shadows on
+ cast_volumetric_shadows on
+ shadow_density 1
+ samples 1
+ normalize on
+ camera 0
+ transmission 0
+ diffuse 1
+ specular 1
+ sss 1
+ indirect 1
+ max_bounces 999
+ volume_samples 2
+ volume 1
+ aov "default"
+ vertices 4 1 VECTOR
+1 -1 0 -1 -1 0 -1 1 0 1 1 0
+ resolution 512
+ roundness 0
+ soft_edge 0
+ spread 1
+ declare dcc_name constant STRING
+ dcc_name "aiAreaLight"
+}

--- a/testsuite/test_2122/data/test.py
+++ b/testsuite/test_2122/data/test.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['ARNOLD_PATH'], 'python'))
+from arnold import *
+
+AiBegin()
+universe = AiUniverse()
+
+usdScene = 'light_resaved.usda'
+AiSceneLoad(universe, 'light.ass', None)
+params = AiParamValueMap()
+AiParamValueMapSetInt(params, 'mask', AI_NODE_LIGHT)
+AiSceneWrite(universe, usdScene, params)
+AiEnd()
+
+expectedLines = ['def RectLight "aiAreaLight"',
+				'float inputs:height = 2',
+				'float inputs:width = 2']
+forbiddenLines = ['vector3f[] primvars:arnold:vertices =']
+
+currentLine = 0
+expectedLinesCount = len(expectedLines)
+success = False
+with open(usdScene, 'r') as f:
+    lines = f.readlines()
+    for line in lines:
+
+        if currentLine < expectedLinesCount and expectedLines[currentLine] in line:
+            currentLine = currentLine + 1
+            if currentLine == expectedLinesCount:
+                success = True
+        
+        for forbiddenLine in forbiddenLines:
+            if forbiddenLine in line:
+                print('This attribute should not be authored: {}'.format(line))
+                sys.exit(-1)            
+
+if not success:
+    print('Line not found in the output usd file:')
+    print(expectedLines[currentLine])
+    sys.exit(-1)
+
+print('SUCCESS')


### PR DESCRIPTION
When we write usd scenes from a quad light, we are authoring both the width / height and also the arnold atribute "vertices", which is reduntant in most cases. Because of that, later on we cannot modify the width / height as it will be overridden by `primvars:arnold:vertices` . This PR skips the author of this arnold attribute when possible (i.e. when the vertices positions are centered)

**Issues fixed in this pull request**
Fixes #2122 
