### PR TITLE
Fix compilation issues with older versions of USD

### DIFF
--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -159,6 +159,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
         _purpose(UsdGeomTokens->render), 
         _universe(universe) 
 {
+#ifdef ARNOLD_SCENE_INDEX
     if (ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX")) 
     {
         // The environment variable is defined, it takes precedence on any other setting
@@ -170,6 +171,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
         }
         _useSceneIndex = (useSceneIndex != "0");
     }
+#endif
     
     _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe, AI_SESSION_INTERACTIVE, procParent);
     TF_VERIFY(_renderDelegate);
@@ -177,6 +179,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     _sceneDelegateId = SdfPath::AbsoluteRootPath();
 
     if (_useSceneIndex) {
+#ifdef ARNOLD_SCENE_INDEX
         UsdImagingCreateSceneIndicesInfo info;
         info.displayUnloadedPrimsWithBounds = false;
         info.overridesSceneIndexCallback =
@@ -194,7 +197,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
             HdsiLegacyDisplayStyleOverrideSceneIndex::New(_sceneIndex);
 
         _renderIndex->InsertSceneIndex(_sceneIndex, _sceneDelegateId);
-        
+#endif        
     } else {        
         _imagingDelegate = new UsdArnoldProcImagingDelegate(_renderIndex, _sceneDelegateId);
     }
@@ -410,6 +413,8 @@ void HydraArnoldReader::WriteDebugScene() const
 }
 
 
+#ifdef ARNOLD_SCENE_INDEX
+
 HdSceneIndexBaseRefPtr
 HydraArnoldReader::_AppendOverridesSceneIndices(
     HdSceneIndexBaseRefPtr const &inputScene)
@@ -449,3 +454,4 @@ HydraArnoldReader::_AppendOverridesSceneIndices(
 
     return sceneIndex;
 }
+#endif

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -17,6 +17,10 @@ TF_DECLARE_REF_PTRS(UsdImagingRootOverridesSceneIndex);
 TF_DECLARE_REF_PTRS(HdsiLegacyDisplayStyleOverrideSceneIndex);
 TF_DECLARE_REF_PTRS(HdsiPrimTypePruningSceneIndex);
 
+#if PXR_VERSION >= 2411
+#define ARNOLD_SCENE_INDEX
+#endif
+
 class UsdArnoldProcImagingDelegate;
 
 // This is the interface we need for the procedural reader
@@ -72,8 +76,10 @@ private:
     std::string _debugScene;
     bool _useSceneIndex = false; 
 
+#ifdef ARNOLD_SCENE_INDEX
     HdSceneIndexBaseRefPtr
     _AppendOverridesSceneIndices(
         const HdSceneIndexBaseRefPtr &inputScene);
+#endif
 
 };


### PR DESCRIPTION
**Changes proposed in this pull request**
A previous PR introducing scene index isn't compiling with older versions of USD. This PR adds ifdefs to restore the builds as before. Scene index will only work for usd 24.11 and up

**Issues fixed in this pull request**
Fixes #2262
