### PR TITLE
Explicitely consider the usd.hide metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [usd#2310](https://github.com/Autodesk/arnold-usd/issues/2310) - Support volume shaders on points with hydra
 - [usd#2320](https://github.com/Autodesk/arnold-usd/issues/2320) - Use overwrite mode for stats and deprecate the render setting stats:mode
 - [usd#2337](https://github.com/Autodesk/arnold-usd/issues/2337) - Don't disable CER error reports through the hydra procedural
+- [usd#2346](https://github.com/Autodesk/arnold-usd/issues/2346) - Registry should explicitely consider the usd.hide metadata instead of DCC-specific ones
 
 ## Next Bugfix release (7.4.2.2)
 

--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -108,6 +108,7 @@ ASTR2(render_context, "RENDER_CONTEXT");
 ASTR2(sidedness_prefix, "sidedness:");
 ASTR2(transformKeys, "arnold:transform_keys");
 ASTR2(ui_groups, "ui.groups");
+ASTR2(usd_hide, "usd.hide");
 ASTR2(visibility_prefix, "visibility:");
 
 ASTR(AA_sample_clamp);

--- a/plugins/node_registry/utils.cpp
+++ b/plugins/node_registry/utils.cpp
@@ -368,7 +368,7 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
         } else if (metadata->name == str::ui_groups) {
             usdPrimMetadata = _tokens->uigroups;
         } else if (metadata->type == AI_TYPE_BOOLEAN && 
-          (metadata->name == str::hide || _StrEndsWith(metadataName, ".hide"))) {
+          (metadata->name == str::hide || metadata->name == str::usd_hide)) {
             hide |= (bool)metadata->value.BOOL();
             continue;          
         } else if (metadata->type == AI_TYPE_STRING && metadata->name == str::dcc) {


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of consider all the metadatas that end with `.hide` we only want to consider `hide`  and `usd.hide` metadatas

**Issues fixed in this pull request**
Fixes #2346 
