### PR TITLE
Remove warnings about RenderSettings prim not supported in hydra mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [usd#2219](https://github.com/Autodesk/arnold-usd/issues/2219) - Fix race condition in hydra with node names
 - [usd#2225](https://github.com/Autodesk/arnold-usd/issues/2225) - Fix crash in point instancers with missing prototypes
 - [usd#2224](https://github.com/Autodesk/arnold-usd/issues/2224) - Fix warning "HdArnoldDriverMain is already installed" 
+- [usd#2234](https://github.com/Autodesk/arnold-usd/issues/2234) - Fix warning "Selected hydra renderer doesn't support prim type 'RenderSettings'" 
 
 ## Pending Feature release
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -256,7 +256,7 @@ inline const TfTokenVector& _SupportedSprimTypes()
 
 inline const TfTokenVector& _SupportedBprimTypes()
 {
-    static const TfTokenVector r{HdPrimTypeTokens->renderBuffer, _tokens->openvdbAsset};
+    static const TfTokenVector r{HdPrimTypeTokens->renderBuffer, _tokens->openvdbAsset, HdPrimTypeTokens->renderSettings};
     return r;
 }
 
@@ -1247,20 +1247,18 @@ HdBprim* HdArnoldRenderDelegate::CreateBprim(const TfToken& typeId, const SdfPat
     if (typeId == _tokens->openvdbAsset) {
         return new HdArnoldOpenvdbAsset(this, bprimId);
     }
+    // Silently ignore render settings primitives, at the moment they're treated
+    // through a different code path
+    if (typeId == HdPrimTypeTokens->renderSettings)
+        return nullptr;
+
     TF_CODING_ERROR("Unknown Bprim Type %s", typeId.GetText());
     return nullptr;
 }
 
 HdBprim* HdArnoldRenderDelegate::CreateFallbackBprim(const TfToken& typeId)
 {
-    if (typeId == HdPrimTypeTokens->renderBuffer) {
-        return new HdArnoldRenderBuffer(SdfPath());
-    }
-    if (typeId == _tokens->openvdbAsset) {
-        return new HdArnoldOpenvdbAsset(this, SdfPath());
-    }
-    TF_CODING_ERROR("Unknown Bprim Type %s", typeId.GetText());
-    return nullptr;
+    return CreateBprim(typeId, SdfPath());
 }
 
 void HdArnoldRenderDelegate::DestroyBprim(HdBprim* bPrim)


### PR DESCRIPTION
We need to declare RenderSettings in the list of Bprims that are supported by Arnold, even though we're not treating it through a Hd primitive as we do for other primitives types.

The warning also shows for RenderProduct primitives in USD 23.11, but this was fixed in the usd side on recent versions

**Issues fixed in this pull request**
Fixes #2234 
