### PR TITLE
Don't set PXR_MTLX_STDLIB_SEARCH_PATHS

### DIFF
--- a/libs/common/materials_utils.cpp
+++ b/libs/common/materials_utils.cpp
@@ -697,9 +697,6 @@ AtNode* ReadShader(const std::string& nodeName, const TfToken& shaderId,
     AtParamValueMap *params = AiParamValueMap();
 
     const AtString &pxrMtlxPath = context.GetPxrMtlxPath();
-    if (!pxrMtlxPath.empty()) {
-        AiParamValueMapSetStr(params, str::MATERIALX_NODE_DEFINITIONS, pxrMtlxPath);
-    }
 
 #if ARNOLD_VERSION_NUM > 70203
     std::string shaderKey = shaderId.GetString();


### PR DESCRIPTION
**Changes proposed in this pull request**
- The delegate passes the value of PXR_MTLX_STDLIB_SEARCH_PATHS through to Arnold's MaterialX library paths via a param value map
- Setting PXR_MTLX_STDLIB_SEARCH_PATHS causes issues when Houdini's MaterialX version (v1.38) doesn't match Arnold
- Husk sets PXR_MTLX_STDLIB_SEARCH_PATHS to $HH/materialx and we have no opportunity to disable this, so for now I'm disabling this passthrough

**Issues fixed in this pull request**
Fixes #
Fixes #

**Additional context**
Add any other context or screenshots about the pull request here.
