### PR TITLE
Remove Arnold path resolver logic from CollectSceneAssets

### DIFF
--- a/plugins/procedural/asset_utils.cpp
+++ b/plugins/procedural/asset_utils.cpp
@@ -411,7 +411,7 @@ bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& asse
 
         std::string resolvedPath = dep.resolvedPath;
         // if could not resolve the path, then use the scene reference
-        // these are potentally paths that can be resolved by Arnold, like UDIM textures
+        // potentially these are paths that can be resolved by Arnold, like UDIM textures
         if (resolvedPath.empty())
             resolvedPath = dep.authoredPath;
 


### PR DESCRIPTION
**Changes proposed in this pull request**
The Arnold API has no support for resolving UDIM/TILE textures at the moment. Therefore we remove the Arnold path resolver and the plugin now returns the unresolved path and let Arnold resolve it. This makes sure all paths, including UDIM/TILE textures are correctly resolved when querying assets via the Arnold Asset API (AiSceneGetAssets).

**Issues fixed in this pull request**
Fixes ARNOLD-17286
