### PR TITLE
Prevent the parallel creation of the render index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - [usd#2260](https://github.com/Autodesk/arnold-usd/issues/2260) - Deepexr settings were not set properly with husk renders
 - [usd#2287](https://github.com/Autodesk/arnold-usd/issues/2287) - Fix mismatch in default value for GI_transmission_depth between USD and Hydra
 
+### Bug fixes
+
+- [usd#2298](https://github.com/Autodesk/arnold-usd/issues/2298) - Fix a potential crash when multiple hydra readers initialize concurrently.
+
 ## Next Bugfix release
 
 ### Bug fixes

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -153,6 +153,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
         _purpose(UsdGeomTokens->render), 
         _universe(universe) 
 {
+    static std::mutex s_renderIndexCreationMutex;
 #ifdef ARNOLD_SCENE_INDEX
     if (ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX")) 
     {
@@ -169,7 +170,10 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     
     _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe, AI_SESSION_INTERACTIVE, procParent);
     TF_VERIFY(_renderDelegate);
-    _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
+    {
+        std::scoped_lock lock(s_renderIndexCreationMutex);
+        _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
+	}
     _sceneDelegateId = SdfPath::AbsoluteRootPath();
 
     if (_useSceneIndex) {

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -173,7 +173,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     {
         std::lock_guard<AtMutex> lock(s_renderIndexCreationMutex);
         _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
-	}
+    }
     _sceneDelegateId = SdfPath::AbsoluteRootPath();
 
     if (_useSceneIndex) {

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -153,7 +153,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
         _purpose(UsdGeomTokens->render), 
         _universe(universe) 
 {
-    static std::mutex s_renderIndexCreationMutex;
+    static AtMutex s_renderIndexCreationMutex;
 #ifdef ARNOLD_SCENE_INDEX
     if (ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX")) 
     {
@@ -171,7 +171,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     _renderDelegate = new HdArnoldRenderDelegate(true, TfToken("kick"), _universe, AI_SESSION_INTERACTIVE, procParent);
     TF_VERIFY(_renderDelegate);
     {
-        std::scoped_lock lock(s_renderIndexCreationMutex);
+        std::lock_guard<AtMutex> lock(s_renderIndexCreationMutex);
         _renderIndex = HdRenderIndex::New(_renderDelegate, HdDriverVector());
 	}
     _sceneDelegateId = SdfPath::AbsoluteRootPath();

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -52,9 +52,11 @@
 // as it won't be available in procedural_update. Therefore we need a global map (#168)
 static std::unordered_map<AtNode*, ProceduralReader*> s_readers;
 static std::mutex s_readersMutex;
+static std::mutex s_proceduralCreationMutex;
 
 inline ProceduralReader *CreateProceduralReader(AtUniverse *universe, bool hydra = true, AtNode* procParent = nullptr)
 {
+	std::scoped_lock lock(s_proceduralCreationMutex);
 #ifdef ENABLE_HYDRA_IN_USD_PROCEDURAL
     // Enable the hydra procedural if it's required by the procedural parameters, 
     // or if the environment variable is defined

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -52,11 +52,9 @@
 // as it won't be available in procedural_update. Therefore we need a global map (#168)
 static std::unordered_map<AtNode*, ProceduralReader*> s_readers;
 static std::mutex s_readersMutex;
-static std::mutex s_proceduralCreationMutex;
 
 inline ProceduralReader *CreateProceduralReader(AtUniverse *universe, bool hydra = true, AtNode* procParent = nullptr)
 {
-	std::scoped_lock lock(s_proceduralCreationMutex);
 #ifdef ENABLE_HYDRA_IN_USD_PROCEDURAL
     // Enable the hydra procedural if it's required by the procedural parameters, 
     // or if the environment variable is defined

--- a/testsuite/groups
+++ b/testsuite/groups
@@ -26,16 +26,15 @@
 
 # NOTE: Try to avoid adding platform-specific tests that output images.
 # Having such tests makes updating image references on a single platform unsafe.
-# test_0176 is currently skipped on linux as it's randomly failing very often
 
 # Only executed on Windows
-windows: test_0176
+windows: 
 
 # Only executed on Linux
 linux: 
 
 # Only executed on Darwin
-darwin: test_0176
+darwin: 
 
 
 #######################


### PR DESCRIPTION
**Changes proposed in this pull request**
- test_0176 creates multiple HydraReader potentially at the same time and this crashes often. This fix adds a lock at the creation of HydraReader's render index to prevent parallel creation.

