### PR TITLE
Crytomatte fix for Hydra 2

### DIFF
--- a/libs/render_delegate/instancer.cpp
+++ b/libs/render_delegate/instancer.cpp
@@ -326,6 +326,27 @@ void HdArnoldInstancer::CalculateInstanceMatrices(HdArnoldRenderDelegate* render
     AiNodeDeclare(instancerNode, str::instance_inherit_xform, "constant array BOOL");
     AiNodeSetArray(instancerNode, str::instance_inherit_xform, AiArray(1, 1, AI_TYPE_BOOLEAN, true));
 
+#ifdef ENABLE_SCENE_INDEX // Hydra2
+    // Declare and set a constant array INT user parameter for crypto_object_offset
+    AiNodeDeclare(instancerNode, AtString("instance_crypto_object"), "constant ARRAY STRING");
+    AtArray* cryptoOffsets = AiArrayAllocate(numInstances, 1, AI_TYPE_STRING);
+    for (int offset = 0; offset < numInstances; ++offset) {
+        std::string name = "/addpointinstancer1/Prototypes/cube1_" + std::to_string(offset);
+        AiArraySetStr(cryptoOffsets, offset, AtString(name.c_str()));
+    }
+    AiNodeSetArray(instancerNode, AtString("instance_crypto_object"), cryptoOffsets);
+
+    // Set a per instance offset
+    //AiNodeDeclare(instancerNode, AtString("instance_crypto_object_offset"), "constant ARRAY INT");
+    //AtArray* cryptoOffsets = AiArrayAllocate(numInstances, 1, AI_TYPE_INT);
+    //for (int offset = 0; offset < numInstances; ++offset) {
+    //    AiArraySetInt(cryptoOffsets, offset, offset);
+    //}
+    //AiNodeSetArray(instancerNode, AtString("instance_crypto_object_offset"), cryptoOffsets);
+#endif // ENABLE_SCENE_INDEX // Hydra2
+
+    // TODO create a string array userdata for each instance id
+
     if (sampleArray.count == 0 || sampleArray.values.front().empty()) {
         AiNodeResetParameter(instancerNode, str::instance_matrix);
         AiNodeResetParameter(instancerNode, str::node_idxs);
@@ -418,6 +439,7 @@ void HdArnoldInstancer::CalculateInstanceMatrices(HdArnoldRenderDelegate* render
 
 void HdArnoldInstancer::SetPrimvars(AtNode* node, const SdfPath& prototypeId, size_t totalInstanceCount, HdArnoldRenderDelegate* renderDelegate )
 {
+    printf("Setting primvars for prototype: %s\n", prototypeId.GetText());
 
     VtIntArray instanceIndices = GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
     size_t instanceCount = instanceIndices.size();

--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -17,7 +17,10 @@
 // limitations under the License.
 #include "shape.h"
 
+#include <pxr/imaging/hd/primOriginSchema.h>
+
 #include <constant_strings.h>
+#include <sstream>
 #include "instancer.h"
 #include "utils.h"
 
@@ -65,6 +68,26 @@ void HdArnoldShape::Sync(
         return;
 
     auto& id = rprim->GetId();
+//#ifdef ENABLE_SCENE_INDEX // Hydra2
+//    HdSceneIndexBaseRefPtr sceneIndex = sceneDelegate->GetRenderIndex().GetTerminalSceneIndex();
+//    if (sceneIndex) {
+//        // Identify if this rprim comes from a prototype in a point instancer, then rename it
+//        HdSceneIndexPrim prim = sceneIndex->GetPrim(id);
+//        HdPrimOriginSchema primOrigin = HdPrimOriginSchema::GetFromParent(prim.dataSource).GetContainer();
+//        if (primOrigin) {
+//            const SdfPath primOriginPath = primOrigin.GetOriginPath(HdPrimOriginSchemaTokens->scenePath);
+//
+//            param.Interrupt();
+//
+//            if (AiNodeLookUpUserParameter(_shape, AtString("crypto_object")) == nullptr) {
+//                AiNodeDeclare(_shape, AtString("crypto_object"), AtString("constant STRING"));
+//            }
+//            AiNodeSetStr(_shape, AtString("crypto_object"), primOriginPath.GetText());
+//        }
+//
+//    }
+//#endif // ENABLE_SCENE_INDEX // Hydra2
+
     if (HdChangeTracker::IsPrimIdDirty(dirtyBits, id)) {
         param.Interrupt();
         _SetPrimId(rprim->GetPrimId());
@@ -160,6 +183,7 @@ void HdArnoldShape::_SyncInstances(
     const TfToken renderTag = sceneDelegate->GetRenderTag(id);
 
     for (size_t i = 0; i < _instancers.size(); ++i) {
+        printf("\tInstancer %zu: %s\n", i, AiNodeGetName(_instancers[i]));
         AiNodeSetPtr(_instancers[i], str::nodes, (i == 0) ? _shape : _instancers[i - 1]);
         renderDelegate->TrackRenderTag(_instancers[i], renderTag);
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- A rough workaround which sets the flattened string list for instance_crypto_object. This doesn't match the Hydra 1 result, but is deterministic
<img width="2128" height="148" alt="image" src="https://github.com/user-attachments/assets/08e46b9c-3a81-41f7-9a07-44f58c759542" />

- A commented out, slightly less inefficient workaround which sets crypto_object on the prototype and instance_crypto_object_offset on the instancer. This doesn't work yet

**Issues fixed in this pull request**
Fixes #
Fixes #

**Additional context**
Add any other context or screenshots about the pull request here.
