### PR TITLE
Fix crash when loading an Arnold ROP scene

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1061,6 +1061,9 @@ VtDictionary HdArnoldRenderDelegate::GetRenderStats() const
 {
     VtDictionary stats;
 
+    if(!AiUniverseGetOptions(_universe))
+        return stats;
+
     float total_progress = 100.0f;
     AiRenderGetHintFlt(GetRenderSession(), str::total_progress, total_progress);
     stats[_tokens->percentDone] = total_progress;

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -291,6 +291,12 @@ HdArnoldRenderPass::HdArnoldRenderPass(
       _renderDelegate(renderDelegate)
 {
     auto* universe = _renderDelegate->GetUniverse();
+    if(!AiUniverseGetOptions(universe))
+    {
+        printf("HdArnoldRenderPass ctor options null, skiping init\n");
+        return;
+    }
+
     _camera = _renderDelegate->CreateArnoldNode(str::persp_camera, 
         _renderDelegate->GetLocalNodeName(str::renderPassCamera));
     AiNodeSetPtr(AiUniverseGetOptions(universe), str::camera, _camera);
@@ -351,6 +357,10 @@ HdArnoldRenderPass::HdArnoldRenderPass(
 
 HdArnoldRenderPass::~HdArnoldRenderPass()
 {
+    AtNode *options = AiUniverseGetOptions(_renderDelegate->GetUniverse());
+    if(!options)
+        return;
+
     reinterpret_cast<HdArnoldRenderParam*>(_renderDelegate->GetRenderParam())->Interrupt();
     _renderDelegate->DestroyArnoldNode(_camera);
     _renderDelegate->DestroyArnoldNode(_defaultFilter);
@@ -388,6 +398,9 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     auto* renderParam = reinterpret_cast<HdArnoldRenderParam*>(_renderDelegate->GetRenderParam());
 
     AtNode *options = AiUniverseGetOptions(_renderDelegate->GetUniverse());
+    if(!options)
+        return;
+
     bool isOrtho = false;
     const auto* currentUniverseCamera =
         static_cast<const AtNode*>(AiNodeGetPtr(options, str::camera));


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added checks that the options node is valid - I'm not sure why _options is becoming null when transitioning from lops to classic scene view yet

**Issues fixed in this pull request**
Fixes HTOA-3023

**Additional context**
Add any other context or screenshots about the pull request here.
