### PR TITLE
Replace procedural & texture search path with asset_searchpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [usd#2331](https://github.com/Autodesk/arnold-usd/issues/2331) - Support multiple AOVs with the same name in hydra render products
 - [usd#2390](https://github.com/Autodesk/arnold-usd/issues/2390) - Add support for the MeshLightAPI
+- [usd#2404](https://github.com/Autodesk/arnold-usd/issues/2404) - Support asset_searchpath as a replacement for procedural & texture search paths.
 
 ### Bug Fixes
 

--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -191,6 +191,7 @@ ASTR(aov_write_vector);
 ASTR(aperture_size);
 ASTR(append);
 ASTR(arnold);
+ASTR(asset_searchpath);
 ASTR(assignment);
 ASTR(atmosphere);
 ASTR(attribute);

--- a/libs/render_delegate/config.cpp
+++ b/libs/render_delegate/config.cpp
@@ -102,11 +102,9 @@ TF_DEFINE_ENV_SETTING(HDARNOLD_report_file, "", "Output file for the Arnold HTML
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_stats_file, "", "Output file for stats information.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_texture_searchpath, "", "Texture search path.");
-
 TF_DEFINE_ENV_SETTING(HDARNOLD_plugin_searchpath, "", "Plugin search path.");
 
-TF_DEFINE_ENV_SETTING(HDARNOLD_procedural_searchpath, "", "Procedural search path.");
+TF_DEFINE_ENV_SETTING(HDARNOLD_asset_searchpath, "", "Asset search path.");
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_osl_includepath, "", "OSL include path.");
 
@@ -145,9 +143,8 @@ HdArnoldConfig::HdArnoldConfig()
     interactive_fps_min =
         std::max(1.0f, static_cast<float>(std::atof(TfGetEnvSetting(HDARNOLD_interactive_fps_min).c_str())));
     profile_file = TfGetEnvSetting(HDARNOLD_profile_file);
-    texture_searchpath = TfGetEnvSetting(HDARNOLD_texture_searchpath);
     plugin_searchpath = TfGetEnvSetting(HDARNOLD_plugin_searchpath);
-    procedural_searchpath = TfGetEnvSetting(HDARNOLD_procedural_searchpath);
+    asset_searchpath = TfGetEnvSetting(HDARNOLD_asset_searchpath);
     osl_includepath = TfGetEnvSetting(HDARNOLD_osl_includepath);
     auto_generate_tx = TfGetEnvSetting(HDARNOLD_auto_generate_tx);
 }

--- a/libs/render_delegate/config.h
+++ b/libs/render_delegate/config.h
@@ -171,17 +171,13 @@ struct HdArnoldConfig {
     ///
     std::string stats_file; ///< Output file for stats data.
 
-    /// Use HDARNOLD_texture_searchpath to set the value.
-    ///
-    std::string texture_searchpath; ///< Texture search path.
-
     /// Use HDARNOLD_plugin_searchpath to set the value.
     ///
     std::string plugin_searchpath; ///< Plugin search path.
 
-    /// Use HDARNOLD_procedural_searchpath to set the value.
+    /// Use HDARNOLD_asset_searchpath to set the value.
     ///
-    std::string procedural_searchpath; ///< Procedural search path.
+    std::string asset_searchpath; ///< Asset search path.
 
     /// Use HDARNOLD_osl_includepath to set the value.
     ///

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -351,9 +351,8 @@ const SupportedRenderSettings& _GetSupportedRenderSettings()
         // Stats Settings
         {str::t_stats_file, {"File Output for Stats", config.stats_file}},
         // Search paths
-        {str::t_texture_searchpath, {"Texture search path.", config.texture_searchpath}},
         {str::t_plugin_searchpath, {"Plugin search path.", config.plugin_searchpath}},
-        {str::t_procedural_searchpath, {"Procedural search path.", config.procedural_searchpath}},
+        {str::t_asset_searchpath, {"Asset search path.", config.asset_searchpath}},
         {str::t_osl_includepath, {"OSL include path.", config.osl_includepath}},
 
         {str::t_subdiv_dicing_camera, {"Subdiv Dicing Camera", std::string{}}},

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -1869,10 +1869,10 @@ AtNode* UsdArnoldReadProcViewport::Read(const UsdPrim &prim, UsdArnoldReaderCont
     // create a temporary universe to create a dummy procedural
     AtUniverse *tmpUniverse = AiUniverse();
 
-    // copy the procedural search path string from the input universe
+    // copy the asset search path string from the input universe
     AiNodeSetStr(
-        AiUniverseGetOptions(tmpUniverse), str::procedural_searchpath,
-        AiNodeGetStr(AiUniverseGetOptions(universe), str::procedural_searchpath));
+        AiUniverseGetOptions(tmpUniverse), str::asset_searchpath,
+        AiNodeGetStr(AiUniverseGetOptions(universe), str::asset_searchpath));
 
     // Create a procedural with the given node type
     AtNode *proc = AiNode(tmpUniverse, AtString(nodeType.c_str()), AtString("viewport_proc"));

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -123,12 +123,12 @@ void applyProceduralSearchPath(std::string &filename, const AtUniverse *universe
     if (optionsNode) {
         // We want to allow using the procedural search path to point to directories containing .abc files in the same
         // way procedural search paths are used to resolve procedural .ass files.
-        // To do this we extract the procedural path from the options node, where environment variables specified using
+        // To do this we extract the asset path from the options node, where environment variables specified using
         // the Arnold standard (e.g. [HOME]) are expanded. If our .abc file exists in any of the directories we
         // concatenate the path and the relative filename to create a new procedural argument filename using the full
         // path.
-        std::string proceduralPath = std::string(AiNodeGetStr(optionsNode, AtString("procedural_searchpath")));
-        std::string expandedSearchpath = ExpandEnvironmentVariables(proceduralPath.c_str());
+        std::string assetPath = std::string(AiNodeGetStr(optionsNode, AtString("asset_searchpath")));
+        std::string expandedSearchpath = ExpandEnvironmentVariables(assetPath.c_str());
 
         PathList pathList;
         TokenizePath(expandedSearchpath, pathList, ":;", true);

--- a/testsuite/test_0158/data/test.ass
+++ b/testsuite/test_0158/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0160/data/test.ass
+++ b/testsuite/test_0160/data/test.ass
@@ -14,7 +14,6 @@ options
  xres 160
  yres 120
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/0persp/1pe.rsp-Sha:pe"
  frame 1

--- a/testsuite/test_0161/data/scene.ass
+++ b/testsuite/test_0161/data/scene.ass
@@ -15,11 +15,9 @@ options
  xres 160
  yres 120
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0162/data/scene.ass
+++ b/testsuite/test_0162/data/scene.ass
@@ -15,11 +15,9 @@ options
  xres 160
  yres 120
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0163/data/test.ass
+++ b/testsuite/test_0163/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0164/data/test.ass
+++ b/testsuite/test_0164/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0165/data/test.ass
+++ b/testsuite/test_0165/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0167/data/test.ass
+++ b/testsuite/test_0167/data/test.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0168/data/scene.ass
+++ b/testsuite/test_0168/data/scene.ass
@@ -15,11 +15,9 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/maya/scenes/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  frame 1
- procedural_searchpath "C:/maya/scenes/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0195/data/test.ass
+++ b/testsuite/test_0195/data/test.ass
@@ -17,12 +17,10 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  meters_per_unit 0.00999999978
  frame 1
- procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0204/data/test.ass
+++ b/testsuite/test_0204/data/test.ass
@@ -15,12 +15,10 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  meters_per_unit 0.00999999978
  frame 1
- procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0205/data/test.ass
+++ b/testsuite/test_0205/data/test.ass
@@ -15,12 +15,10 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  meters_per_unit 0.00999999978
  frame 1
- procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0206/data/test.ass
+++ b/testsuite/test_0206/data/test.ass
@@ -18,12 +18,10 @@ options
  yres 120
  ignore_motion on
  texture_per_file_stats on
- texture_searchpath "C:/Users/blairs/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  meters_per_unit 0.00999999978
  frame 46
- procedural_searchpath ""
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0207/data/test.ass
+++ b/testsuite/test_0207/data/test.ass
@@ -16,12 +16,10 @@ options
  yres 120
  pixel_aspect_ratio 1.33333325
  texture_per_file_stats on
- texture_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
  texture_automip off
  camera "/persp/perspShape"
  meters_per_unit 0.00999999978
  frame 1
- procedural_searchpath "C:/Users/blaines.ADS/Documents/maya/projects/default/"
  GI_diffuse_depth 1
  GI_specular_depth 1
  GI_transmission_depth 8

--- a/testsuite/test_0317/data/test.usda
+++ b/testsuite/test_0317/data/test.usda
@@ -22,10 +22,8 @@ def Scope "Render"
         int arnold:GI_transmission_depth = 8
         float arnold:meters_per_unit = 0.01
         string arnold:name = "options"
-        string arnold:procedural_searchpath = "C:/Users/blaines.ADS/Documents/maya/projects/default/"
         bool arnold:texture_automip = 0
         bool arnold:texture_per_file_stats = 1
-        string arnold:texture_searchpath = "C:/Users/blaines.ADS/Documents/maya/projects/default/sourceimages"
         prepend rel camera = </persp/perspShape>
         uniform float pixelAspectRatio = 1
         string primvars:render_layer = "defaultRenderLayer" (

--- a/testsuite/test_1546/data/test.ass
+++ b/testsuite/test_1546/data/test.ass
@@ -17,7 +17,7 @@ options
  AA_seed 0
  xres 640
  yres 360
- texture_searchpath "tex"
+ asset_searchpath "tex"
  camera "/Camera"
  fps 30
  GI_diffuse_depth 1


### PR DESCRIPTION
This PR replaces all ocurrences of procedural_searchpath and texture_searchpath and replaces it with a single asset_searchpath, to match an unreleased change in arnold.

I removed it from a bunch of tests that had a dummy, local path on these attributes.