### PR TITLE
Ensure the ArnoldUsd schema is properly generated

### DIFF
--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -90,6 +90,7 @@ node_parameters
     AiParameterInt("cache_id", 0);
     AiParameterBool("interactive", false);
     AiParameterBool("hydra", false);
+    // Note : if a new attribute is added here, it should be added to the schema in createSchemaFile.py
     
     // Set metadata that triggers the re-generation of the procedural contents when this attribute
     // is modified (see #176)


### PR DESCRIPTION
**Changes proposed in this pull request**
The changes done for #2088 were missing a use case : when the schemas are generated there might not be a "usd" node entry yet (which is the case when arnold-usd is compiled through arnold core). Also, when that happens the usd procedural has not been built as it needs the schemas to be generated first.
Therefore we need to explicitely add the schema ArnoldUsd to the schemas file. This is not ideal as we need to hardcode the usd procedural attributes list. I added a comment in the procedural `node_parameters` function so that every time an attribute is added it's ported to the schemas script.

I could have done all this only when the usd node entry is not found, but I think it's better to do it all the time. Otherwise we're using the node entry that was generated in a previous build and that might not have the correct attributes list. So here when we iterate over the node entries I'm always skipping the usd type, and I'm always explicitely adding later on.


**Issues fixed in this pull request**
Fixes #2088 

