### PR TITLE
Write junit report 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10
 - [usd#2170](https://github.com/Autodesk/arnold-usd/issues/2170) - Fix handling of render tags in hydra.
 - [usd#2177](https://github.com/Autodesk/arnold-usd/issues/2177) - Declare render delegate's stop render instead of pause.
+- [usd#2183](https://github.com/Autodesk/arnold-usd/issues/2183) - Enable JUnit reports
 
 ### Bug fixes
 - [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision

--- a/SConstruct
+++ b/SConstruct
@@ -135,6 +135,7 @@ vars.AddVariables(
     StringVariable('USDGENSCHEMA_CMD', 'Custom command to run usdGenSchema', None),
     StringVariable('TESTSUITE_OUTPUT', 'Optional output path where the testsuite results are saved', None),
     StringVariable('JUNIT_TESTSUITE_NAME', 'Optional name for the JUnit report', None),
+    StringVariable('JUNIT_TESTSUITE_URL', 'Optional URL for the JUnit report', None),
     BoolVariable('REPORT_ONLY_FAILED_TESTS', 'Only failed test will be kept', False),
     StringVariable('TIMELIMIT', 'Time limit for each test (in seconds)', '300'),
     ('TEST_PATTERN', 'Glob pattern of tests to be run', 'test_*'),

--- a/tools/test/testsuite.py
+++ b/tools/test/testsuite.py
@@ -264,7 +264,8 @@ class Testsuite(object):
             if 'JUNIT_TESTSUITE_NAME' in env:
                 testsuite_url = env['JUNIT_TESTSUITE_URL'] if 'JUNIT_TESTSUITE_URL' in env else None
                 testsuite.report_junit_xml(env['JUNIT_TESTSUITE_NAME'], testsuite_url)
-            testsuite.report_html()
+            report_only_fail = env['REPORT_ONLY_FAILED_TESTS'] if 'REPORT_ONLY_FAILED_TESTS' in env else false
+            testsuite.report_html(only_failed_tests=report_only_fail)
             system.print_safe(testsuite.report_text(), flush=True)
             system.print_safe('View testsuite results at: file://{}'.format(target[0].abspath), flush=True)
             return 1 if testsuite.failed(float(env['TESTSUITE_INSTABILITY_THRESHOLD'])) else 0

--- a/tools/test/testsuite.py
+++ b/tools/test/testsuite.py
@@ -260,6 +260,10 @@ class Testsuite(object):
             return 0
          def action_gen_report(target, source, env):
             testsuite = env['TEST_SUITE']
+            testsuite.report_json()
+            if 'JUNIT_TESTSUITE_NAME' in env:
+                testsuite_url = env['JUNIT_TESTSUITE_URL'] if 'JUNIT_TESTSUITE_URL' in env else None
+                testsuite.report_junit_xml(env['JUNIT_TESTSUITE_NAME'], testsuite_url)
             testsuite.report_html()
             system.print_safe(testsuite.report_text(), flush=True)
             system.print_safe('View testsuite results at: file://{}'.format(target[0].abspath), flush=True)


### PR DESCRIPTION
**Changes proposed in this pull request**
- Write junit report if the JUNIT_TESTSUITE_NAME arg is set
- Re-enable the report on fail only

**Issues fixed in this pull request**
Fixes #2183

