### PR TITLE
Prevent unstable tests from failing the CI

### DIFF
--- a/tools/test/testsuite.py
+++ b/tools/test/testsuite.py
@@ -604,7 +604,7 @@ class Testsuite(object):
             Test.Status.FAILED   : 'failure' ,
             Test.Status.CRASHED  : 'error'   ,
             Test.Status.TIMEDOUT : 'error'   ,
-            Test.Status.UNSTABLE : 'error'   ,
+            Test.Status.UNSTABLE : 'passed'  , # Don't fail a PR for unstable tests
             Test.Status.SKIPPED  : 'skipped' ,
          }.get(data.get('result'), 'failure')
          testcase_status_num[testcase_status] += 1


### PR DESCRIPTION
This PR makes it so that unstable tests don't return an error in the testsuite. This way, we can all the automation to run despite the random failures.