### PR TITLE
Use scene index on 25.05 and beyond

### DIFF
--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -12,7 +12,7 @@
 #include "pxr/usdImaging/usdImaging/stageSceneIndex.h"
 #include "procedural_reader.h"
 
-#if PXR_VERSION >= 2411
+#if PXR_VERSION >= 2505
 #define ARNOLD_SCENE_INDEX
 
 #include "pxr/usdImaging/usdImaging/sceneIndices.h"


### PR DESCRIPTION
**Changes proposed in this pull request**
- Compile scene index code only with 25.05 and after

