### PR TITLE
Hydra procedural breaks the arnold logging settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 - [usd#2148](https://github.com/Autodesk/arnold-usd/issues/2248) - Leverage new Shared Arrays API in the render delegate.
+- [usd#2227](https://github.com/Autodesk/arnold-usd/issues/2227) - Hydra procedural breaks the Arnold logging settings
 
 ### Bug fixes
 

--- a/libs/common/procedural_reader.h
+++ b/libs/common/procedural_reader.h
@@ -11,7 +11,6 @@ PXR_NAMESPACE_USING_DIRECTIVE
 class ProceduralReader {
 public:
     virtual ~ProceduralReader() {};
-    virtual void SetProceduralParent(AtNode *node) = 0;
     virtual void SetFrame(float frame) = 0;
     virtual void SetDebug(bool b) = 0;
     virtual void SetThreadCount(unsigned int t) = 0;
@@ -20,7 +19,6 @@ public:
     virtual void SetConvertPrimitives(bool b) = 0;
     virtual void SetPurpose(const std::string &p) = 0;
     virtual void SetMask(int m) = 0;
-    virtual void SetUniverse(AtUniverse *universe) = 0;
     virtual void SetRenderSettings(const std::string &renderSettings) = 0;
     virtual void CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) = 0;
     virtual void ReadStage(UsdStageRefPtr stage,

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -146,8 +146,8 @@ HydraArnoldReader::~HydraArnoldReader() {
     // }
 }
 
-HydraArnoldReader::HydraArnoldReader(AtUniverse *universe) : _purpose(UsdGeomTokens->render), _universe(universe) {
-    _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe);
+HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) : _purpose(UsdGeomTokens->render), _universe(universe) {
+    _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe, AI_SESSION_INTERACTIVE, procParent);
     TF_VERIFY(_renderDelegate);
     _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
     SdfPath _sceneDelegateId = SdfPath::AbsoluteRootPath();
@@ -270,11 +270,6 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
         _renderIndex->SyncAll(&_tasks, &_taskContext);
     }
 }
