### PR TITLE
Declare render delegate "stop render" instead of pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Feature
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10
 - [usd#2170](https://github.com/Autodesk/arnold-usd/issues/2170) - Fix handling of render tags in hydra.
+- [usd#2177](https://github.com/Autodesk/arnold-usd/issues/2177) - Declare render delegate's stop render instead of pause.
 
 ### Bug fixes
 - [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1666,9 +1666,11 @@ bool HdArnoldRenderDelegate::HasPendingChanges(HdRenderIndex* renderIndex, const
     return changes;
 }
 
-bool HdArnoldRenderDelegate::IsPauseSupported() const { return true; }
+bool HdArnoldRenderDelegate::IsPauseSupported() const { return false; }
 
-bool HdArnoldRenderDelegate::Pause()
+bool HdArnoldRenderDelegate::IsStopSupported() const { return true; }
+
+bool HdArnoldRenderDelegate::Stop(bool blocking)
 {
     _renderParam->Pause();
     return true;
@@ -1678,6 +1680,18 @@ bool HdArnoldRenderDelegate::Resume()
 {
     _renderParam->Resume();
     return true;
+}
+
+bool HdArnoldRenderDelegate::Restart()
+{    
+    _renderParam->Restart();
+    return true;
+}
+
+bool HdArnoldRenderDelegate::IsStopped() const
+{   
+    int status = AiRenderGetStatus(GetRenderSession());
+    return (status != AI_RENDER_STATUS_RENDERING && status != AI_RENDER_STATUS_RESTARTING);
 }
 
 const HdArnoldRenderDelegate::NativeRprimParamList* HdArnoldRenderDelegate::GetNativeRprimParamList(
@@ -1815,12 +1829,12 @@ HdCommandDescriptors HdArnoldRenderDelegate::GetCommandDescriptors() const
 bool HdArnoldRenderDelegate::InvokeCommand(const TfToken& command, const HdCommandArgs& args)
 {
     if (command == TfToken("flush_texture")) {
-        // Pause render
+        // Stop render
         _renderParam->Pause();
         // Flush texture
         AiUniverseCacheFlush(_universe, AI_CACHE_TEXTURE);
         // Restart the render
-        _renderParam->Resume();
+        _renderParam->Restart();
     }
     return false;
 }

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -359,16 +359,36 @@ public:
     /// @return True if pause/restart is supported.
     HDARNOLD_API
     bool IsPauseSupported() const override;
-    /// Pause all of this delegate's background rendering threads. Default
+    
+    /// Advertise whether this delegate supports stopping and restarting of
+    /// background render threads. Default implementation returns false.
+    ///
+    /// @return True if stop/restart is supported.
+    HDARNOLD_API
+    bool IsStopSupported() const override;
+
+    /// Advertise whether the render was stopped or if it's in progress
+    /// @return True if no render is in progress
+    HDARNOLD_API
+    bool IsStopped() const override;
+
+    /// Stop all of this delegate's background rendering threads. Default
     /// implementation does nothing.
     ///
     /// @return True if successful.
     HDARNOLD_API
-    bool Pause() override;
-    /// Resume all of this delegate's background rendering threads previously
-    /// paused by a call to Pause. Default implementation does nothing.
+    bool Stop(bool blocking = true) override;
+
+    /// Restart all of this delegate's background rendering threads previously
+    /// paused by a call to Stop. Default implementation does nothing.
     ///
     /// @return True if successful.
+    HDARNOLD_API
+    bool Restart() override;
+
+    /// Resume all of this delegate's background rendering threads previously
+    /// paused by a call to Pause. Default implementation does nothing. This is
+    /// currently doing the same as restart
     HDARNOLD_API
     bool Resume() override;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
We were previously returning true in render delegate's `IsPauseSupported` and interrupting the render when pause was called. Then, for "resume render" we were simply restarting it from scratch, since arnold currently doesn't support pause & resume rendering. This PR removes the "pause" functions from our render delegate (which defaults to pause not being supported), and instead returns true in `IsStopSupported`. In Solaris, this will replace the previous "Pause Render" menu with "Stop Render".
It then removes several issues that happened because of the render pause (e.g. render restarting in Solaris when the AOVs are changed in Houdini 20.5)

**Issues fixed in this pull request**
Fixes #2177 
