### PR TITLE
Fix incorrect reset of mesh parameters

### DIFF
--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -181,12 +181,12 @@ HdArnoldMesh::~HdArnoldMesh() {
     // be pointing to deallocated memory.
     AtNode *node = GetArnoldNode();
     if (node && !_arrayHandler.empty()) {
-        AiNodeSetArray(node, str::nsides, nullptr);
-        AiNodeSetArray(node, str::vidxs, nullptr);
-        AiNodeSetArray(node, str::vlist, nullptr);
-        AiNodeSetArray(node, str::nlist, nullptr);
-        AiNodeSetArray(node, str::nidxs, nullptr); // nidxs might be shared with vidx so we need to reset it as well
-        AiNodeSetArray(node, str::uvlist, nullptr);
+        AiNodeResetParameter(node, str::nsides);
+        AiNodeResetParameter(node, str::vidxs);
+        AiNodeResetParameter(node, str::vlist);
+        AiNodeResetParameter(node, str::nlist);
+        AiNodeResetParameter(node, str::nidxs); // nidxs might be shared with vidx so we need to reset it as well
+        AiNodeResetParameter(node, str::uvlist);
     }
 
     // We the ArrayHolder should be empty, otherwise it means that we are potentially destroying


### PR DESCRIPTION
**Changes proposed in this pull request**
- Since we share the mesh parameters we have to reset them when the HdMesh is destroyed. The previous way of doing it was to set the parameter array to nullptr which is incorrect. This PR uses the AiNodeResetParameter function to correctly reset the parameter.

**Issues fixed in this pull request**
Fixes #2214

