### PR TITLE
Fix regression in default value of texture_auto_generate_tx in the render delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## [7.4.4.1] (Unreleased)
+
+### Bug Fixes
+
+- [usd#2472](https://github.com/Autodesk/arnold-usd/issues/2472) Fix regression in default value of texture_auto_generate_tx in the render delegate plugin
+
 ## [7.4.4.0] 2025-11-12
 
 ### Features

--- a/libs/render_delegate/config.h
+++ b/libs/render_delegate/config.h
@@ -43,6 +43,7 @@
 #include "api.h"
 
 #include <string>
+#include <ai.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
After a recent change in #2406 we started using the definition of ARNOLD_VERSION_NUM inside of config.h, but ai.h wasn't included. So depending on the order of includes in the different .cpp files, they wouldn't always consider the ifdefs the same way. Because of that, the value of `config.auto_generate_tx` that is just after this ifdef, isn't correct in render_delegate.cpp, and is therefore set to false by default

**Issues fixed in this pull request**
Fixes #2472 

**Additional context**
Add any other context or screenshots about the pull request here.
