### PR TITLE
Fix crash with render outputs when the render pass is destroyed

### DIFF
--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -384,7 +384,21 @@ HdArnoldRenderPass::~HdArnoldRenderPass()
             }
         }
     }
-
+#if ARNOLD_VERSION_NUM >= 70405
+    // With Arnold 7.4.5.0 and up, arnold converts the options outputs strings as render_output nodes.
+    // Here we are destroying the filters & drivers, but we also have to destroy the render_outputs
+    // in order to avoid possible crashes during interactive updates. This can go away when we directly
+    // create render outputs here
+    if (!_renderDelegate->GetProceduralParent()) {
+        AtNodeIterator* nodeIter = AiUniverseGetNodeIterator(_renderDelegate->GetUniverse(), AI_NODE_RENDER_OUTPUT);
+        while (!AiNodeIteratorFinished(nodeIter))
+        {
+           AtNode *node = AiNodeIteratorGetNext(nodeIter);
+           AiNodeDestroy(node);
+        }
+        AiNodeIteratorDestroy(nodeIter);
+    }
+#endif
     _ClearRenderBuffers();
 }
 


### PR DESCRIPTION
Here we ensure that when the render pass is destroyed, as we delete the drivers and filters, that we also delete the render output nodes that were automatically created by arnold with latest versions. This avoids crashes in Solaris when the render LOP is interactively changed