### PR TITLE
Fix mtlx texture connection in the render delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 # Changelog
 
 ## Pending Feature release
+- [usd#2197](https://github.com/Autodesk/arnold-usd/issues/2197) - MaterialX textures not applied properly in hydra through mayaHydra
+
+## Pending Feature release (7.3.7.0)
 
 ### Feature
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10

--- a/libs/common/materials_utils.cpp
+++ b/libs/common/materials_utils.cpp
@@ -654,9 +654,16 @@ AtNode* ReadMtlxOslShader(const std::string& nodeName,
                 const AtParamValue *defaultValue = AiParamGetDefault(paramEntry);
                 // Getting the default array, and checking its type
                 arrayType = (defaultValue) ? AiArrayGetType(defaultValue->ARRAY()) : AI_TYPE_NONE;
-            }
+            } else if (!attr.connection.IsEmpty()) {
+                // This attribute is linked, ask the MaterialReader to handle the connection.
+                // In this case, we don't need to convert any VtValue as it will be ignored
+                materialReader.ConnectShader(node, attrNameStr, attr.connection, ArnoldAPIAdapter::CONNECTION_LINK);
+                continue;
+            } 
             // Read the attribute value, as we do for regular attributes
-            ReadAttribute(attr, node, attrNameStr, time, context, paramType, arrayType);
+            ReadAttribute(attr, node, attrNameStr, time, 
+                    context, paramType, arrayType);
+            
         }
         return node;
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
In `ReadMtlxOslShader`, as we call `AddConnection` to connect parameters, we were not finding the arnold node due to a naming scope issue. Now, we do the same as with builtin arnold shaders, and eventually call `MaterialReader::ConnectShader`. This function will eventually add the scope of the material so that we find the right shader.


**Issues fixed in this pull request**
Fixes #2197 
