### PR TITLE
Restore arnoldUsd filename to be a string attribute

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -505,7 +505,7 @@ createArnoldClass('procedural_custom', 'Gprim', proceduralCustomAttrs,
 # We want a schema ArnoldUsd with the base shape attributes, as well as the usd proc parameters.
 # Note : this should be updated when new attributes are added to the procedural
 proceduralUsdAttrs = typeParams['shape'] + ['override_nodes', 'namespace', 'operator']
-proceduralUsdAppendAttrs = ['asset arnold:filename = @@', 
+proceduralUsdAppendAttrs = ['string arnold:filename = ""', 
                             'string arnold:object_path = ""', 
                             'float arnold:frame = 0',
                             'bool arnold:debug = 0',


### PR DESCRIPTION
In #2143 I enforced the filename attribute to be an asset attribute, which was different from before (it was a string). Because of that, there are issues in Maya when exporting such a node to usd, with error messages about string VS asset.

My first attempts to make it work as an asset aren't working and causing other issues, so I'll make another ticket to make this attribute an asset, and here I'll roll it back to the previous behaviour