### PR TITLE
Arnold-16340 | Fix volume shaders on points

### DIFF
--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -545,7 +545,6 @@ HdDirtyBits HdArnoldMesh::GetInitialDirtyBitsMask() const
            HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyVisibility | HdArnoldShape::GetInitialDirtyBitsMask();
 }
 
-bool HdArnoldMesh::_IsVolume() const { return AiNodeGetFlt(GetArnoldNode(), str::step_size) > 0.0f; }
 
 AtNode *HdArnoldMesh::_GetMeshLight(HdSceneDelegate* sceneDelegate, const SdfPath& id)
 {

--- a/libs/render_delegate/mesh.h
+++ b/libs/render_delegate/mesh.h
@@ -83,12 +83,6 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
 protected:
-    /// Returns true if step size is bigger than zero, false otherwise.
-    ///
-    /// @return True if polymesh is a volume boundary.
-    HDARNOLD_API
-    bool _IsVolume() const;
-
     HDARNOLD_API
     AtNode *_GetMeshLight(HdSceneDelegate* sceneDelegate, const SdfPath& id);
 

--- a/libs/render_delegate/rprim.h
+++ b/libs/render_delegate/rprim.h
@@ -153,6 +153,12 @@ public:
 
 
 protected:
+    /// Returns true if step size is bigger than zero, false otherwise.
+    ///
+    /// @return True if prim is a volume boundary.
+    HDARNOLD_API
+    bool _IsVolume() const { return AiNodeGetFlt(GetArnoldNode(), str::step_size) > 0.0f; }
+
     HdArnoldShape _shape;                                     ///< HdArnoldShape to handle instances and shape creation.
     HdArnoldRenderDelegate* _renderDelegate;                  ///< Pointer to the Arnold Render Delegate.
     HdArnoldRayFlags _visibilityFlags{AI_RAY_ALL};            ///< Visibility of the shape.


### PR DESCRIPTION
**Changes proposed in this pull request**
- Volume shaders now work on point geometry
![image](https://github.com/user-attachments/assets/c693b3a5-df8d-4582-b175-4f289506202c)

- HdArnoldPoints now calls _IsVolume() to determine if the volume material should be used (i.e. if step_size is set on the prim)
- The most pragmatic way of doing this was to move the point material assignment *after* the primvar sync in Sync(), because I need to query the value of step_size. If this isn't a good idea then we will need to add logic which will re-check the materials after the primvar sync.
- I've moved _IsVolume() from mesh.h to rprim.h so I can reuse it in points.h - if we don't want to break the API, I can just copy & paste it instead until it's safe to move into rprim

**Issues fixed in this pull request**
Fixes #2310 

**Additional context**
Add any other context or screenshots about the pull request here.
