### PR TITLE
Fix recent build issues in arnold-usd plugins

### DIFF
--- a/plugins/render_delegate/SConscript
+++ b/plugins/render_delegate/SConscript
@@ -6,7 +6,7 @@ local_env = env.Clone()
 src_dir = os.path.join(env['ROOT_DIR'], 'plugins', 'render_delegate')
 
 source_files = ['renderer_plugin.cpp']
-if not system.IS_WINDOWS:
+if not system.is_windows:
     local_env.Append(CXXFLAGS = Split('-fPIC'))
 
 local_env.Append(CPPDEFINES=['HDARNOLD_EXPORTS'])

--- a/plugins/scene_delegate/SConscript
+++ b/plugins/scene_delegate/SConscript
@@ -28,7 +28,7 @@ source_files = [
     'rprim_adapter.cpp',
 ]
 
-if not system.IS_WINDOWS:
+if not system.is_windows:
     local_env.Append(CXXFLAGS = Split('-fPIC'))
 
 local_env.Append(CPPDEFINES=['IMAGINGARNOLD_EXPORTS'])


### PR DESCRIPTION
Recent changes in our build scripts broke the compilation of the scene delegate and render delegate plugins.
This PR ports the changes to these scripts