### PR TITLE
Fix handling of hydra updates in batch renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
-## Pending feature release
+## Pending Bugfix release
+- [usd#2154](https://github.com/Autodesk/arnold-usd/issues/2154) - Husk renders can miss scene updates
+
+## [7.3.5.0] - 2024-11-08
 
 ### Feature
 - [usd#1738](https://github.com/Autodesk/arnold-usd/issues/1738) - Support all camera Arnold attributes in Hydra
@@ -42,7 +45,6 @@
 - [usd#2109](https://github.com/Autodesk/arnold-usd/issues/2109) - Expose hydra parameter in the procedural
 - [usd#2107](https://github.com/Autodesk/arnold-usd/issues/2107) - Support procedural updates in hydra mode
 - [usd#2111](https://github.com/Autodesk/arnold-usd/issues/2111) - Add support for transform_keys in xform primitives
-
 
 ### Bug fixes
 - [usd#1961](https://github.com/Autodesk/arnold-usd/issues/1961) - Random curves width in Hydra when radius primvars are authored

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -223,8 +223,8 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
     arnoldRenderDelegate->SetRenderTags(purpose);
 
     // The scene might not be up to date, because of light links, etc, that were generated during the first sync.
-    // UpdateSceneChanges updates the dirtybits for a resync, this is how it works in our hydra render pass.
-    while (arnoldRenderDelegate->UpdateSceneChanges(_renderIndex, _shutter)) {
+    // HasPendingChanges updates the dirtybits for a resync, this is how it works in our hydra render pass.
+    while (arnoldRenderDelegate->HasPendingChanges(_renderIndex, _shutter)) {
         _renderIndex->SyncAll(&_tasks, &_taskContext);
     }
 }
@@ -251,7 +251,7 @@ void HydraArnoldReader::Update()
 {
     HdArnoldRenderDelegate *arnoldRenderDelegate = static_cast<HdArnoldRenderDelegate*>(_renderDelegate);
     _imagingDelegate->ApplyPendingUpdates();
-    arnoldRenderDelegate->UpdateSceneChanges(_renderIndex, _shutter);
+    arnoldRenderDelegate->HasPendingChanges(_renderIndex, _shutter);
     _renderIndex->SyncAll(&_tasks, &_taskContext);
 }
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1535,7 +1535,8 @@ bool HdArnoldRenderDelegate::CanUpdateScene()
     const int status = AiRenderGetStatus(_renderSession);
     return status != AI_RENDER_STATUS_RESTARTING && status != AI_RENDER_STATUS_RENDERING;
 }
-bool HdArnoldRenderDelegate::UpdateSceneChanges(HdRenderIndex* renderIndex, const GfVec2f& shutter)
+
+bool HdArnoldRenderDelegate::HasPendingChanges(HdRenderIndex* renderIndex, const GfVec2f& shutter)
 {
     HdDirtyBits bits = HdChangeTracker::Clean;
     // If Light Linking have changed, we have to dirty the categories on all rprims to force updating the

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -459,7 +459,8 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
     _context(context),
     _universe(universe),
     _procParent(nullptr),
-    _renderDelegateOwnsUniverse(universe==nullptr)
+    _renderDelegateOwnsUniverse(universe==nullptr),
+    _renderSessionType(renderSessionType)
 {    
 
     _lightLinkingChanged.store(false, std::memory_order_release);
@@ -484,7 +485,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
         AiADPAddProductMetadata(AI_ADP_PLUGINVERSION, AtString{AI_VERSION});
         AiADPAddProductMetadata(AI_ADP_HOSTNAME, AtString{"Hydra"});
         AiADPAddProductMetadata(AI_ADP_HOSTVERSION, AtString{PXR_VERSION_STR});
-        AiBegin(renderSessionType);
+        AiBegin(_renderSessionType);
     }
     _supportedRprimTypes = {HdPrimTypeTokens->mesh, HdPrimTypeTokens->volume, HdPrimTypeTokens->points,
                             HdPrimTypeTokens->basisCurves, str::t_procedural_custom};
@@ -562,7 +563,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
 
     if (_renderDelegateOwnsUniverse) {
         _universe = AiUniverse();
-        _renderSession = AiRenderSession(_universe, renderSessionType);
+        _renderSession = AiRenderSession(_universe, _renderSessionType);
     }
 
     _renderParam.reset(new HdArnoldRenderParam(this));
@@ -1527,7 +1528,7 @@ void HdArnoldRenderDelegate::ProcessConnections()
 bool HdArnoldRenderDelegate::CanUpdateScene()
 {
     // For interactive renders, it is always possible to update the scene
-    if (!_isBatch)
+    if (_renderSessionType == AI_SESSION_INTERACTIVE)
         return true;
     // For batch renders, only update the scene if the render hasn't started yet,
     // or if it's finished

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -327,15 +327,15 @@ public:
     HDARNOLD_API
     void ApplyLightLinking(HdSceneDelegate *delegate, AtNode* node, SdfPath const& id);
 
-    /// Updates the eventual changes that happened in the input scene
-    /// since the last iteration.
+    /// Eventually mark some hydra primitives as being dirty
+    /// in which case we'll have another sync iteration pending
     ///
     /// @param renderIndex Pointer to the Hydra Render Index.
     /// @param shutterOpen Shutter Open value of the active camera.
     /// @param shutterClose Shutter Close value of the active camera.
-    /// @return True if the iteration contains scene changes.
+    /// @return True if hydra has pending changes.
     HDARNOLD_API
-    bool UpdateSceneChanges(HdRenderIndex* renderIndex, const GfVec2f& shutter);
+    bool HasPendingChanges(HdRenderIndex* renderIndex, const GfVec2f& shutter);
 
     /// Returns whether the Arnold scene can be updated or
     /// if Hydra changes should be ignored.

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -720,6 +720,7 @@ private:
     AtNode* _fallbackShader = nullptr;   ///< Pointer to the fallback Arnold Shader.
     AtNode* _fallbackVolumeShader = nullptr; ///< Pointer to the fallback Arnold Volume Shader.
     AtNode* _procParent = nullptr;
+    AtSessionMode _renderSessionType = AI_SESSION_INTERACTIVE;
     std::string _logFile;
     std::string _statsFile;
     AtStatsMode _statsMode;

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -969,10 +969,11 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         clearBuffers(_renderBuffers);
     }
 
-    _renderDelegate->UpdateSceneChanges(
+    bool hasSceneChanges = _renderDelegate->UpdateSceneChanges(
         GetRenderIndex(),
         {AiNodeGetFlt(currentCamera, str::shutter_start), AiNodeGetFlt(currentCamera, str::shutter_end)});
-    const auto renderStatus = renderParam->UpdateRender();
+    const auto renderStatus = (hasSceneChanges && _renderDelegate->IsBatchContext()) ? 
+        HdArnoldRenderParam::Status::Converging : renderParam->UpdateRender();
     _isConverged = renderStatus != HdArnoldRenderParam::Status::Converging;
 
     // We need to set the converged status of the render buffers.

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -969,10 +969,15 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         clearBuffers(_renderBuffers);
     }
 
-    bool hasSceneChanges = _renderDelegate->UpdateSceneChanges(
+    // Check if hydra still has pending changes that will be processed in the next iteration.
+    bool hasPendingChanges = _renderDelegate->HasPendingChanges(
         GetRenderIndex(),
         {AiNodeGetFlt(currentCamera, str::shutter_start), AiNodeGetFlt(currentCamera, str::shutter_end)});
-    const auto renderStatus = (hasSceneChanges && _renderDelegate->IsBatchContext()) ? 
+    
+    // If we still have pending Hydra changes, we don't want to start / update the render just yet,
+    // as we'll receive shortly another sync. In particular in the case of batch renders, this prevents
+    // from rendering the final scene #2154
+    const auto renderStatus = hasPendingChanges ? 
         HdArnoldRenderParam::Status::Converging : renderParam->UpdateRender();
     _isConverged = renderStatus != HdArnoldRenderParam::Status::Converging;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
The changes introduced in #2079 were actually pretty wrong, and caused by a miss-understanding of what the function was doing. This PR reverts most of it, and adds the explanations and comments that were missing in the original code.

In the function I had renamed as `UpdateSceneChanges`, some hydra primitives are marked as dirty. I thought the Sync function would be called immediately, thus updating the arnold scene, but it's actually called later on.  So for clarity I'm renaming it as `HasPendingChanges` which tells us that a Sync call is going to happen shortly. In this case, we don't want to start the render just yet, cause we know the scene might change. For interactive renders it's not so bad because we can interrupt and restart the render to process the changes, but since we recently changes the arnold session to be "batch" in husk, this is preventing us from receiving some hydra notifications.

**Issues fixed in this pull request**
Fixes #2154 
