### PR TITLE
Fix the typeName:parameter arnold usd warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 
 - [usd#2349](https://github.com/Autodesk/arnold-usd/issues/2349) - Husk renders with the Arnold product type overwrites the same output path when rendering mutliple frames in same process
+- [usd#2392](https://github.com/Autodesk/arnold-usd/issues/2392) - Fix a warning due to additional metadata parameters, typeName and colorSpace introduced in USD 25.05.
 
 ## Next feature release (7.4.3.0)
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Skip additional metadata parameters [introduced in USD 25.05](https://github.com/PixarAnimationStudios/OpenUSD/blob/14e978d726ac5cac01ba15eade7da42c69a1a814/CHANGELOG.md?plain=1#L905). 

**Issues fixed in this pull request**
Fixes #2392

