### PR TITLE
Add missing constant string

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -401,6 +401,7 @@ ASTR(parallel_node_init);
 ASTR(param_colorspace);
 ASTR(param_filename);
 ASTR(param_shader_file);
+ASTR(param_shader_file_colorspace);
 ASTR(parent_instance);
 ASTR(path);
 ASTR(penumbra_angle);


### PR DESCRIPTION
This PR adds a missing constant string used in #[2160](https://github.com/Autodesk/arnold-usd/pull/2160)