### PR TITLE
Remove procedural_get_assets from the USD procedural

### DIFF
--- a/plugins/procedural/asset_utils.cpp
+++ b/plugins/procedural/asset_utils.cpp
@@ -364,13 +364,8 @@ inline std::string GetNodeParameterFromDependency(const USDDependency& dep)
  * 
  * The function collects all dependencies 
  * and converts them to Arnold assets.
- * 
- * It can be called from a scene format plugin or 
- * from a procedural plugin, shown by the isProcedural
- * argument. Resolving Arnold paths is different based on
- * where the function is used,
  */
-bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets, bool isProcedural)
+bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets)
 {
     // open the scene file
     UsdStageRefPtr stage = UsdStage::Open(filename);

--- a/plugins/procedural/asset_utils.h
+++ b/plugins/procedural/asset_utils.h
@@ -74,7 +74,7 @@ std::vector<USDDependency> CollectDependencies(UsdStageRefPtr stage);
 /**
  * Returns all assets found in the given USD scene. 
  */
-bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets, bool isProcedural);
+bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -363,31 +363,6 @@ procedural_viewport
 }
 #endif
 
-// procedural_get_assets function was added in Arnold 7.4.5.0
-#if ARNOLD_VERSION_NUM >= 70405
-// static AtArray* ProceduralGetAssets(const AtNode* node, const AtParamValueMap* params)
-procedural_get_assets
-{
-    const std::string origFilename(AiNodeGetStr(node, AtString("filename")));
-    std::string filename(AiResolveFilePath(origFilename.c_str(), AtFileType::Asset));
-
-    // collect assets from the procedural scene file
-    std::vector<AtAsset*> assets;
-    bool isProcedural = true;
-    CollectSceneAssets(filename, assets, isProcedural);
-
-    // convert our list to an Arnold array
-    // the ownership of the array and the assets is delegated to the caller
-    AtArray* assetArray = AiArrayAllocate(assets.size(), 1, AI_TYPE_POINTER);
-    void* assetArrayData = AiArrayMap(assetArray);
-    void* assetData = assets.data();
-    if (assetArrayData && assetData)
-       memcpy(assetArrayData, assetData, assets.size() * sizeof(void*));
-
-    return assetArray;
-}
-#endif
-
 #if defined(_DARWIN) || defined(_LINUX)
 std::string USDLibraryPath()
 {
@@ -604,8 +579,7 @@ scene_get_assets
 {
     // collect assets from the scene
     std::vector<AtAsset*> assets;
-    bool isProcedural = false;
-    CollectSceneAssets(filename, assets, isProcedural);
+    CollectSceneAssets(filename, assets);
 
     if (assets.empty())
         return nullptr;


### PR DESCRIPTION
**Changes proposed in this pull request**
`procedural_get_assets` is removed from the Arnold core Asset API. This PR removes it from the USD procedural.

**Issues fixed in this pull request**
Fixes ARNOLD-17321