### PR TITLE
Support shape instancing in GPU

### DIFF
--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -139,9 +139,6 @@ static bool UseArnoldInstancer(HdSceneDelegate* sceneDelegate, HdArnoldRenderDel
     if (!renderDelegate->SupportShapeInstancing())
         return true;
 
-    if (AiDeviceGetSelectedType(renderDelegate->GetRenderSession()) == AI_DEVICE_TYPE_GPU)
-        return true;
-
     // If we have a nested instancer configuration, we'll use an arnold instancer node.
     HdInstancer * parentInstancer = sceneDelegate->GetRenderIndex().GetInstancer(instancer->GetParentId());
     if (parentInstancer)


### PR DESCRIPTION
We were skipping shape instancing for gpu rendering, but this is properly supported in latest daily arnold.