### PR TITLE
Add node_entry parameter in the schema for the usd procedural

### DIFF
--- a/schemas/createSchemaFile.py
+++ b/schemas/createSchemaFile.py
@@ -511,7 +511,8 @@ proceduralUsdAppendAttrs = ['string arnold:filename = ""',
                             'string[] arnold:overrides',
                             'int arnold:cache_id = 0', 
                             'bool arnold:interactive = 0',
-                            'bool arnold:hydra = 1']
+                            'bool arnold:hydra = 1',
+                            'string arnold:node_entry = ""']
 createArnoldClass('usd', 'Gprim', proceduralCustomAttrs, ai.AiNodeEntryLookUp('procedural'), 
     ignoreShapeAttributes, False, True, proceduralUsdAppendAttrs)
 


### PR DESCRIPTION
We were missing an attribute in the usd schema for ArnoldUsd primitives, which is defined in our other schemas. This would sometimes cause problems when building HtoA locally when running UsdGenSchema. It shouldn't have any impact on the user side
