### PR TITLE
Fix MaterialX triplanar colorspace issue

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -401,7 +401,6 @@ ASTR(parallel_node_init);
 ASTR(param_colorspace);
 ASTR(param_filename);
 ASTR(param_shader_file);
-ASTR(param_shader_file_colorspace);
 ASTR(parent_instance);
 ASTR(path);
 ASTR(penumbra_angle);

--- a/libs/common/materials_utils.cpp
+++ b/libs/common/materials_utils.cpp
@@ -639,11 +639,12 @@ AtNode* ReadMtlxOslShader(const std::string& nodeName,
                     std::string colorSpaceStr = std::string("colorSpace:")+ attrName.GetString();
                     TfToken colorSpace(colorSpaceStr);
                     const auto colorSpaceAttr = inputAttrs.find(colorSpace);
+                    AtString colorspace_param((attrNameStr + "_colorspace").c_str());
                     if (colorSpaceAttr != inputAttrs.end()) {
                         std::string colorSpaceStr = VtValueGetString(colorSpaceAttr->second.value);
-                        AiNodeSetStr(node, str::param_shader_file_colorspace, AtString(colorSpaceStr.c_str()));
+                        AiNodeSetStr(node, colorspace_param, AtString(colorSpaceStr.c_str()));
                     } else {
-                        AiNodeSetStr(node, str::param_shader_file_colorspace, str::_auto);
+                        AiNodeSetStr(node, colorspace_param, str::_auto);
                     }
                 }
             }


### PR DESCRIPTION
The fix proposed in #2160 is failing to set the colorspace on the MaterialX triplanar node, as the file parameter is named differently. I verified that this fix is passing the testsuite. 