### PR TITLE
ARNOLD-16217: Re-process connections after sync in update

### DIFF
--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -326,6 +326,9 @@ void HydraArnoldReader::Update()
     _imagingDelegate->ApplyPendingUpdates();
     arnoldRenderDelegate->HasPendingChanges(_renderIndex, _shutter);
     _renderIndex->SyncAll(&_tasks, &_taskContext);
+    // Connections may have been made as part of the sync pass, so we need to process them
+    // again to make sure that the nodes are up to date. (ARNOLD-16217)
+    arnoldRenderDelegate->ProcessConnections();
 }
 
 void HydraArnoldReader::WriteDebugScene() const


### PR DESCRIPTION
**Changes proposed in this pull request**
Adds an additional call to ProcessConnections after running SyncAll as new links could be made during the sync


**Issues fixed in this pull request**
Fixes ARNOLD-16217

**Additional context**
Not sure a test cn be made for this due to it requiring 