### PR TITLE
Don't disable CER reports with the hydra procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [usd#1405](https://github.com/Autodesk/arnold-usd/issues/1405) - Combine DomeLight texture, color and temperature properly in usd and hydra
 - [usd#2310](https://github.com/Autodesk/arnold-usd/issues/2310) - Support volume shaders on points with hydra
 - [usd#2320](https://github.com/Autodesk/arnold-usd/issues/2320) - Use overwrite mode for stats and deprecate the render setting stats:mode
+- [usd#2337](https://github.com/Autodesk/arnold-usd/issues/2337) - Don't disable CER error reports through the hydra procedural
 
 ## Next Bugfix release (7.4.2.1)
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -485,9 +485,12 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
 #else
     _isArnoldActive = AiUniverseIsActive();
 #endif
-    if (_isBatch) {
+    if (_isBatch && _renderDelegateOwnsUniverse) {
 #if ARNOLD_VERSION_NUM >= 70104
         // Ensure that the ADP dialog box will not pop up and hang the application
+        // We only want to do this when we own the universe (e.g. with husk), 
+        // otherwise this would prevent CER from showing up when we're rendering it
+        // through a procedural, or scene format plugin
         AiADPDisableDialogWindow();
         AiErrorReportingSetEnabled(false);
 #endif


### PR DESCRIPTION
**Changes proposed in this pull request**

In the render delegate constructor, we are disabling CER reports when `isBatch` is enabled. But this variable seems to be always enabled when it's created through the `HydraArnoldReader`, so for procedural & scene format renders.
We only want to do this when the render delegate is owning the universe (e.g. with husk), to ensure no pop-up shows up during batch renders. Otherwise, this is already handled by kick

**Issues fixed in this pull request**
Fixes #2337
