### PR TITLE
Fix race condition in hydra node names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - [usd#2208](https://github.com/Autodesk/arnold-usd/issues/2208) - Fix unnecessary allocations in the instancer and mesh.
+- [usd#2219](https://github.com/Autodesk/arnold-usd/issues/2219) - Fix race condition in hydra with node names
 
 ## Pending Feature release
 


### PR DESCRIPTION
**Changes proposed in this pull request**
I'm adding a mutex for accessing the _nodeNames map so that it becomes thread-safe

**Issues fixed in this pull request**
Fixes #2219 


**Additional context**
Add any other context or screenshots about the pull request here.
