### PR TITLE
Fix handling of render tags in hydra.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10
+- [usd#2170](https://github.com/Autodesk/arnold-usd/issues/2170) - Fix handling of render tags in hydra.
 
 ## Pending Feature release (7.2.6.0)
 

--- a/libs/render_delegate/rprim.h
+++ b/libs/render_delegate/rprim.h
@@ -76,6 +76,14 @@ public:
     ///
     /// @return Pointer to the Render Delegate.
     HdArnoldRenderDelegate* GetRenderDelegate() { return _renderDelegate; }
+
+    /// Tracking render tag changes
+    void UpdateRenderTag(HdSceneDelegate *delegate, HdRenderParam *renderParam) override {
+        HdRprim::UpdateRenderTag(delegate, renderParam);
+        HdArnoldRenderParamInterrupt param(renderParam);
+        _shape.UpdateRenderTag(this, delegate, param);
+    }
+
     /// Syncs internal data and arnold state with hydra.
     void SyncShape(
         HdDirtyBits dirtyBits, HdSceneDelegate* sceneDelegate, HdArnoldRenderParamInterrupt& param, bool force = false)

--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -69,17 +69,17 @@ void HdArnoldShape::Sync(
         param.Interrupt();
         _SetPrimId(rprim->GetPrimId());
     }
-    
-    // If render tags are empty, we are displaying everything.
-    if (dirtyBits & HdChangeTracker::DirtyRenderTag) {
-        param.Interrupt();
-        const auto renderTag = sceneDelegate->GetRenderTag(id);
-        _renderDelegate->TrackRenderTag(_shape, renderTag);
-        for (auto &instancer : _instancers) {
-            _renderDelegate->TrackRenderTag(instancer, renderTag);
-        }
-    }
+
     _SyncInstances(dirtyBits, _renderDelegate, sceneDelegate, param, id, rprim->GetInstancerId(), force);
+}
+
+void HdArnoldShape::UpdateRenderTag(HdRprim* rprim, HdSceneDelegate *sceneDelegate, HdArnoldRenderParamInterrupt& param){
+    param.Interrupt();
+    const auto renderTag = sceneDelegate->GetRenderTag(rprim->GetId());
+    _renderDelegate->TrackRenderTag(_shape, renderTag);
+    for (auto &instancer : _instancers) {
+        _renderDelegate->TrackRenderTag(instancer, renderTag);
+    }
 }
 
 void HdArnoldShape::SetVisibility(uint8_t visibility)

--- a/libs/render_delegate/shape.h
+++ b/libs/render_delegate/shape.h
@@ -86,6 +86,12 @@ public:
         HdRprim* rprim, HdDirtyBits dirtyBits, HdSceneDelegate* sceneDelegate, HdArnoldRenderParamInterrupt& param,
         bool force = false);
 
+    /// @brief Update the render tag of the rprim
+    /// @param rprim 
+    /// @param delegate 
+    /// @param param 
+    void UpdateRenderTag(HdRprim* rprim, HdSceneDelegate *delegate, HdArnoldRenderParamInterrupt& param);
+
     /// Sets the internal visibility parameter.
     ///
     /// @param visibility New value for visibility.
@@ -103,7 +109,7 @@ public:
     static HdDirtyBits GetInitialDirtyBitsMask()
     {
         return HdChangeTracker::DirtyInstancer | HdChangeTracker::DirtyInstanceIndex |
-               HdChangeTracker::DirtyCategories | HdChangeTracker::DirtyPrimID | HdChangeTracker::DirtyRenderTag;
+               HdChangeTracker::DirtyCategories | HdChangeTracker::DirtyPrimID;
     }
 
 protected:


### PR DESCRIPTION
**Changes proposed in this pull request**
- This PR mimics how Storm handles the render tags. The `HdChangeTracker::DirtyRenderTag` bit seems to be used internally by hydra and not used in the render delegate. When a render tag is updated, the update is passed to a dedicated function `HdRprim::UpdateRenderTag` which can be overridden. 

**Issues fixed in this pull request**
Fixes #2170

