### PR TITLE
Fix build issue on older versions of Arnold

### DIFF
--- a/libs/translator/writer/prim_writer.h
+++ b/libs/translator/writer/prim_writer.h
@@ -30,6 +30,8 @@
 
 #include "writer.h"
 
+#include <common_utils.h>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 /**


### PR DESCRIPTION
AI_NODE_IMAGER was not defined on older versions of Arnold. We're handling this in common_utils.h.
But recently we started to use this variable in prim_writer.h which does not include the above file, which prevents from building in older versions of Arnold. I'm fixing it here