### PR TITLE
Crytomatte fix for Hydra 2

### DIFF
--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -72,7 +72,8 @@ void HdArnoldShape::Sync(
 #ifdef ENABLE_SCENE_INDEX // Hydra2
     HdSceneIndexBaseRefPtr sceneIndex = sceneDelegate->GetRenderIndex().GetTerminalSceneIndex();
     if (sceneIndex) {
-        // Identify if this rprim comes from a prototype in a point instancer, then rename it
+        // Identify if this rprim comes from a prototype in a point instancer,
+        // then set the metadata to override it's cryptomatte id
         HdSceneIndexPrim prim = sceneIndex->GetPrim(id);
         HdPrimOriginSchema primOrigin = HdPrimOriginSchema::GetFromParent(prim.dataSource).GetContainer();
         if (primOrigin) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Set `crypto_object` on prototype prims to workaround the non-deterministic prototype hash set [here](https://github.com/PixarAnimationStudios/OpenUSD/blob/dev/pxr/usdImaging/usdImaging/piPrototypePropagatingSceneIndex.cpp#L408)
- I attempted to set `instance_crypto_object_offset` on the instancer itself, which should cause each instanced prim to have a unique cryptomatte ID - I haven't managed to get this to work yet
- This means that for now, we match the Karma behaviour with point instancers and each instance will share the same hash
- Left is the new behaviour we need to fix, right is the original behaviour
<img width="370" height="98" alt="image" src="https://github.com/user-attachments/assets/f63e1e64-ce27-4630-a46e-f6db15d7c15b" />

**Issues fixed in this pull request**
Fixes #

**Additional context**
Add any other context or screenshots about the pull request here.
