### PR TITLE
First support of scene index

### DIFF
--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -9,7 +9,13 @@
 #include "pxr/imaging/hd/engine.h"
 #include "pxr/imaging/hd/renderDelegate.h"
 #include "pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h"
+#include "pxr/usdImaging/usdImaging/stageSceneIndex.h"
 #include "procedural_reader.h"
+
+TF_DECLARE_REF_PTRS(UsdImagingStageSceneIndex);
+TF_DECLARE_REF_PTRS(UsdImagingRootOverridesSceneIndex);
+TF_DECLARE_REF_PTRS(HdsiLegacyDisplayStyleOverrideSceneIndex);
+TF_DECLARE_REF_PTRS(HdsiPrimTypePruningSceneIndex);
 
 class UsdArnoldProcImagingDelegate;
 
@@ -47,6 +53,15 @@ private:
     UsdArnoldProcImagingDelegate* _imagingDelegate = nullptr;
     HdEngine _engine;
     HdRenderDelegate *_renderDelegate;
+    SdfPath _sceneDelegateId;
+    UsdImagingStageSceneIndexRefPtr _stageSceneIndex;
+    //UsdImagingSelectionSceneIndexRefPtr _selectionSceneIndex;
+    UsdImagingRootOverridesSceneIndexRefPtr _rootOverridesSceneIndex;
+    HdSceneIndexBaseRefPtr _sceneIndex;
+    HdsiLegacyDisplayStyleOverrideSceneIndexRefPtr _displayStyleSceneIndex;
+    HdsiPrimTypePruningSceneIndexRefPtr _materialPruningSceneIndex;
+    HdsiPrimTypePruningSceneIndexRefPtr _lightPruningSceneIndex;
+
     AtUniverse *_universe = nullptr;
     HdRenderPassSharedPtr _syncPass;
     HdRprimCollection _collection;
@@ -55,4 +70,10 @@ private:
     HdTaskContext _taskContext;
     std::vector<AtNode*> _nodes;
     std::string _debugScene;
+    bool _useSceneIndex = false; 
+
+    HdSceneIndexBaseRefPtr
+    _AppendOverridesSceneIndices(
+        const HdSceneIndexBaseRefPtr &inputScene);
+
 };


### PR DESCRIPTION
This PR introduces a first set of changes that look for the environment variable `USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX`  and enables the scene index instead of the previous UsdImagingDelegate from older versions of Hydra.

This is a first draft, there are still a few missing bits, like where to set the shutter, the object path, or the purpose.

**Issues fixed in this pull request**
Fixes #2262

**Additional context**
Add any other context or screenshots about the pull request here.
