### PR TITLE
Add NDEBUG when compiling with clang and gcc in opt mode

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -404,6 +404,9 @@ if env['_COMPILER'] in ['gcc', 'clang']:
     if env['MODE'] == 'opt' or env['MODE'] == 'profile':
         env.Append(CCFLAGS = Split('-O3'))
 
+    if env['MODE'] == 'opt':
+        env.Append(CPPDEFINES=Split('NDEBUG'))
+
     # Debug and profile flags
     if env['MODE'] == 'debug' or env['MODE'] == 'profile':
         env.ParseFlags('-DDEBUG')


### PR DESCRIPTION
**Issues fixed in this pull request**
Fixes #2357

