### PR TITLE
Skip test_0176 on linux

### DIFF
--- a/testsuite/groups
+++ b/testsuite/groups
@@ -26,15 +26,17 @@
 
 # NOTE: Try to avoid adding platform-specific tests that output images.
 # Having such tests makes updating image references on a single platform unsafe.
+# test_0176 is currently skipped on linux as it's randomly failing very often
 
 # Only executed on Windows
-windows:
+windows: test_0176
 
 # Only executed on Linux
 linux: 
 
 # Only executed on Darwin
-darwin: 
+darwin: test_0176
+
 
 #######################
 # SPECIAL TEST GROUPS #

--- a/tools/test/testsuite.py
+++ b/tools/test/testsuite.py
@@ -311,11 +311,7 @@ class Testsuite(object):
       if len(self.tests_filtered) > 1:
          self.tests_ignored['ignore'] = self.tests_filtered & self.skipped_tests['ignore']
          self.tests_filtered -= self.skipped_tests['ignore']
-
-      ''' SEB
-      self.tests_ignored['pass_cpu'] = self.tests_filtered & self.skipped_tests['pass_cpu']
-      self.tests_ignored['pass_gpu'] = self.tests_filtered & self.skipped_tests['pass_gpu']
-      '''
+      
       self.tests_ignored['load']  = set()
       self.tests_ignored['build'] = set()
       self.tests_ignored['other'] = set()


### PR DESCRIPTION
test_0176 is currently failing way too often on windows, due to random issues.
For the moment we're disabling it, until we find a proper fix