### PR TITLE
Allow the use of a global shared arrays map

### DIFF
--- a/libs/render_delegate/CMakeLists.txt
+++ b/libs/render_delegate/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC
     render_param.cpp
     render_pass.cpp
     shape.cpp
+	shared_arrays.cpp
     utils.cpp
     volume.cpp
     )

--- a/libs/render_delegate/SConscript
+++ b/libs/render_delegate/SConscript
@@ -37,6 +37,7 @@ source_files = [
     'render_param.cpp',
     'render_pass.cpp',
     'shape.cpp',
+    'shared_arrays.cpp',
     'utils.cpp',
     'volume.cpp',
     os.path.join('nodes', 'driver_main.cpp'),

--- a/libs/render_delegate/mesh.cpp
+++ b/libs/render_delegate/mesh.cpp
@@ -176,7 +176,7 @@ HdArnoldMesh::~HdArnoldMesh() {
     if (_geometryLight) {
         _renderDelegate->UnregisterMeshLight(_geometryLight);
     }
-
+#if SHARED_ARRAYS_USE_GLOBAL_MAP == 0
     // Reset the shared buffers
     // We are assuming there is only one reference pointing on each of them. If this is not the
     // case, the following code will not correctly deallocate the VtValue and pointers in Arnold could
@@ -195,6 +195,7 @@ HdArnoldMesh::~HdArnoldMesh() {
     // We the ArrayHolder should be empty, otherwise it means that we are potentially destroying
     // shared VtArray buffers still used in Arnold. We check this condition in debug mode.
     assert(_arrayHandler.empty());
+#endif
 }
 
 void HdArnoldMesh::Sync(

--- a/libs/render_delegate/shared_arrays.cpp
+++ b/libs/render_delegate/shared_arrays.cpp
@@ -1,0 +1,6 @@
+#include "shared_arrays.h"
+
+#if SHARED_ARRAYS_USE_GLOBAL_MAP
+ArrayHolder::BufferMapT ArrayHolder::_bufferMap;
+std::mutex ArrayHolder::_bufferMapMutex;
+#endif


### PR DESCRIPTION
**Changes proposed in this pull request**
- Create a global shared array map that replace local storage.
- Enable this global map using a define

**Issues fixed in this pull request**
Fixes #2488