-
-void HydraArnoldReader::SetProceduralParent(AtNode *node) {
-    static_cast<HdArnoldRenderDelegate*>(_renderDelegate)->SetProceduralParent(node);
-}
-void HydraArnoldReader::SetUniverse(AtUniverse *universe) {_universe = universe; }
 void HydraArnoldReader::SetFrame(float frame) {    
     if (_imagingDelegate) {
         _imagingDelegate->SetTime(UsdTimeCode(frame));

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -17,16 +17,13 @@ class UsdArnoldProcImagingDelegate;
 
 class HydraArnoldReader : public ProceduralReader {
 public:
-    HydraArnoldReader(AtUniverse *universe);
+    HydraArnoldReader(AtUniverse *universe, AtNode *procParent);
     ~HydraArnoldReader();
     const std::vector<AtNode *> &GetNodes() const override;
 
     void ReadStage(UsdStageRefPtr stage,
                    const std::string &path) override; // read a specific UsdStage
     
-    void SetProceduralParent(AtNode *node) override;
-    void SetUniverse(AtUniverse *universe) override;
-  
     void SetFrame(float frame) override;
     void SetMotionBlur(bool motionBlur, float motionStart = 0.f, float motionEnd = 0.f) override;
     void SetDebug(bool b) override;

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -111,7 +111,7 @@ class HdArnoldRenderDelegate final : public HdRenderDelegate {
 public:
     HDARNOLD_API
     HdArnoldRenderDelegate(bool isBatch, const TfToken &context, 
-        AtUniverse *universe = nullptr, AtSessionMode sessionTtype = AI_SESSION_INTERACTIVE); ///< Constructor for the Render Delegate.
+        AtUniverse *universe = nullptr, AtSessionMode sessionTtype = AI_SESSION_INTERACTIVE, AtNode* procParent = nullptr); ///< Constructor for the Render Delegate.
     HDARNOLD_API
     ~HdArnoldRenderDelegate() override; ///< Destuctor for the Render Delegate.
     /// Returns an instance of HdArnoldRenderParam.
@@ -536,10 +536,7 @@ public:
     bool IsBatchContext() const {return _isBatch;}
 
     HydraArnoldAPI &GetAPIAdapter() {return _apiAdapter;}
-    /// @brief set the procedural parent
-    /// @param procParent the procedural parent
-    void SetProceduralParent(AtNode *procParent) { _procParent = procParent;}
-
+    
     /// @brief Get the procedural parent
     /// @return 
     const AtNode *GetProceduralParent() const { return _procParent; }

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -88,9 +88,9 @@ namespace {
 
 static AtMutex s_globalReaderMutex;
 static std::unordered_map<long int, int> s_cacheRefCount;
-UsdArnoldReader::UsdArnoldReader()
-        : _procParent(nullptr),
-          _universe(nullptr),
+UsdArnoldReader::UsdArnoldReader(AtUniverse *universe, AtNode *procParent)
+        : _procParent(procParent),
+          _universe(universe),
           _convert(true),
           _debug(false),
           _threadCount(1),
@@ -820,32 +820,9 @@ void UsdArnoldReader::ClearNodes()
     _defaultShader = nullptr; // reset defaultShader
 }
 
-void UsdArnoldReader::SetProceduralParent(AtNode *node)
-{
-    // should we clear the nodes when a new procedural parent is set ?
-    ClearNodes();
-    _procParent = node;
-    _universe = (node) ? AiNodeGetUniverse(node) : nullptr;
-}
-
 void UsdArnoldReader::CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) {
     delete _readerRegistry;
     _readerRegistry = new UsdArnoldViewportReaderRegistry(mode, params);
-}
-
-void UsdArnoldReader::SetUniverse(AtUniverse *universe)
-{
-    if (_procParent) {
-        if (universe != _universe) {
-            AiMsgError(
-                "UsdArnoldReader: we cannot set a universe that is different "
-                "from the procedural parent");
-        }
-        return;
-    }
-    // should we clear the nodes when a new universe is set ?
-    ClearNodes();
-    _universe = universe;
 }
 
 AtNode *UsdArnoldReader::GetDefaultShader()

--- a/libs/translator/reader/reader.h
+++ b/libs/translator/reader/reader.h
@@ -48,7 +48,7 @@ class UsdArnoldReaderRegistry;
 
 class UsdArnoldReader : public ProceduralReader {
 public:
-    UsdArnoldReader();
+    UsdArnoldReader(AtUniverse *universe, AtNode *procParent = nullptr);
     ~UsdArnoldReader();
 
     void ReadStage(UsdStageRefPtr stage,
@@ -60,10 +60,7 @@ public:
     void InitCacheId();
 
     void Update() override;
-
-    void SetProceduralParent(AtNode *node) override;
-    void SetUniverse(AtUniverse *universe) override;
-
+    
     void CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) override;
     void SetFrame(float frame) override;
     void SetMotionBlur(bool motionBlur, float motionStart = 0.f, float motionEnd = 0.f) override;


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR could have been a single liner. In order to fix the logging issue we just need a single test 
`if (_renderDelegateOwnsUniverse) ` before all the code that calls the AiMsgSet* functions. This way, only the render delegate used from hydra (solaris) should initialize the logging.

In my first version, I thought the condition should be about whether there is a procedural parent or not, and we don't have that information when the render delegate is created. So I did a few changes in the constructors, so that we have that setting at the construction of the readers & render delegate. It allows to get rid of the functions SetProceduralParent and SetUniverse, which aren't actually needed, since we never need to modify them after the reader was created. So even though this isn't needed in the end, I feel like this cleans a bit of code and deserves to be in the commit


**Issues fixed in this pull request**
Fixes #2227 


**Additional context**
Add any other context or screenshots about the pull request here.
