### PR TITLE
Release usd stage after hydra procedural finished translating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Features
 
-- [usd#2148](https://github.com/Autodesk/arnold-usd/issues/2248) - Leverage new Shared Arrays API in the render delegate.
+- [usd#2148](https://github.com/Autodesk/arnold-usd/issues/2148) - Leverage new Shared Arrays API in the render delegate.
+- [usd#2228](https://github.com/Autodesk/arnold-usd/issues/2228) - Release usd stage after the hydra procedural translation
 
 ### Bug fixes
 

--- a/libs/render_delegate/node_graph.cpp
+++ b/libs/render_delegate/node_graph.cpp
@@ -137,7 +137,7 @@ HdArnoldNodeGraph::~HdArnoldNodeGraph()
     // Ensure all AtNodes created for this node graph are properly deleted
     for (const auto& node : _nodes) {
         if (node.second)
-            AiNodeDestroy(node.second);
+            _renderDelegate->DestroyArnoldNode(node.second);
     }
 
 }
@@ -203,7 +203,7 @@ void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
             for (const auto& previousNode : _previousNodes) {
                 if (previousNode.second) {
                     // Destroy the arnold node
-                    AiNodeDestroy(previousNode.second);
+                    _renderDelegate->DestroyArnoldNode(previousNode.second);
                     // Remove this pointer from our list of nodes
                     auto it = _nodes.find(previousNode.first);
                     if (it != _nodes.end())

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -130,20 +130,22 @@ private:
     double _shutterEnd = 0.;
 };
 
-HydraArnoldReader::~HydraArnoldReader() {
-    // TODO: If we delete the delegates, the arnold scene is also destroyed and the render fails. Investigate how
-    //       to safely delete the delegates without deleting the arnold scene
-    // if (_imagingDelegate) {
-    //     delete _imagingDelegate;
-    //     _imagingDelegate = nullptr;
-    // }
-    // if (_renderIndex) {
-    //     delete _renderIndex;
-    //     _renderIndex = nullptr;
-    // }
-    // if (_renderDelegate) {
-    //     delete _renderDelegate;
-    // }
+HydraArnoldReader::~HydraArnoldReader() 
+{
+    // Warn the render delegate that we're deleting it because the reader is being destroyed.
+    // At this stage we don't want any AtNode to be deleted, the nodes ownership is now in the Arnold side
+    // and here we're just clearing the usd stage. So we tell the render delegate that nodes
+    // destruction should be skipped
+    if (_renderDelegate)
+        static_cast<HdArnoldRenderDelegate*>(_renderDelegate)->EnableNodesDestruction(false);
+    if (_imagingDelegate)
+        delete _imagingDelegate;
+
+    if (_renderIndex)
+        delete _renderIndex;
+    
+    if (_renderDelegate)    
+        delete _renderDelegate;
 }
 
 HydraArnoldReader::HydraArnoldReader(AtUniverse *universe) : _purpose(UsdGeomTokens->render), _universe(universe) {
@@ -154,7 +156,8 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe) : _purpose(UsdGeomTok
     _imagingDelegate = new UsdArnoldProcImagingDelegate(_renderIndex, _sceneDelegateId);
 }
 
-const std::vector<AtNode *> &HydraArnoldReader::GetNodes() const { return static_cast<HdArnoldRenderDelegate*>(_renderDelegate)->_nodes; }
+const std::vector<AtNode *> &HydraArnoldReader::GetNodes() const {
+    return _renderDelegate ? static_cast<HdArnoldRenderDelegate*>(_renderDelegate)->_nodes : _nodes; }
     
 void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
                                 const std::string &path)
@@ -268,6 +271,25 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
     // HasPendingChanges updates the dirtybits for a resync, this is how it works in our hydra render pass.
     while (arnoldRenderDelegate->HasPendingChanges(_renderIndex, _shutter)) {
         _renderIndex->SyncAll(&_tasks, &_taskContext);
+    }
+
+    // If we're not doing an interactive render, we want to destroy the render delegate in order to release
+    // the usd stage
+    if (!_interactive) {
+        // At this stage we don't want any AtNode to be deleted, the nodes ownership is now in the Arnold side
+        // and here we're just clearing the usd stage. So we tell the render delegate that nodes
+        // destruction should be skipped
+        arnoldRenderDelegate->EnableNodesDestruction(false);
+        delete _imagingDelegate;
+        _imagingDelegate = nullptr;
+        delete _renderIndex;
+        _renderIndex = nullptr;
+        // Copy the render delegate list of nodes to the reader
+        // so that it can be passed through procedural_get_nodes
+        std::swap(_nodes, arnoldRenderDelegate->_nodes);
+        
+        delete _renderDelegate;
+        _renderDelegate = nullptr;
     }
 }
 

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -56,4 +56,5 @@ private:
     GfVec2f _shutter;
     HdTaskSharedPtrVector _tasks;
     HdTaskContext _taskContext;
+    std::vector<AtNode*> _nodes;
 };

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1216,42 +1216,6 @@ HdSprim* HdArnoldRenderDelegate::CreateSprim(const TfToken& typeId, const SdfPat
 
 HdSprim* HdArnoldRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
 {
-    // TODO Do we need fallback sprims ? in which case ??
-    // _renderParam->Interrupt();
-    // if (typeId == HdPrimTypeTokens->camera) {
-    //     return new HdArnoldCamera(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->material) {
-    //     return new HdArnoldNodeGraph(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->sphereLight) {
-    //     return HdArnoldLight::CreatePointLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->distantLight) {
-    //     return HdArnoldLight::CreateDistantLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->diskLight) {
-    //     return HdArnoldLight::CreateDiskLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->rectLight) {
-    //     return HdArnoldLight::CreateRectLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->cylinderLight) {
-    //     return HdArnoldLight::CreateCylinderLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == HdPrimTypeTokens->domeLight) {
-    //     return HdArnoldLight::CreateDomeLight(this, SdfPath::EmptyPath());
-    // }
-    // if (typeId == _tokens->GeometryLight) {
-    //     return nullptr;
-    // }
-    // if (typeId == HdPrimTypeTokens->simpleLight) {
-    //     return nullptr;
-    // }
-    // if (typeId == HdPrimTypeTokens->extComputation) {
-    //     return new HdExtComputation(SdfPath::EmptyPath());
-    // }
-    // TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
     return nullptr;
 }
 

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -586,23 +586,29 @@ public:
         return node;
     };
 
-    /// Method used to destroy nodes in the context of the render delegate. 
-    /// If a parent procedural exists, the destruction must be skipped as it will 
-    /// happen automatically when the parent procedural is destroyed.
-    /// This method should always be called, instead of explicit AiNodeDestroy()
+    /// Method used to destroy nodes in the context of the render delegate.
+    /// This method should always be called, instead of explicit AiNodeDestroy() 
     inline 
     void DestroyArnoldNode(AtNode *node)
     {
-        if (node == nullptr || _procParent != nullptr)
+        /// When the render delegate is used through a HydraArnoldReader, it can be deleted
+        /// after the translation to Arnold was completed. In that case, we want to 
+        /// skip any nodes destruction, as their ownership was already passed on to Arnold.
+        if (node == nullptr || !_enableNodesDestruction)
             return;
-
         {
             std::lock_guard<std::mutex> guard(_nodeNamesMutex);
             auto nodeIt = _nodeNames.find(AiNodeGetName(node));
             if (nodeIt != _nodeNames.end())
                 _nodeNames.erase(nodeIt);
         }
-        AiNodeDestroy(node);
+
+        // If we have a procedural parent, the node was already added to our 
+        // _nodes list. For now we just disable it
+        if (_procParent)
+            AiNodeSetDisabled(node, true);
+        else
+            AiNodeDestroy(node);
     }
 
     inline void AddNodeName(const std::string &name, AtNode *node)
@@ -660,6 +666,8 @@ public:
         _meshLightsChanged.store(true, std::memory_order_release);
     }
 
