### PR TITLE
Improve interactive fps values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## Next Feature release
+
+### Features
+- [usd#2276](https://github.com/Autodesk/arnold-usd/issues/2276) - Improve default interactive FPS settings in the render delegate
+
 ## Next Bugfix release
 
 ### Bug fixes

--- a/libs/render_delegate/config.cpp
+++ b/libs/render_delegate/config.cpp
@@ -89,12 +89,12 @@ TF_DEFINE_ENV_SETTING(HDARNOLD_shutter_start, "-0.25f", "Shutter start for the c
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_shutter_end, "0.25f", "Shutter end for the camera.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_interactive_target_fps, "30.0", "Interactive target fps for progressive rendering.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_interactive_target_fps, "32.0", "Interactive target fps for progressive rendering.");
 
 TF_DEFINE_ENV_SETTING(
-    HDARNOLD_interactive_target_fps_min, "20.0", "Min interactive target fps for progressive rendering.");
+    HDARNOLD_interactive_target_fps_min, "8.0", "Min interactive target fps for progressive rendering.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_interactive_fps_min, "5.0", "Minimum fps for progressive rendering.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_interactive_fps_min, "2.0", "Minimum fps for progressive rendering.");
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_profile_file, "", "Output file for profiling information.");
 


### PR DESCRIPTION
As discussed in HtoA ticket HTOA-2279, the current defaults for interactive fps values should be improved. This PR sets them to more appropriate values. In particual, we want a factor of 4 between `interactive_target_fps` and `interactive_target_fps_min`