### PR TITLE
Destroy child nodes from the hydra procedural instead of disabling them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## Next Feature release
+
+### Features
+- [usd#2277](https://github.com/Autodesk/arnold-usd/issues/2277) - Ensure child nodes are properly destroyed in the hydra procedural
+
 ## Next Bugfix release
 
 ### Bug fixes

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -599,13 +599,7 @@ public:
             if (nodeIt != _nodeNames.end())
                 _nodeNames.erase(nodeIt);
         }
-
-        // If we have a procedural parent, the node was already added to our 
-        // _nodes list. For now we just disable it
-        if (_procParent)
-            AiNodeSetDisabled(node, true);
-        else
-            AiNodeDestroy(node);
+        AiNodeDestroy(node);
     }
 
     inline void AddNodeName(const std::string &name, AtNode *node)


### PR DESCRIPTION
It should now be possible to destroy nodes even when they come from a procedural, instead of disabling them as we were doing before

**Issues fixed in this pull request**
Fixes #2277
