### PR TITLE
Fix build issue in older versions of USD

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1688,11 +1688,13 @@ bool HdArnoldRenderDelegate::Restart()
     return true;
 }
 
+#if PXR_VERSION >= 2203
 bool HdArnoldRenderDelegate::IsStopped() const
 {   
     int status = AiRenderGetStatus(GetRenderSession());
     return (status != AI_RENDER_STATUS_RENDERING && status != AI_RENDER_STATUS_RESTARTING);
 }
+#endif
 
 const HdArnoldRenderDelegate::NativeRprimParamList* HdArnoldRenderDelegate::GetNativeRprimParamList(
     const AtString& arnoldNodeType) const

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -367,10 +367,12 @@ public:
     HDARNOLD_API
     bool IsStopSupported() const override;
 
+#if PXR_VERSION >= 2203
     /// Advertise whether the render was stopped or if it's in progress
     /// @return True if no render is in progress
     HDARNOLD_API
     bool IsStopped() const override;
+#endif
 
     /// Stop all of this delegate's background rendering threads. Default
     /// implementation does nothing.


### PR DESCRIPTION
The changes in #2177 are not compiling with USD 21.11, because the IsStopped API didn't exist yet