### PR TITLE
Remove pdb generation from debug builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -448,7 +448,7 @@ elif env['_COMPILER'] == 'msvc':
     elif env['MODE'] == 'profile':
         env.Append(CCFLAGS=Split('/Ob2 /MD /Zi'))
     else:  # debug mode
-        env.Append(CCFLAGS=Split('/Od /Zi /MD'))
+        env.Append(CCFLAGS=Split('/Od /MD'))
         env.Append(LINKFLAGS=Split('/DEBUG'))
 
     if env['WARN_LEVEL'] == 'strict':


### PR DESCRIPTION
**Changes proposed in this pull request**
- remove ther `/Zi` flag for MSVC SCons builds to prevent build errors when running multiple parallel builds

**Issues fixed in this pull request**
Fixes #2380 

**Additional context**
Add any other context or screenshots about the pull request here.
