### PR TITLE
Fix indentation in schema script

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -318,9 +318,9 @@ def createArnoldClass(entryName, parentClass, paramList, nentry, parentParamList
         if paramStr != None and len(paramStr) > 0:
             file.write('    {}\n'.format(paramStr))
 
-        if appendAttrs:
-            for appendAttr in appendAttrs:
-                file.write('    {}\n'.format(appendAttr))
+    if appendAttrs:
+        for appendAttr in appendAttrs:
+            file.write('    {}\n'.format(appendAttr))
    
     file.write('}\n')
 


### PR DESCRIPTION
There is a mistake in the schemas script, that duplicates some attributes multiple times in the schema.usda file. In theory this shouldn't be too much of an issue, since we run `usdGenSchema` on this file, and it should fix the duplication. But it's still better to have something correct in our files