### PR TITLE
Resample the values returned by SamplePrimvar 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 
 ## Pending Feature release
 
-- [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision
+### Feature
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10
 
-## Pending Feature release (7.2.6.0)
+### Bug fixes
+- [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision
+- [usd#2168](https://github.com/Autodesk/arnold-usd/issues/2168) - Workaround a bug in USD >= 24.08 by resampling values returned by SamplePrimvar.
+
+## [7.3.6.0] - 2024-12-12
 
 ### Feature
 - [usd#2119](https://github.com/Autodesk/arnold-usd/issues/2119) - Support options shader_override attribute

--- a/libs/render_delegate/basis_curves.cpp
+++ b/libs/render_delegate/basis_curves.cpp
@@ -260,7 +260,7 @@ void HdArnoldBasisCurves::Sync(
                 // The number of motion keys has to be matched between points and orientations, so if there are multiple
                 // position keys, so we are forcing the user to use the SamplePrimvars function.
                 if (primvar.first == _tokens->orientations) {
-                    HdArnoldSetNormalsFromPrimvar(GetArnoldNode(), id, _tokens->orientations, str::orientations, sceneDelegate);
+                    HdArnoldSetNormalsFromPrimvar(GetArnoldNode(), id, _tokens->orientations, str::orientations, sceneDelegate, param());
                 } else if (primvar.first != _tokens->basis) {
                     // We skip reading the basis for now as it would require remapping the vertices, widths and
                     // all the primvars.

--- a/libs/render_delegate/instancer.cpp
+++ b/libs/render_delegate/instancer.cpp
@@ -88,11 +88,12 @@ void HdArnoldInstancer::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
     _UpdateInstancer(sceneDelegate, dirtyBits);
 
     if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, GetId())) {
-        _SyncPrimvars(*dirtyBits);
+        HdArnoldRenderParam *param = reinterpret_cast<HdArnoldRenderParam*>(renderParam);
+        _SyncPrimvars(*dirtyBits, param);
     }
 }
 
-void HdArnoldInstancer::_SyncPrimvars(HdDirtyBits dirtyBits)
+void HdArnoldInstancer::_SyncPrimvars(HdDirtyBits dirtyBits, HdArnoldRenderParam* renderParam)
 {
     auto& changeTracker = GetDelegate()->GetRenderIndex().GetChangeTracker();
     const auto& id = GetId();
@@ -121,19 +122,19 @@ void HdArnoldInstancer::_SyncPrimvars(HdDirtyBits dirtyBits)
             if (primvar.name == GetInstanceTransformsToken()) {
                 HdArnoldSampledPrimvarType sample;
                 GetDelegate()->SamplePrimvar(id, GetInstanceTransformsToken(), &sample);
-                _transforms.UnboxFrom(sample);
+                HdArnoldUnboxResample(sample, renderParam->GetShutterRange(), _transforms);
             } else if (primvar.name == GetRotateToken()) {
                 HdArnoldSampledPrimvarType sample;
                 GetDelegate()->SamplePrimvar(id, GetRotateToken(), &sample);
-                _rotates.UnboxFrom(sample);
+                HdArnoldUnboxResample(sample, renderParam->GetShutterRange(), _rotates);
             } else if (primvar.name == GetScaleToken()) {
                 HdArnoldSampledPrimvarType sample;
                 GetDelegate()->SamplePrimvar(id, GetScaleToken(), &sample);
-                _scales.UnboxFrom(sample);
+                HdArnoldUnboxResample(sample, renderParam->GetShutterRange(), _scales);
             } else if (primvar.name == GetTranslateToken()) {
                 HdArnoldSampledPrimvarType sample;
                 GetDelegate()->SamplePrimvar(id, GetTranslateToken(), &sample);
-                _translates.UnboxFrom(sample);
+                HdArnoldUnboxResample(sample, renderParam->GetShutterRange(), _translates);
             } else {
                 HdArnoldInsertPrimvar(
                     _primvars, primvar.name, primvar.role, primvar.interpolation, GetDelegate()->Get(id, primvar.name),

--- a/libs/render_delegate/instancer.h
+++ b/libs/render_delegate/instancer.h
@@ -82,7 +82,7 @@ protected:
     ///
     /// Safe to call on multiple threads.
     HDARNOLD_API
-    void _SyncPrimvars(HdDirtyBits dirtyBits);
+    void _SyncPrimvars(HdDirtyBits dirtyBits, HdArnoldRenderParam* renderParam);
     HdArnoldRenderDelegate* _delegate = nullptr;
     std::mutex _mutex;                                ///< Mutex to safe-guard calls to _SyncPrimvars.
     HdArnoldPrimvarMap _primvars;                     ///< Unordered map to store all the primvars.


### PR DESCRIPTION
**Changes proposed in this pull request**
- In USD >= 24.08 the SamplePrimvar function returns different values than before, omitting the shutter boundaries. This leads to several test failures. This PR adds code to resamples the values returned by SamplePrimvar such that they work with what Arnold expects, equally spaced values in the shutter range.

**Issues fixed in this pull request**
Fixes #2168
