### PR TITLE
Add build variable for TESTSUITE_PASSES

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -139,6 +139,7 @@ vars.AddVariables(
     StringVariable('JUNIT_TESTSUITE_URL', 'Optional URL for the JUnit report', None),
     BoolVariable('REPORT_ONLY_FAILED_TESTS', 'Only failed test will be kept', False),
     StringVariable('TIMELIMIT', 'Time limit for each test (in seconds)', '300'),
+    ListVariable('TESTSUITE_PASSES', 'Test passes to enable', None, ['usd','hydra']),
     ('TEST_PATTERN', 'Glob pattern of tests to be run', 'test_*'),
     ('KICK_PARAMS', 'Additional parameters for kick', '-v 6'),
     ('TESTSUITE_RERUNS_FAILED', 'Numbers of reruns of failed test to detect instability', 1),

--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -70,8 +70,10 @@ while True:
 
 testsuite_source_path = test_env.Dir('.').srcnode().abspath
 testsuite_target_path = test_env.Dir('.').abspath
-testsuite_passes = ['usd', 'hydra'] 
-
+if 'TESTSUITE_PASSES' in test_env:
+   testsuite_passes = test_env['TESTSUITE_PASSES']
+else:
+   testsuite_passes = ['usd', 'hydra'] 
 
 args_load = dict(
    path   = testsuite_source_path,


### PR DESCRIPTION
As we have in the arnold testsuite, I'm adding the build variable TESTSUITE_PASSES that can be used to customize it and just render "usd" or "hydra" test. This can be useful for debugging a specific issue and only running one of those tests