### PR TITLE
Fix runtime warning  "HdArnoldDriverMain is already installed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [usd#2208](https://github.com/Autodesk/arnold-usd/issues/2208) - Fix unnecessary allocations in the instancer and mesh.
 - [usd#2218](https://github.com/Autodesk/arnold-usd/issues/2218) - Fix Hydra warning with orthographic cameras
 - [usd#2219](https://github.com/Autodesk/arnold-usd/issues/2219) - Fix race condition in hydra with node names
+- [usd#2224](https://github.com/Autodesk/arnold-usd/issues/2224) - Fix warning "HdArnoldDriverMain is already installed" 
 
 ## Pending Feature release
 

--- a/libs/render_delegate/nodes/nodes.cpp
+++ b/libs/render_delegate/nodes/nodes.cpp
@@ -63,6 +63,8 @@ const auto builtInNodes = []() -> const BuiltInNodes& {
 void hdArnoldInstallNodes()
 {
     for (const auto& it : builtInNodes()) {
+        if(AiNodeEntryLookUp(it.name))
+            continue;
         AiNodeEntryInstall(it.type, it.outputType, it.name, "<built-in>", it.methods, AI_VERSION);
     }
 }


### PR DESCRIPTION
When we run the procedural in hydra mode we can see a bunch of 
WARNING |  node "HdArnoldDriverMain" is already installed

We can fix this by checking if the node entry exists before we install it