### PR TITLE
Changing the frame should not reinitialize the procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [usd#2320](https://github.com/Autodesk/arnold-usd/issues/2320) - Use overwrite mode for stats and deprecate the render setting stats:mode
 - [usd#2337](https://github.com/Autodesk/arnold-usd/issues/2337) - Don't disable CER error reports through the hydra procedural
 - [usd#2346](https://github.com/Autodesk/arnold-usd/issues/2346) - Registry should explicitely consider the usd.hide metadata instead of DCC-specific ones
+- [usd#2352](https://github.com/Autodesk/arnold-usd/issues/2352) - Changing the frame should not re-initialize the procedural
 
 ## Next Bugfix release (7.4.2.2)
 

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -108,7 +108,6 @@ node_parameters
     // is modified (see #176)
     AiMetaDataSetBool(nentry, AtString("filename"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("object_path"), AtString("_triggers_reload"), true);
-    AiMetaDataSetBool(nentry, AtString("frame"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("overrides"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("cache_id"), AtString("_triggers_reload"), true);
     AiMetaDataSetBool(nentry, AtString("hydra"), AtString("_triggers_reload"), true);


### PR DESCRIPTION
**Changes proposed in this pull request**
We should not declare the attribute "frame" as triggering a full reloading of the usd procedural. First, it will be much more optimized when moving the timeline to avoid reading the whole usd file again. Second, it prevents a current bug with `AiProceduralExpand` that is making objects disappear in Maya & 3dsMax when we scrub the timeline

**Issues fixed in this pull request**
Fixes #2352 
