### PR TITLE
Fix crash when the root primitive is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug fixes
 - [usd#2129](https://github.com/Autodesk/arnold-usd/issues/2129) - Fixed crashes when instancers have empty / invalid positions
+- [usd#2133](https://github.com/Autodesk/arnold-usd/issues/2133) - Fixed crash when the root primitive is invalid
 
 ## Pending feature release - 803176
 

--- a/libs/translator/writer/writer.cpp
+++ b/libs/translator/writer/writer.cpp
@@ -230,7 +230,7 @@ void UsdArnoldWriter::SetRegistry(UsdArnoldWriterRegistry *registry) { _registry
 
 void UsdArnoldWriter::CreateScopeHierarchy(const SdfPath &path)
 {
-    if (path == SdfPath::AbsoluteRootPath() || _stage->GetPrimAtPath(path))
+    if (path.IsEmpty() || path == SdfPath::AbsoluteRootPath() || _stage->GetPrimAtPath(path))
         return;
         
     // Ensure the parents scopes are created first, otherwise they'll
@@ -241,7 +241,7 @@ void UsdArnoldWriter::CreateScopeHierarchy(const SdfPath &path)
 
 void UsdArnoldWriter::CreateHierarchy(const SdfPath &path, bool leaf)
 {
-    if (path == SdfPath::AbsoluteRootPath())
+    if (path.IsEmpty() || path == SdfPath::AbsoluteRootPath())
         return;
     
     if (!leaf) {


### PR DESCRIPTION
**Changes proposed in this pull request**
In the USD writer, when we create the usd hierarchy based on the node name, we recursively create the parent prims until we reach a primitive which path is `SdfPath::AbsoluteRootPath()`. However, we have a scenario where the path can be empty, in which case it will go in an endless recursive loop calling `UsdArnoldWriter::CreateScopeHierarchy`.

To fix this, in both `CreateHierarchy` and `CreateScopeHierarchy`, I'm also checking if the SdfPath is empty. This fixes the crashes with the mayaUSD repro


**Issues fixed in this pull request**
Fixes #2133
