### PR TITLE
Don't return cryptomatte metadatas before the render is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
-## Next Bugfix release (7.4.2.1)
+## Next Bugfix release (7.4.2.2)
+
+### Bug Fixes
+
+- [usd#2303](https://github.com/Autodesk/arnold-usd/issues/2334) - Fix random crashes with husk and cryptomatte
+
+## [7.4.2.1] - 2025-06-09
 
 ### Bug Fixes
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1090,39 +1090,43 @@ VtDictionary HdArnoldRenderDelegate::GetRenderStats() const
     snprintf(&resolutionBuffer[0], maxResChars, "%s %i x %i", renderStatus.c_str(), width, height);
     stats[_tokens->renderProgressAnnotation] = VtValue(resolutionBuffer);
 
-    // If there are cryptomatte drivers, we look for the metadata that is stored in each of them.
-    // In theory, we could just look for the first driver, but for safety we're doing it for all of them
-    for (const auto& cryptoDriver : _cryptomatteDrivers) {
-        const AtNode *driver = LookupNode(cryptoDriver.c_str());
-        if (!driver)
-            continue;
-        if (AiNodeLookUpUserParameter(driver, str::custom_attributes) == nullptr)
-            continue;
-        const AtArray *customAttrsArray = AiNodeGetArray(driver, str::custom_attributes);
-        if (customAttrsArray == nullptr)
-            continue;
-        unsigned int customAttrsCount = AiArrayGetNumElements(customAttrsArray);
-        for (unsigned int i = 0; i < customAttrsCount; ++i) {
-            AtString customAttr = AiArrayGetStr(customAttrsArray, i);
-            std::string customAttrStr(customAttr.c_str());
-            // the custom_attributes attribute will be an array of strings, where each  
-            // element is set like:
-            // "STRING cryptomatte/f834d0a/conversion uint32_to_float32"
-            // where the second element is the metadata name and the last one
-            // is the metadata value
-            size_t pos = customAttrStr.find_first_of(' ');
-            if (pos == std::string::npos)
+    if (total_progress >= 100) {
+        // If there are cryptomatte drivers, we look for the metadata that is stored in each of them.
+        // In theory, we could just look for the first driver, but for safety we're doing it for all of them.
+        // This doesn't need to be done while the render is in progress as it's only required
+        // when the exr file is authored on disk #2334
+        for (const auto& cryptoDriver : _cryptomatteDrivers) {
+            const AtNode *driver = LookupNode(cryptoDriver.c_str());
+            if (!driver)
                 continue;
-            std::string customAttrType = customAttrStr.substr(0, pos);
-            customAttrStr = customAttrStr.substr(pos + 1);
+            if (AiNodeLookUpUserParameter(driver, str::custom_attributes) == nullptr)
+                continue;
+            const AtArray *customAttrsArray = AiNodeGetArray(driver, str::custom_attributes);
+            if (customAttrsArray == nullptr)
+                continue;
+            unsigned int customAttrsCount = AiArrayGetNumElements(customAttrsArray);
+            for (unsigned int i = 0; i < customAttrsCount; ++i) {
+                AtString customAttr = AiArrayGetStr(customAttrsArray, i);
+                std::string customAttrStr(customAttr.c_str());
+                // the custom_attributes attribute will be an array of strings, where each  
+                // element is set like:
+                // "STRING cryptomatte/f834d0a/conversion uint32_to_float32"
+                // where the second element is the metadata name and the last one
+                // is the metadata value
+                size_t pos = customAttrStr.find_first_of(' ');
+                if (pos == std::string::npos)
+                    continue;
+                std::string customAttrType = customAttrStr.substr(0, pos);
+                customAttrStr = customAttrStr.substr(pos + 1);
 
-            pos = customAttrStr.find_first_of(' ');
-            if (pos == std::string::npos)
-                continue;
-            std::string metadataName = customAttrStr.substr(0, pos);
-            std::string metadataVal = customAttrStr.substr(pos + 1);
-            // TODO do we want to check if the metadata is not a string ?
-            stats[TfToken(metadataName)] = TfToken(metadataVal);
+                pos = customAttrStr.find_first_of(' ');
+                if (pos == std::string::npos)
+                    continue;
+                std::string metadataName = customAttrStr.substr(0, pos);
+                std::string metadataVal = customAttrStr.substr(pos + 1);
+                // TODO do we want to check if the metadata is not a string ?
+                stats[TfToken(metadataName)] = TfToken(metadataVal);
+            }
         }
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR I'm skipping the code that went through the cryptomatte drivers to return their metadatas, until the render finishes. It should fix the random crashes that we found on scenes with cryptomatte.

**Issues fixed in this pull request**
Fixes #2334

**Additional context**
Add any other context or screenshots about the pull request here.
