### PR TITLE
Consider global option to roll back distant lights normalize

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -494,6 +494,7 @@ ASTR(transmission);
 ASTR(twrap);
 ASTR(uniform);
 ASTR(usd);
+ASTR(usd_legacy_distant_light_normalize);
 ASTR(useMetadata);
 ASTR(useSpecularWorkflow);
 ASTR(use_light_group);

--- a/libs/render_delegate/light.cpp
+++ b/libs/render_delegate/light.cpp
@@ -293,6 +293,20 @@ auto distantLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* ne
     TF_UNUSED(filter);
     iterateParams(light, nentry, id, sceneDelegate, renderDelegate, distantParams);
     readUserData(light, id, sceneDelegate, renderDelegate);
+
+    bool ignoreNormalize = true;
+
+#if ARNOLD_VERSION_NUM >= 70400
+    AtNode* options = AiUniverseGetOptions(renderDelegate->GetUniverse());
+    if (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(options), str::usd_legacy_distant_light_normalize)) {
+        ignoreNormalize = AiNodeGetBool(options, str::usd_legacy_distant_light_normalize);
+    }    
+#endif
+    if (ignoreNormalize) {
+        // For distant lights, we want to ignore the normalize attribute, as it's not behaving
+        // as expected in arnold (see #1191)
+        AiNodeResetParameter(light, str::normalize);
+    }
 };
 
 auto diskLightSync = [](AtNode* light, AtNode** filter, const AtNodeEntry* nentry, const SdfPath& id,

--- a/libs/translator/reader/read_light.cpp
+++ b/libs/translator/reader/read_light.cpp
@@ -306,9 +306,20 @@ AtNode* UsdArnoldReadDistantLight::Read(const UsdPrim &prim, UsdArnoldReaderCont
     if (GET_LIGHT_ATTR(light, Angle).Get(&angleValue, time.frame)) {
         AiNodeSetFlt(node, str::angle, VtValueGetFloat(angleValue));
     }
-    VtValue normalizeValue;
-    if (GET_LIGHT_ATTR(light, Normalize).Get(&normalizeValue, time.frame)) {
-        AiNodeSetBool(node, str::normalize, VtValueGetBool(normalizeValue));
+
+    bool ignoreNormalize = true;
+
+#if ARNOLD_VERSION_NUM >= 70400
+    AtNode* options = AiUniverseGetOptions(context.GetReader()->GetUniverse());
+    if (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(options), str::usd_legacy_distant_light_normalize)) {
+        ignoreNormalize = AiNodeGetBool(options, str::usd_legacy_distant_light_normalize);
+    }    
+#endif
+    if (!ignoreNormalize) {
+        VtValue normalizeValue;
+        if (GET_LIGHT_ATTR(light, Normalize).Get(&normalizeValue, time.frame)) {
+            AiNodeSetBool(node, str::normalize, VtValueGetBool(normalizeValue));
+        }
     }
 
     _ReadLightCommon(prim, node, time);


### PR DESCRIPTION
In #2176  we have changed the current behaviour of distant lights normalize attributes.
We want to add a global option to roll back to the previous behaviour. 
Note that we first need this attribute to be added in arnold core before we can make a test for that, otherwise the current code sees that this attribute doesn't exist in the options and rolls back to ignore the normalize.