### PR TITLE
Support arnold primvars for ArnoldProceduralCustom primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 - [usd#2303](https://github.com/Autodesk/arnold-usd/issues/2303) - Improve detection of hidden primitives that should be skipped
 - [usd#2309](https://github.com/Autodesk/arnold-usd/issues/2309) - Fix recent conflict between primitives visibility and purpose
+- [usd#2313](https://github.com/Autodesk/arnold-usd/issues/2313) - Arnold primvars aren't taken into account for ArnoldProceduralCustom primitives in usd
 
 ## [7.4.2.0] - 2025-05-16
 

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -64,6 +64,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (LightAPI)
     (normals)
     ((PrimvarsArnoldLightShaders, "primvars:arnold:light:shaders"))
+    ((PrimvarsArnoldNodeEntry, "primvars:arnold:node_entry"))
 );
 
 namespace {
@@ -220,7 +221,6 @@ static inline void _ReadGenericShape(const UsdPrim &prim, UsdArnoldReaderContext
     ReadPrimvars(prim, node, time, context, primvarsRemapper);
     // Read the parameters that are explicitely namespaced for arnold
     ReadArnoldParameters(prim, context, node, time, arnoldNamespace);
-
     // If this primitive is hidden, we must set the arnold visibility to 0
     if (!primVisibility) {
         AiNodeSetByte(node, str::visibility, 0);
@@ -1788,8 +1788,13 @@ AtNode* UsdArnoldReadProceduralCustom::Read(const UsdPrim &prim, UsdArnoldReader
     // This schema is meant for custom procedurals. Its attribute "node_entry" will
     // indicate what is the node entry name for this node.
     UsdAttribute attr = prim.GetAttribute(str::t_arnold_node_entry);
+
+    // We can also support primvars:arnold:node_entry
+    if (!attr || !attr.HasAuthoredValue())
+        attr = prim.GetAttribute(_tokens->PrimvarsArnoldNodeEntry);
+
     // for backward compatibility, check the attribute without namespace
-    if (!attr)
+    if (!attr || !attr.HasAuthoredValue())
         attr = prim.GetAttribute(str::t_node_entry);
     
     const TimeSettings &time = context.GetTimeSettings();
@@ -1802,7 +1807,11 @@ AtNode* UsdArnoldReadProceduralCustom::Read(const UsdPrim &prim, UsdArnoldReader
     std::string nodeType = VtValueGetString(value);
     AtNode *node = context.CreateArnoldNode(nodeType.c_str(), prim.GetPath().GetText());
     ReadMaterialBinding(prim, node, context, false); // don't assign the default shader
+
     _ReadGenericShape(prim, context, node, time, "arnold", nullptr, false);
+    // Attributes could also be authored as "primvars:arnold"
+    ReadArnoldParameters(prim, context, node, time, "primvars:arnold"); 
+
     return node;
 }
 

--- a/testsuite/test_1730/data/test.usda
+++ b/testsuite/test_1730/data/test.usda
@@ -15,6 +15,7 @@ def ArnoldProceduralCustom "myinstancer"
     string arnold:node_entry = "instancer"
     uint[] arnold:node_idxs = [0, 0, 1, 1, 2, 2]
     string[] arnold:nodes = ["/cube", "/sphere", "/cone"]
+    string[] primvars:arnold:nodes = ["/cube", "/sphere", "/cone"]
 }
 
 def Cube "cube"

--- a/testsuite/test_2064/data/test.usda
+++ b/testsuite/test_2064/data/test.usda
@@ -27,8 +27,8 @@ def PointInstancer "point_instancer" (
 
             def ArnoldProceduralCustom "mesh_0"
             {
-                string arnold:node_entry = "sphere"
-                float arnold:radius = 1            
+                string primvars:arnold:node_entry = "sphere"
+                float primvars:arnold:radius = 1            
             }
         }
     }


### PR DESCRIPTION
**Changes proposed in this pull request**
As it is already done in hydra, we also check for attributes `primvars:arnold` on the `ArnoldProceduralCustom` primitives.
I edited test_2064 so that it uses this format and we can track regressions. I also changed one of the attributes in test_1730. I left test_0739 as using the previous format

**Issues fixed in this pull request**
Fixes #2313
