### PR TITLE
Support resolutions with a different aspect ratio than the data window

### DIFF
--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -563,6 +563,15 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
         }
     }
     float currentPixelAspectRatio = AiNodeGetFlt(options, str::pixel_aspect_ratio);
+    GfVec2i delegateResolution = _renderDelegate->GetResolution();
+    // If the render delegate resolution is explicitely set as being different from 
+    // our data window, we want to apply a pixel aspect ratio so that the final image matches.
+    // This can be skipped if the render has a window NDC as a similar logic was already applied
+    if (!hasWindowNDC && delegateResolution[0] > 0 && delegateResolution[1] > 0 &&
+            (delegateResolution[0] != _width || delegateResolution[1] != _height)) {
+        pixelAspectRatio *= (float) (_height * delegateResolution[0]) / (float) (_width * delegateResolution[1]);
+    }
+
     if (!GfIsClose(currentPixelAspectRatio, pixelAspectRatio, AI_EPSILON)) {
         renderParam->Interrupt(true, false);
         AiNodeSetFlt(options, str::pixel_aspect_ratio, pixelAspectRatio);


### PR DESCRIPTION
**Changes proposed in this pull request**
We receive render resolution through 2 different ways : a "resolution" render setting and the dataWindow's widht & height.
In general, they are both identical, but in the case of Solaris clone render, they can be different. We get a default 1920x1080 data window resolution, but with the resolution specified in the render settings. 
In that case, we still need to render for the data window resolution (that's the size of the output buffers that need to be filled), but the image will then be modified to be in the render settings resolution. The only solution is to adjust the pixel aspect ratio in that case, so that we get the expected result.

Setting this PR as a draft until we confirm that we want to go ahead with that fix


**Issues fixed in this pull request**
Fixes HTOA-2793

**Additional context**
Add any other context or screenshots about the pull request here.
