### PR TITLE
Fix error message in hydra with ortho cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - [usd#2208](https://github.com/Autodesk/arnold-usd/issues/2208) - Fix unnecessary allocations in the instancer and mesh.
+- [usd#2218](https://github.com/Autodesk/arnold-usd/issues/2218) - Fix Hydra warning with orthographic cameras
 
 ## Pending Feature release
 

--- a/libs/render_delegate/camera.cpp
+++ b/libs/render_delegate/camera.cpp
@@ -252,12 +252,17 @@ void HdArnoldCamera::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     if (_camera == nullptr || !AiNodeIs(_camera, cameraType)) {
         // The camera type has changed, let's create a new node and delete the previous one
         param->Interrupt();
+        
+        // First reset and delete the previous camera, so that we don't try to create another
+        // on with the same name, below in CreateArnoldNode #2218
+        if (_camera)
+            SetCamera(nullptr);
+
         AtNode *newCamera = _delegate->CreateArnoldNode(cameraType, AtString(GetId().GetText()));
         if (newCamera) {
-            // This will delete the previous cam
+            // Set the new camera in _camera
             SetCamera(newCamera); 
-            // Ensure the camera name is set properly, it might have been discarded 
-            // due to the duplicate object name with the previous cam
+            // Ensure the camera name is set properly
             AiNodeSetStr(newCamera, str::name, AtString(GetId().GetText()));
         }
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
To avoid being in a state where the "previous" camera and the new one coexist, even temporarily, we ensure the previous one is deleted first. We do this by calling SetCamera(nullptr). Then we create the new camera (with the same name but a different type) 

This fixes the warnings in test_0115

**Issues fixed in this pull request**
Fixes #2218 


**Additional context**
Add any other context or screenshots about the pull request here.
