### PR TITLE
Add metadatas path and extension to the usd procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [usd#2307](https://github.com/Autodesk/arnold-usd/issues/2307) - DomeLight connections are taken into account twice when written from an arnold scene
 - [usd#1405](https://github.com/Autodesk/arnold-usd/issues/1405) - Combine DomeLight texture, color and temperature properly in usd and hydra
 - [usd#2310](https://github.com/Autodesk/arnold-usd/issues/2310) - Support volume shaders on points with hydra
+- [usd#2318](https://github.com/Autodesk/arnold-usd/issues/2318) - Add metadatas for path and extensions in the usd procedural
 
 ## Next Bugfix release (7.4.2.2)
 

--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -278,6 +278,7 @@ ASTR(enable_procedural_cache);
 ASTR(enable_progressive_pattern);
 ASTR(enable_progressive_render);
 ASTR(exposure);
+ASTR(extensions);
 ASTR(fallback);
 ASTR(far_clip);
 ASTR(file);

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -113,6 +113,9 @@ node_parameters
     AiMetaDataSetBool(nentry, AtString("cache_id"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("hydra"), AtString("_triggers_reload"), true);
 
+    AiMetaDataSetStr(nentry, str::filename, str::path, str::file);
+    AiMetaDataSetStr(nentry, str::filename, str::extensions, AtString("usd usda usdc usdz"));
+    
     // This type of procedural can be initialized in parallel
     AiMetaDataSetBool(nentry, AtString(""), AtString("parallel_init"), true);
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds the missing metadatas to the usd procedural `filename` attribute. 
One to tell arnold that this string is actually a path, and another to provide the expected list of extensions for file browser in the plugin UIs

**Issues fixed in this pull request**
Fixes #2318 
