### PR TITLE
Fix crash in HdMesh when using indexed uvs and shared arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug Fixes
 
 - [usd#2333](https://github.com/Autodesk/arnold-usd/issues/2333) - Fix crash in USD writer when the outputs string contains asterisk
+- [usd#2364](https://github.com/Autodesk/arnold-usd/issues/2364) - Fix crash render delegate when using indexed uvs and shared arrays.
 
 ## Next Bugfix release (7.4.2.2)
 

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -188,6 +188,7 @@ HdArnoldMesh::~HdArnoldMesh() {
         AiNodeResetParameter(node, str::nlist);
         AiNodeResetParameter(node, str::nidxs); // nidxs might be shared with vidx so we need to reset it as well
         AiNodeResetParameter(node, str::uvlist);
+        AiNodeResetParameter(node, str::uvidxs);// uvidxs might be shared with vidx so we need to reset it as well
     }
 
     // We the ArrayHolder should be empty, otherwise it means that we are potentially destroying


### PR DESCRIPTION
**Changes proposed in this pull request**
- reset the uvidxs parameter as it might be shared with vidx and reference twice. If it is not reset, after the deletion of the HdMesh the buffers are invalid and the arnold node is pointing to invalid memory.

**Issues fixed in this pull request**
Fixes #2364

