### PR TITLE
Replace MarkAllRprimsDirty with scene index filter

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -40,6 +40,8 @@
 #include <pxr/imaging/hd/resourceRegistry.h>
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/dirtyBitsTranslator.h>
+#include <pxr/imaging/hd/retainedDataSource.h>
 
 #include <common_utils.h>
 #include <constant_strings.h>
@@ -1573,6 +1575,34 @@ bool HdArnoldRenderDelegate::HasPendingChanges(HdRenderIndex* renderIndex, const
     bool changes = false;
     if (bits != HdChangeTracker::Clean) {
         renderIndex->GetChangeTracker().MarkAllRprimsDirty(bits);
+        // Unfortunately the MarkAllRprimsDirty doesn't work as we would expect in USD 25.05 with hydra 2, it marks dirty the prims of the legacy scene index which doesn't contain rprims, so all
+        // the dirty notifications get discarded. We have to use a workaround to get the same behaviour as before by propagating the dirtyness to a dedicated scene index filter.
+        if (HdRenderIndex::IsSceneIndexEmulationEnabled()) {
+            if (HdSceneIndexBaseRefPtr sceneIndex = renderIndex->GetTerminalSceneIndex()) {
+                // Regarding the used of TfHashMap to carry the dirtyness, we unfortunately can't pass
+                // directly HdSceneIndexObserver::DirtiedPrimEntries due to template functions implementation
+                // missing for this type. Vectors of SdfPath and HdDataSourceLocatorSet don't work as well. So
+                // we revert to an hashmap which it not ideal, but it allows us to decouple the libraries using
+                // only available functions and supported types known by each libs.
+                TfHashMap<SdfPath, HdDataSourceLocatorSet, SdfPath::Hash> dirtyEntries;
+                for (const SdfPath& id : renderIndex->GetRprimIds()) {
+                    HdSceneIndexPrim prim = sceneIndex->GetPrim(id);
+                    HdDataSourceLocatorSet locators;
+                    // TODO: We might have to also translate bespoke arnold nodes parameters if they are not supported.
+                    HdDirtyBitsTranslator::RprimDirtyBitsToLocatorSet(prim.primType, bits, &locators);
+                    if (!locators.IsEmpty()) {
+                        dirtyEntries.insert({id, locators});
+                    }
+                }
+                if (!dirtyEntries.empty()) {
+                    auto toto = HdRetainedTypedSampledDataSource<
+                        TfHashMap<SdfPath, HdDataSourceLocatorSet, SdfPath::Hash>>::New(dirtyEntries);
+                    sceneIndex->SystemMessage(TfToken("ArnoldMarkAllRprimsDirty"), toto);
+                }
+            }
+        } else {
+            renderIndex->GetChangeTracker().MarkAllRprimsDirty(bits);
+        }
         changes = true;
     }
     SdfPath id;

--- a/plugins/scene_index/CMakeLists.txt
+++ b/plugins/scene_index/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
     fixInvalidationSIP.cpp
     fixMaterialPruningSIP.cpp
     fixPropagatedPrototypesVisibilitySIP.cpp
+    propagateDirtyPrimsSIP.cpp
     implicitSurfaceSIP.cpp
     lightLinkingSIP.cpp
     nurbsApproximatingSIP.cpp
@@ -17,6 +18,7 @@ set(HDR
     fixInvalidationSIP.h
     fixMaterialPruningSIP.h
     fixPropagatedPrototypesVisibilitySIP.h
+    propagateDirtyPrimsSIP.h
     implicitSurfaceSIP.h
     nurbsApproximatingSIP.h
 )
@@ -38,7 +40,7 @@ if (NOT BUILD_WITH_USD_STATIC)
         target_sources(sceneIndexArnold PRIVATE ${HDR})
     endif ()
     #TODO check only the useful ones
-    set(SCENEINDEX_LIBS ar;arch;plug;tf;trace;vt;gf;work;sdf;sdr;hf;hd;usd;usdGeom;usdImaging;hdsi;usdLux;usdShade;usdSkelImaging)
+    set(SCENEINDEX_LIBS ar;arch;plug;tf;vt;gf;work;sdf;sdr;hf;hd;usd;usdGeom;usdImaging;hdsi;usdSkelImaging)
     if (${USD_VERSION} VERSION_LESS "0.25.05")
         list(APPEND SCENEINDEX_LIBS ndr)
     endif()

--- a/plugins/scene_index/SConscript
+++ b/plugins/scene_index/SConscript
@@ -26,6 +26,7 @@ source_files = [
 	'fixInvalidationSIP.cpp',
 	'fixMaterialPruningSIP.cpp',
     'fixPropagatedPrototypesVisibilitySIP.cpp',
+	'propagateDirtyPrimsSIP.cpp',
     'nurbsApproximatingSIP.cpp',
 ]
 

--- a/plugins/scene_index/plugInfo.json.in
+++ b/plugins/scene_index/plugInfo.json.in
@@ -56,8 +56,13 @@
                         "loadWithRenderer": "Arnold",
                         "priority": 0,
                         "displayName": "Arnold: fix invalidation for custom types"
+                    },
+                    "HdArnoldPropagateDirtyPrimsSceneIndexPlugin" : {
+                        "bases": ["HdSceneIndexPlugin"],
+                        "loadWithRenderer": "Arnold",
+                        "priority": 0,
+                        "displayName": "Arnold: propagate dirty prims"
                     }
