### PR TITLE
Enable the hydra mode of the procedural by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [usd#2228](https://github.com/Autodesk/arnold-usd/issues/2228) - Release usd stage after the hydra procedural translation
 - [usd#2240](https://github.com/Autodesk/arnold-usd/issues/2240) - Default volume shader should be assigned in the usd procedural
 - [usd#2242](https://github.com/Autodesk/arnold-usd/issues/2242) - Support HDARNOLD_DEBUG_SCENE env var in the hydra procedural
+- [usd#2248](https://github.com/Autodesk/arnold-usd/issues/2248) - Enable the hydra mode of the procedural by default
 
 ### Bug fixes
 

--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -495,6 +495,7 @@ ASTR(twrap);
 ASTR(uniform);
 ASTR(usd);
 ASTR(usd_legacy_distant_light_normalize);
+ASTR(usd_legacy_translation);
 ASTR(useMetadata);
 ASTR(useSpecularWorkflow);
 ASTR(use_light_group);

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -281,8 +281,10 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
         _renderIndex->SyncAll(&_tasks, &_taskContext);
     }
 
+#ifndef ENABLE_SHARED_ARRAYS
     // If we're not doing an interactive render, we want to destroy the render delegate in order to release
-    // the usd stage
+    // the usd stage.
+    // However, if shared arrays are enabled, we shouldn't destroy anything until the render finishes
     if (!_interactive) {
         // At this stage we don't want any AtNode to be deleted, the nodes ownership is now in the Arnold side
         // and here we're just clearing the usd stage. So we tell the render delegate that nodes
@@ -299,6 +301,7 @@ void HydraArnoldReader::ReadStage(UsdStageRefPtr stage,
         delete _renderDelegate;
         _renderDelegate = nullptr;
     }
+#endif
 
     if (!_debugScene.empty())
         WriteDebugScene();

--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -513,7 +513,7 @@ proceduralUsdAppendAttrs = ['string arnold:filename = ""',
                             'string[] arnold:overrides',
                             'int arnold:cache_id = 0', 
                             'bool arnold:interactive = 0',
-                            'bool arnold:hydra = 0']
+                            'bool arnold:hydra = 1']
 createArnoldClass('usd', 'Gprim', proceduralCustomAttrs, ai.AiNodeEntryLookUp('procedural'), 
     ignoreShapeAttributes, False, True, proceduralUsdAppendAttrs)
 


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR enables the hydra mode of the usd procedural by default. It also looks for an options attribute "usd_legacy_translation" (to be added in the arnold side) that can force the hydra mode to be disabled. 

The environment variables always take precedence on all these settings

**Issues fixed in this pull request**
Fixes #2248 
