### PR TITLE
Support HDARNOLD_DEBUG_SCENE env var in the hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [usd#2148](https://github.com/Autodesk/arnold-usd/issues/2248) - Leverage new Shared Arrays API in the render delegate.
 - [usd#2227](https://github.com/Autodesk/arnold-usd/issues/2227) - Hydra procedural breaks the Arnold logging settings
 - [usd#2228](https://github.com/Autodesk/arnold-usd/issues/2228) - Release usd stage after the hydra procedural translation
+- [usd#2242](https://github.com/Autodesk/arnold-usd/issues/2242) - Support HDARNOLD_DEBUG_SCENE env var in the hydra procedural
 
 ### Bug fixes
 

--- a/libs/common/procedural_reader.h
+++ b/libs/common/procedural_reader.h
@@ -10,6 +10,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 /// @brief This is the base class for any arnold procedural reader
 class ProceduralReader {
 public:
+    ProceduralReader() {};
     virtual ~ProceduralReader() {};
     virtual void SetFrame(float frame) = 0;
     virtual void SetDebug(bool b) = 0;

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -148,12 +148,20 @@ HydraArnoldReader::~HydraArnoldReader()
         delete _renderDelegate;
 }
 
-HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) : _purpose(UsdGeomTokens->render), _universe(universe) {
+HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) : 
+        ProceduralReader(), 
+        _purpose(UsdGeomTokens->render), 
+        _universe(universe) 
+{
     _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe, AI_SESSION_INTERACTIVE, procParent);
     TF_VERIFY(_renderDelegate);
     _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
     SdfPath _sceneDelegateId = SdfPath::AbsoluteRootPath();
     _imagingDelegate = new UsdArnoldProcImagingDelegate(_renderIndex, _sceneDelegateId);
+
+    const char *debugScene = std::getenv("HDARNOLD_DEBUG_SCENE");
+    if (debugScene)
+        _debugScene = std::string(debugScene);
 }
 
 const std::vector<AtNode *> &HydraArnoldReader::GetNodes() const {
@@ -291,6 +299,9 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
         delete _renderDelegate;
         _renderDelegate = nullptr;
     }
+
+    if (!_debugScene.empty())
+        WriteDebugScene();
 }
 void HydraArnoldReader::SetFrame(float frame) {    
     if (_imagingDelegate) {
@@ -314,11 +325,14 @@ void HydraArnoldReader::Update()
     _renderIndex->SyncAll(&_tasks, &_taskContext);
 }
 
-void HydraArnoldReader::WriteDebugScene(const std::string &debugScene) const
+void HydraArnoldReader::WriteDebugScene() const
 {
-    AiMsgWarning("Saving debug arnold scene as \"%s\"", debugScene.c_str());
+    if (_debugScene.empty())
+        return;
+    
+    AiMsgWarning("Saving debug arnold scene as \"%s\"", _debugScene.c_str());
     AtParamValueMap* params = AiParamValueMap();
     AiParamValueMapSetBool(params, str::binary, false);
-    AiSceneWrite(_universe, AtString(debugScene.c_str()), params);
+    AiSceneWrite(_universe, AtString(_debugScene.c_str()), params);
     AiParamValueMapDestroy(params);
 }

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -36,7 +36,7 @@ public:
     void Update() override;
     void CreateViewportRegistry(AtProcViewportMode mode, const AtParamValueMap* params) override {}; // Do we need to create a registry with hydra ???
 
-    void WriteDebugScene(const std::string &debugScene) const;
+    void WriteDebugScene() const;
 
 private:
     std::string _renderSettings;
@@ -54,4 +54,5 @@ private:
     HdTaskSharedPtrVector _tasks;
     HdTaskContext _taskContext;
     std::vector<AtNode*> _nodes;
+    std::string _debugScene;
 };

--- a/libs/translator/reader/reader.cpp
+++ b/libs/translator/reader/reader.cpp
@@ -89,7 +89,8 @@ namespace {
 static AtMutex s_globalReaderMutex;
 static std::unordered_map<long int, int> s_cacheRefCount;
 UsdArnoldReader::UsdArnoldReader(AtUniverse *universe, AtNode *procParent)
-        : _procParent(procParent),
+        : ProceduralReader(),
+          _procParent(procParent),
           _universe(universe),
           _convert(true),
           _debug(false),


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR I'm checking the environment variable HDARNOLD_DEBUG_SCENE and if set we're writing out the arnold scene to a debug file after the usd file was translated, in ReadStage.

Note that, as in the case of the render delegate, the debug file is not directly renderable as it will contain the usd procedural node, as well as all the child nodes. At the moment, this is the best way to get a debug scene and introspect the procedural translation. 

I'm not doing it in the usd procedural at the moment, although it might end up being useful to compare usd VS hydra. But for now this is only for hydra.

While doing this, in my first attempt I was putting this in the base reader class ProceduralReader, and I realized we didn't have a constructor in this class and that the inherited classes were not calling the parent constructor. So to ensure it doesn't cause problems in the future, I added this in the current PR

**Issues fixed in this pull request**
Fixes #2242 
here.
