### PR TITLE
Add override environment variables for the testsuite to use with cmake

### DIFF
--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -28,13 +28,13 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/testsuite"
     #       add a way to run a set of tests instead of the whole testsuite
     COMMAND
         ${CMAKE_COMMAND} -E env
-            "ARNOLD_PLUGIN_PATH=${CMAKE_SOURCE_DIR}/build/cmake_build/procedural"
-            "PXR_PLUGINPATH_NAME=${CMAKE_SOURCE_DIR}/build/cmake_build/schema:${CMAKE_SOURCE_DIR}/build/cmake_build/plugin"
-            ./abuild USD_PROCEDURAL_PATH="${CMAKE_SOURCE_DIR}/build/cmake_build/procedural" USD_PATH=${USD_LOCATION} BOOST_INCLUDE=${USD_LOCATION}/include ARNOLD_PATH=${ARNOLD_LOCATION} BUILD_SCHEMAS=0 BUILD_DOCS=0 BUILD_TESTSUITE=1 testsuite
+            "TESTSUITE_ARNOLD_PLUGIN_PATH=${CMAKE_SOURCE_DIR}/build/cmake_build/procedural"
+            "TESTSUITE_PXR_PLUGINPATH_NAME=${CMAKE_SOURCE_DIR}/build/cmake_build/schema:${CMAKE_SOURCE_DIR}/build/cmake_build/plugin"
+            "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${USD_LOCATION}/lib"
+            ./abuild USD_PATH=${USD_LOCATION} BOOST_INCLUDE=${USD_LOCATION}/include ARNOLD_PATH=${ARNOLD_LOCATION} BUILD_SCHEMAS=0 BUILD_DOCS=0 BUILD_TESTSUITE=1 testsuite
 
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
-
 add_custom_target(testsuite
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/testsuite"
 )

--- a/tools/test/testsuite.py
+++ b/tools/test/testsuite.py
@@ -147,10 +147,16 @@ class Testsuite(object):
       # Configure CER to use AUTOSEND mode, which was purposefully designed for use in automated testing
       
       self.report_params = {}
-
-      self.environment['ARNOLD_PLUGIN_PATH'] = os.path.dirname(self.environment['USD_PROCEDURAL_PATH'])
-      self.environment['PXR_PLUGINPATH_NAME'] = self.environment['PREFIX_RENDER_DELEGATE']
+      if 'TESTSUITE_ARNOLD_PLUGIN_PATH' in self.environment:
+         self.environment['ARNOLD_PLUGIN_PATH'] = self.environment['TESTSUITE_ARNOLD_PLUGIN_PATH']
+      else:
+         self.environment['ARNOLD_PLUGIN_PATH'] = os.path.dirname(self.environment['USD_PROCEDURAL_PATH'])
       
+      if 'TESTSUITE_PXR_PLUGINPATH_NAME' in self.environment:
+         self.environment['PXR_PLUGINPATH_NAME'] = self.environment['TESTSUITE_PXR_PLUGINPATH_NAME']
+      else:
+         self.environment['PXR_PLUGINPATH_NAME'] = self.environment['PREFIX_RENDER_DELEGATE']
+
       # Disable ADP in testsuite. On linux there's a 5s delay at exit, which
       # multiplied by a few thousand tests is not OK. The opt-in dialog window
       # might pop up on a fresh machine, which could hang or crash depending on


### PR DESCRIPTION
**Changes proposed in this pull request**
- When using cmake, we compile the procedural in a different directory than scons. In order to run the testsuite on different procedural location we add 2 new environment variables that, if defined, are going to be used by the testsuite to override ARNOLD_PLUGIN_PATH and PXR_PLUGINPATH_NAME:
  - TESTSUITE_ ARNOLD_PLUGIN_PATH -> ARNOLD_PLUGIN_PATH
  - TESTSUITE_PXR_PLUGINPATH_NAME -> PXR_PLUGINPATH_NAME
- We use those variables in cmake to run the testsuite with `make testsuite`

**Issues fixed in this pull request**
Fixes #2195


**Additional context**
Add any other context or screenshots about the pull request here.
