### PR TITLE
Save read stage time in the stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [usd#2176](https://github.com/Autodesk/arnold-usd/issues/2176) - Support distant light's normalize attribute
 - [usd#2177](https://github.com/Autodesk/arnold-usd/issues/2177) - Declare render delegate's stop render instead of pause.
 - [usd#2183](https://github.com/Autodesk/arnold-usd/issues/2183) - Enable JUnit reports
+- [usd#2190](https://github.com/Autodesk/arnold-usd/issues/2190) - Save the time taken to read the stage in the stats. 
 
 ### Bug fixes
 - [usd#2159](https://github.com/Autodesk/arnold-usd/issues/2159) - User data errors with deformed meshes and subdivision

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -107,7 +107,7 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
     HdArnoldRenderDelegate *arnoldRenderDelegate = static_cast<HdArnoldRenderDelegate*>(_renderDelegate);
     if (arnoldRenderDelegate == 0)
         return;
-
+    AiProfileBlock("hydra_proc:read_stage"); 
     if (stage == nullptr) {
         AiMsgError("[usd] Unable to create USD stage from %s", _filename.c_str());
         return;

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -397,7 +397,7 @@ unsigned int UsdArnoldReader::ProcessConnectionsThread(void *data)
 void UsdArnoldReader::ReadStage(UsdStageRefPtr stage, const std::string &path)
 {
     UsdPrim *rootPrimPtr = nullptr;
-
+    AiProfileBlock("usd_proc:read_stage"); 
     if (!_updating) {
         // set the stage while we're reading
         _stage = stage;


### PR DESCRIPTION
**Changes proposed in this pull request**
- Add profile blocks in read_stage functions

**Issues fixed in this pull request**
Fixes #2190