-                    
                 }
             },
             "LibraryPath": "${LIB_PATH}${LIB_EXTENSION}",

--- a/plugins/scene_index/propagateDirtyPrimsSIP.cpp
+++ b/plugins/scene_index/propagateDirtyPrimsSIP.cpp
@@ -1,0 +1,100 @@
+#include "propagateDirtyPrimsSIP.h"
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+PropagateDirtyPrimsSceneIndexRefPtr PropagateDirtyPrimsSceneIndex::New(const HdSceneIndexBaseRefPtr &inputSceneIndex)
+{
+    return TfCreateRefPtr(new PropagateDirtyPrimsSceneIndex(inputSceneIndex));
+}
+
+HdSceneIndexPrim PropagateDirtyPrimsSceneIndex::GetPrim(const SdfPath &primPath) const
+{
+    return _GetInputSceneIndex()->GetPrim(primPath);
+}
+
+SdfPathVector PropagateDirtyPrimsSceneIndex::GetChildPrimPaths(const SdfPath &primPath) const
+{
+    return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+}
+
+void PropagateDirtyPrimsSceneIndex::DirtyPrims(const HdSceneIndexObserver::DirtiedPrimEntries &entries)
+{
+    _SendPrimsDirtied(entries);
+}
+
+PropagateDirtyPrimsSceneIndex::PropagateDirtyPrimsSceneIndex(const HdSceneIndexBaseRefPtr &inputSceneIndex)
+    : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+{
+#if PXR_VERSION >= 2308
+    SetDisplayName("Arnold: propagate dirty prims");
+#endif
+}
+
+void PropagateDirtyPrimsSceneIndex::_PrimsAdded(
+    const HdSceneIndexBase &sender, const HdSceneIndexObserver::AddedPrimEntries &entries)
+{
+    if (!_IsObserved()) {
+        return;
+    }
+    // Check if prims added are light and have dependencies, keep the dependencies
+    _SendPrimsAdded(entries);
+}
+
+void PropagateDirtyPrimsSceneIndex::_PrimsRemoved(
+    const HdSceneIndexBase &sender, const HdSceneIndexObserver::RemovedPrimEntries &entries)
+{
+    if (!_IsObserved()) {
+        return;
+    }
+    _SendPrimsRemoved(entries);
+}
+
+void PropagateDirtyPrimsSceneIndex::_PrimsDirtied(
+    const HdSceneIndexBase &sender, const HdSceneIndexObserver::DirtiedPrimEntries &entries)
+{
+    if (!_IsObserved()) {
+        return;
+    }
+    _SendPrimsDirtied(entries);
+}
+
+void PropagateDirtyPrimsSceneIndex::_SystemMessage(const TfToken &messageType, const HdDataSourceBaseHandle &args)
+{
+    if (messageType == TfToken("ArnoldMarkAllRprimsDirty")) {
+        // The type is defined in render_delegate.cpp, ideally we would like a more memory friendly type
+        auto handle =
+            HdRetainedTypedSampledDataSource<TfHashMap<SdfPath, HdDataSourceLocatorSet, SdfPath::Hash>>::Cast(args);
+        if (handle) {
+            TfHashMap<SdfPath, HdDataSourceLocatorSet, SdfPath::Hash> passedEntries =
+                handle->GetTypedValue(0); // Is this a copy ? Oo
+            HdSceneIndexObserver::DirtiedPrimEntries dirtyEntries;
+            for (const auto &[id, locators] : passedEntries) {
+                dirtyEntries.emplace_back(id, locators);
+            }
+            _SendPrimsDirtied(dirtyEntries);
+        }
+    }
+}
+
+HdArnoldPropagateDirtyPrimsSceneIndexPlugin::HdArnoldPropagateDirtyPrimsSceneIndexPlugin() = default;
+
+HdSceneIndexBaseRefPtr HdArnoldPropagateDirtyPrimsSceneIndexPlugin::_AppendSceneIndex(
+    const HdSceneIndexBaseRefPtr &inputScene, const HdContainerDataSourceHandle &inputArgs)
+{
+    return PropagateDirtyPrimsSceneIndex::New(inputScene);
+}
+
+TF_REGISTRY_FUNCTION(TfType) { HdSceneIndexPluginRegistry::Define<HdArnoldPropagateDirtyPrimsSceneIndexPlugin>(); }
+
+TF_REGISTRY_FUNCTION(HdSceneIndexPlugin)
+{
+    const HdSceneIndexPluginRegistry::InsertionPhase insertionPhase = 0;
+
+    HdSceneIndexPluginRegistry::GetInstance().RegisterSceneIndexForRenderer(
+        "Arnold", TfToken("HdArnoldPropagateDirtyPrimsSceneIndexPlugin"), nullptr, insertionPhase,
+        HdSceneIndexPluginRegistry::InsertionOrderAtStart);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugins/scene_index/propagateDirtyPrimsSIP.h
+++ b/plugins/scene_index/propagateDirtyPrimsSIP.h
@@ -1,0 +1,54 @@
+
+#pragma once
+
+#ifdef ENABLE_SCENE_INDEX
+
+#include <pxr/imaging/hd/filteringSceneIndex.h>
+#include <pxr/imaging/hd/sceneIndexPlugin.h>
+#include <pxr/pxr.h>
+#include "api.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DECLARE_REF_PTRS(PropagateDirtyPrimsSceneIndex);
+
+// This scene index is an entry point for the arnold render delegate, it is basically used to
+// invalidate prims from the RenderPass::_Execute function, to mimic the original hydra 1 behaviour.
+
+class PropagateDirtyPrimsSceneIndex : public HdSingleInputFilteringSceneIndexBase {
+public:
+    static PropagateDirtyPrimsSceneIndexRefPtr New(const HdSceneIndexBaseRefPtr &inputSceneIndex);
+    HDSCENEINDEX_API
+    HdSceneIndexPrim GetPrim(const SdfPath &primPath) const override;
+    HDSCENEINDEX_API
+    SdfPathVector GetChildPrimPaths(const SdfPath &primPath) const override;
+
+    HDSCENEINDEX_API
+    void DirtyPrims(const HdSceneIndexObserver::DirtiedPrimEntries &entries);
+
+protected:
+    HDSCENEINDEX_API
+    PropagateDirtyPrimsSceneIndex(const HdSceneIndexBaseRefPtr &inputSceneIndex);
+    HDSCENEINDEX_API
+    void _PrimsAdded(const HdSceneIndexBase &sender, const HdSceneIndexObserver::AddedPrimEntries &entries) override;
+    HDSCENEINDEX_API
+    void _PrimsRemoved(
+        const HdSceneIndexBase &sender, const HdSceneIndexObserver::RemovedPrimEntries &entries) override;
+    HDSCENEINDEX_API
+    void _PrimsDirtied(
+        const HdSceneIndexBase &sender, const HdSceneIndexObserver::DirtiedPrimEntries &entries) override;
+    HDSCENEINDEX_API
+    void _SystemMessage(const TfToken &messageType, const HdDataSourceBaseHandle &args) override;
+};
+
+class HdArnoldPropagateDirtyPrimsSceneIndexPlugin : public HdSceneIndexPlugin {
+public:
+    HdArnoldPropagateDirtyPrimsSceneIndexPlugin();
+
+protected:
+    HdSceneIndexBaseRefPtr _AppendSceneIndex(
+        const HdSceneIndexBaseRefPtr &inputScene, const HdContainerDataSourceHandle &inputArgs) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+#endif

--- a/plugins/usd_imaging/CMakeLists.txt
+++ b/plugins/usd_imaging/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT BUILD_WITH_USD_STATIC)
     if (BUILD_HEADERS_AS_SOURCES)
         target_sources(usdImagingArnold PRIVATE ${HDR})
     endif ()
-    set(USDIMAGING_LIBS ar;arch;plug;tf;trace;vt;gf;work;sdf;sdr;hf;hd;usd;usdGeom;usdImaging;usdLux;usdShade)
+    set(USDIMAGING_LIBS ar;arch;plug;tf;trace;vt;gf;work;sdf;sdr;hf;hd;hdsi;usd;usdGeom;usdImaging;usdLux;usdShade)
     if (${USD_VERSION} VERSION_LESS "0.25.05")
         list(APPEND USDIMAGING_LIBS ndr)
     endif()
@@ -56,7 +56,6 @@ if (NOT BUILD_WITH_USD_STATIC)
     if (BUILD_SCENE_INDEX_PLUGIN)
         target_compile_definitions(usdImagingArnold PUBLIC ENABLE_SCENE_INDEX=1)
     endif()
-
     # For the generated shape adapters to find headers here.
     target_include_directories(usdImagingArnold PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
     

--- a/tools/utils/dependencies.py
+++ b/tools/utils/dependencies.py
@@ -116,6 +116,7 @@ def usd_imaging_plugin(env, sources):
         'sdr',
         'hf',
         'hd',
+        'hdsi',
         'usd',
         'usdGeom',
         'usdImaging',


### PR DESCRIPTION
**Changes proposed in this pull request**
- The MarkAllRprimsDirty function doesn't work as we would expect in USD 25.05 with Hydra 2. When we call it on actual prims of the scene, it doesn't mark them dirty as they don't belong to the legacy scene index. So the dirty flags are not propagated properly. We use MarkAllRprimsDirty when there have been some changes that can affect the sampling of the scene, motion blur for instance, or when there have been changes coming from arnold when using multiple usd procedurals. This PR propose a workaround using a scene index filter to propagate the dirty flags and the of the SystemMessage function to avoid dependencies between libraries
