### PR TITLE
Remove AI_ERROR_UNAVAILABLE_DEVICE from Arnold version higher that 7.3

### DIFF
--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -129,8 +129,10 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
                 TF_WARN("[arnold-usd] Render interrupted by user.");
             } else if (_errorCode == AI_ERROR_NO_OUTPUTS) {
                 TF_WARN("[arnold-usd] No rendering outputs.");
+#if ARNOLD_VERSION_NUM <= 70305
             } else if (_errorCode == AI_ERROR_UNAVAILABLE_DEVICE) {
                 TF_WARN("[arnold-usd] Cannot create GPU context.");
+#endif
             } else if (_errorCode == AI_ERROR) {
                 TF_WARN("[arnold-usd] Generic error.");
             }

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -129,7 +129,7 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
                 TF_WARN("[arnold-usd] Render interrupted by user.");
             } else if (_errorCode == AI_ERROR_NO_OUTPUTS) {
                 TF_WARN("[arnold-usd] No rendering outputs.");
-#if ARNOLD_VERSION_NUM <= 70305
+#if ARNOLD_VERSION_NUM < 70400
             } else if (_errorCode == AI_ERROR_UNAVAILABLE_DEVICE) {
                 TF_WARN("[arnold-usd] Cannot create GPU context.");
 #endif


### PR DESCRIPTION
**Changes proposed in this pull request**
- We remove AI_ERROR_UNAVAILABLE_DEVICE that is now deprecated.