### PR TITLE
Fixed crash in point instancers with missing prototypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [usd#2208](https://github.com/Autodesk/arnold-usd/issues/2208) - Fix unnecessary allocations in the instancer and mesh.
 - [usd#2218](https://github.com/Autodesk/arnold-usd/issues/2218) - Fix Hydra warning with orthographic cameras
 - [usd#2219](https://github.com/Autodesk/arnold-usd/issues/2219) - Fix race condition in hydra with node names
+- [usd#2225](https://github.com/Autodesk/arnold-usd/issues/2225) - Fix crash in point instancers with missing prototypes
 
 ## Pending Feature release
 

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1469,6 +1469,9 @@ AtNode* UsdArnoldReadPointInstancer::Read(const UsdPrim &prim, UsdArnoldReaderCo
         // since we don't control the order in which nodes are read.
         UsdPrim protoPrim = reader->GetStage()->GetPrimAtPath(protoPath);
 
+        if (!protoPrim)
+            continue;
+        
         // If some of the prototypes are lights we'll need to set a user data
         // instance_intensity, as we do for meshes visibility. 
         // There are currently different ways of having light primitives in USD.


### PR DESCRIPTION
**Changes proposed in this pull request**
In the usd translator, when we get the list of prototypes, we must ensure they're valid. If some of them are missing, we must skip them to avoid usd crashes

**Issues fixed in this pull request**
Fixes #2225
