### PR TITLE
Hydra procedural should not modify the usd stage for shutter range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Changelog
 
 ## Pending Feature release
+### Bug fixes
+- [usd#2201](https://github.com/Autodesk/arnold-usd/issues/2201) - Hydra procedural should not modify the input usd stage with shutter range
+
+## Pending Feature release (7.3.7.0)
 
 ### Feature
 - [usd#2160](https://github.com/Autodesk/arnold-usd/issues/2160) - Support OSL code generated from image shaders in MaterialX 1.38.10

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -11,6 +11,8 @@
 #include "pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h"
 #include "procedural_reader.h"
 
+class UsdArnoldProcImagingDelegate;
+
 // This is the interface we need for the procedural reader
 
 class HydraArnoldReader : public ProceduralReader {
@@ -45,7 +47,7 @@ private:
 
     TfToken _purpose;
     HdRenderIndex* _renderIndex;
-    UsdImagingDelegate* _imagingDelegate;
+    UsdArnoldProcImagingDelegate* _imagingDelegate = nullptr;
     HdEngine _engine;
     HdRenderDelegate *_renderDelegate;
     AtUniverse *_universe = nullptr;


### PR DESCRIPTION
**Changes proposed in this pull request**
In the hydra procedural, we could be creating a dummy usd camera, just to assign it to our usd imaging delegate in `SetCameraForSampling`. Since the input usd stage is supposed to be read-only when we read through a stage cache, we must handle it differently. Here we subclass UsdImagingDelegate and redefine the function `GetCameraParamValue` so that it can return directly the shutter range when requested. To do that we must pass a dummy primitive name in `SetCameraForSampling`, but this shouldn't be a problem as the name isn't used anywhere, except in `GetCurrentTimeSamplingInterval` . It first verifies that the "render camera path" isn't empty (which is why we need to set a dummy name), and then calls `GetCameraParamValue` for `sutterOpen` and `shutterClose` .
In my tests, this passes the full testsuite, including the 9 scenes affected by this use case, which means that the shutter is properly taken into account.
 
Of course, this is relying on the current behaviour of `UsdImagingDelegate` and it could start failing in future versions if the usd code is changed (and e.g. the render camera is used for other reasons). If that happens we'll start seeing error messages about primitives not being found in the hydra scene index, but it shouldn't cause any crashes.

**Issues fixed in this pull request**
Fixes #2201 

