### PR TITLE
re-enable checking the DirtyRenderTag tag for versions < 24.08

### DIFF
--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -69,6 +69,17 @@ void HdArnoldShape::Sync(
         param.Interrupt();
         _SetPrimId(rprim->GetPrimId());
     }
+#if PXR_VERSION < 2408
+    // If render tags are empty, we are displaying everything.
+     if (dirtyBits & HdChangeTracker::DirtyRenderTag) {
+         param.Interrupt();
+         const auto renderTag = sceneDelegate->GetRenderTag(id);
+         _renderDelegate->TrackRenderTag(_shape, renderTag);
+         for (auto &instancer : _instancers) {
+             _renderDelegate->TrackRenderTag(instancer, renderTag);
+         }
+     }
+#endif
 
     _SyncInstances(dirtyBits, _renderDelegate, sceneDelegate, param, id, rprim->GetInstancerId(), force);
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
- with a ifdef we re-enable the previous render tags handling behaviour for usd versions < 24.08 
- we don't add a changelog entry since this is a fix for https://github.com/Autodesk/arnold-usd/pull/2171

**Issues fixed in this pull request**
Fixes #2178 

