### PR TITLE
Workaround to support interactive updates of shape instancing

### DIFF
--- a/libs/render_delegate/instancer.cpp
+++ b/libs/render_delegate/instancer.cpp
@@ -227,6 +227,13 @@ void HdArnoldInstancer::ComputeShapeInstancesTransforms(
     if (!AiNodeLookUpUserParameter(prototypeNode, str::instance_matrix)) {
         AiNodeDeclare(prototypeNode, str::instance_matrix, "constant ARRAY MATRIX");
     }
+    // Temporary workaround to handle IPR updates of the instance_matrix.
+    // If we force setting the matrix attribute of the prototype geo, arnold will
+    // properly rebuild the scene locations.
+    AtArray *mtx = AiArrayCopy(AiNodeGetArray(prototypeNode, str::matrix));
+    AiNodeResetParameter(prototypeNode, str::matrix);
+    AiNodeSetArray(prototypeNode, str::matrix, mtx);
+
     AiNodeSetArray(prototypeNode, str::instance_matrix, matrices);
     AiNodeSetFlt(prototypeNode, str::motion_start, sampleArray.times[0]);
     AiNodeSetFlt(prototypeNode, str::motion_end, sampleArray.times[sampleArray.count - 1]);


### PR DESCRIPTION
As described in ARNOLD-17357, instance_matrix on shapes is not refreshing properly in IPR updates. This PR adds a workaround by ensuring the matrix is forced to be set again. This can go away when it is fixed in the arnold side
