### PR TITLE
Fix mismatch between USD and Hydra for GI_transmission_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [usd#2276](https://github.com/Autodesk/arnold-usd/issues/2276) - Improve default interactive FPS settings in the render delegate
 - [usd#2231](https://github.com/Autodesk/arnold-usd/issues/2231) - Fix velocity motion blur coherence when there is varying number of instances
 - [usd#2285](https://github.com/Autodesk/arnold-usd/issues/2285) - Use point instancer angular velocity in the render delegate
+- [usd#2287](https://github.com/Autodesk/arnold-usd/issues/2287) - Fix mismatch in default value for GI_transmission_depth between USD and Hydra
 
 ## Next Bugfix release
 

--- a/libs/common/rendersettings_utils.cpp
+++ b/libs/common/rendersettings_utils.cpp
@@ -462,6 +462,7 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
     AiNodeSetInt(options, str::AA_samples, 3);
     AiNodeSetInt(options, str::GI_diffuse_depth, 1);
     AiNodeSetInt(options, str::GI_specular_depth, 1);
+    AiNodeSetInt(options, str::GI_transmission_depth, 8);
 
     // Eventual render region: in arnold it's expected to be in pixels in the range [0, resolution]
     // but in usd it's between [0, 1]

--- a/libs/translator/writer/write_options.cpp
+++ b/libs/translator/writer/write_options.cpp
@@ -51,6 +51,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     ((aaSamples, "arnold:AA_samples"))
     ((giDiffuseDepth, "arnold:GI_diffuse_depth"))
     ((giSpecularDepth, "arnold:GI_specular_depth"))
+    ((giTransmissionDepth, "arnold:GI_transmission_depth"))
     ((aovDriverFormat, "driver:parameters:aov:format"))
     ((aovSettingName,"driver:parameters:aov:name"))
     ((aovGlobalAtmosphere, "arnold:global:atmosphere"))
@@ -269,6 +270,11 @@ void UsdArnoldWriteOptions::Write(const AtNode *node, UsdArnoldWriter &writer)
         prim.CreateAttribute(_tokens->giSpecularDepth, SdfValueTypeNames->Int), 
         AiNodeGetInt(node, str::GI_specular_depth));
     _exportedAttrs.insert("GI_specular_depth");
+
+    writer.SetAttribute(
+        prim.CreateAttribute(_tokens->giTransmissionDepth, SdfValueTypeNames->Int), 
+        AiNodeGetInt(node, str::GI_transmission_depth));
+    _exportedAttrs.insert("GI_transmission_depth");
 
     AtNode* colorManager = (AtNode*) AiNodeGetPtr(node, str::color_manager);
     // If the options node has a color manager set, we want to author it in the render settings #1965


### PR DESCRIPTION
**Changes proposed in this pull request**
In USD we were forcing some default values for GI_diffuse_depth and GI_specular_depth, but not for GI_transmission_depth. 
Here I'm setting it to 8 by default, as it's set in all the arnold plugins (the core defaults to 2). 
I'm also forcing it to be set in the usd writer as for the other 2 attributes

**Issues fixed in this pull request**
Fixes #2287