+    void EnableNodesDestruction(bool b) {_enableNodesDestruction = b;}
+    
 private:    
     HdArnoldRenderDelegate(const HdArnoldRenderDelegate&) = delete;
     HdArnoldRenderDelegate& operator=(const HdArnoldRenderDelegate&) = delete;
@@ -793,6 +801,7 @@ private:
     std::mutex _nodesMutex;
     mutable std::mutex _nodeNamesMutex;
     bool _renderDelegateOwnsUniverse;
+    bool _enableNodesDestruction = true;
 
     std::unordered_map<std::string, AtNode *> _nodeNames;
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we destroy the render delegate (along with its usd stage), at the end of ReadStage, as it's already done in the usd translator. For this to work properly, a few fixes had to be done : 

- When the reader is about to delete the render delegate, it disables a flag "EnableNodesDestruction", so that all the calls to DestroyArnoldNode during the render delegate destruction don't destroy the AtNodes that were just created (which is the reason why we were not deleting the render delegate before). The list of AtNodes (_nodes) needed for procedural_get_node is moved to the hydra reader in that case (as it stays alive until procedural_finish) 

- Proper management of nodes destruction : There were still some explicit calls to AiNodeDestroy which should always be replaced by renderDelegate->DestroyArnoldNode. When a node is being destroyed from a procedural parent, since for now we don't want to actually delete it (it's not clear whether arnold would support it, and the node is already in the _nodes list), we set it as being disabled, so that it's ignored by arnold renders.

- Since usd Point lights can end up being rendered as point_light, spot_light, photometric_light, we were first creating an arnold point light in the HdArnoldGenericLight constructor. Then in the first Sync we would delete the light and create one with the proper type. As this is not ideal inside of a procedural, we're skipping the creation of the point light in the constructor, and deferring it to the following Sync.

- When a node is being replaced with another of the same type (which can happen for cameras or lights), we use AiNodeReplace which handles dependency updates in the arnold side. However, this function is currently a no-op during batch renders, and in husk we can set the render camera before the Sync of this camera is invoked. So I'm keeping the existing code that was replacing the camera in the options when it was the previously assigned one (we need it when we render through an ortho camera)

- Removed legacy commented out code for lights fallback prims. This was changed a while ago and doesn't seem to be used.
- Fixed the changelog of another ticket that had a wrong link

**Issues fixed in this pull request**
Fixes #2228 
