### PR TITLE
Fix stats mode in the render delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [usd#2231](https://github.com/Autodesk/arnold-usd/issues/2231) - Fix velocity motion blur coherence when there is varying number of instances
 - [usd#2285](https://github.com/Autodesk/arnold-usd/issues/2285) - Use point instancer angular velocity in the render delegate
 - [usd#2287](https://github.com/Autodesk/arnold-usd/issues/2287) - Fix mismatch in default value for GI_transmission_depth between USD and Hydra
+- [usd#2296](https://github.com/Autodesk/arnold-usd/issues/2296) - Proper support of stats mode in the render delegate
 
 ## Next Bugfix release
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -708,9 +708,18 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
     } else if (key == str::t_stats_mode) {
         if (value.IsHolding<int>()) {
             _statsMode = static_cast<AtStatsMode>(VtValueGetInt(value));
-            AiStatsSetMode(_statsMode);
-            AiStatsSetMode(AtStatsMode(0));
+        } else if (value.IsHolding<std::string>()) {
+            // This value can be returned as a string, with 0 & 1, 
+            // or with overwrite & append
+            std::string statsStr = VtValueGetString(value);
+            if (statsStr == std::string("0") || statsStr == std::string("overwrite"))
+                _statsMode = AI_STATS_MODE_OVERWRITE;
+            else if (statsStr == std::string("1") || statsStr == std::string("append"))
+                _statsMode = AI_STATS_MODE_APPEND;
+            else
+                AiMsgWarning("Unknown Stats mode %s", statsStr.c_str());
         }
+        AiStatsSetMode(_statsMode);
     } else if (key == str::t_profile_file) {
         if (value.IsHolding<std::string>()) {
             _profileFile = value.UncheckedGet<std::string>();


### PR DESCRIPTION
**Changes proposed in this pull request**
The stats mode was not being set properly in the render delegate. It was always forced to be "overwrite".
This PR takes into account the provided value, and it also supports string values for this setting, which is what HtoA returns us.

**Issues fixed in this pull request**
Fixes #2296
