### PR TITLE
Set frame and fps on options

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -677,6 +677,11 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
 
     // When husk/houdini changes frame, they set the new frame number via the render settings.
     if (_key == str::t_houdiniFrame) {
+        if (_value.IsHolding<double>()) {
+            const float frame = static_cast<float>(_value.UncheckedGet<double>());
+            AiNodeSetFlt(_options, str::frame, frame);
+        }
+
         // We want to restart a new render in that case.
         _renderParam->Restart();
     }
@@ -790,7 +795,10 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             _forceIgnoreMotionBlur = true; 
         });
     } else if (key == str::t_houdiniFps) {
-        _CheckForFloatValue(value, [&](const float f) { _fps = f; });
+        _CheckForFloatValue(value, [&](const float f) {
+            _fps = f;
+            AiNodeSetFlt(_options, str::fps, _fps);
+        });
     } else if (key == str::t_background) {
         ArnoldUsdCheckForSdfPathValue(value, [&](const SdfPath& p) { _background = p; });
     } else if (key == str::t_atmosphere) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Set frame & fps (from [houdini:frame and houdini:fps](https://www.sidefx.com/docs/hdk/_h_d_k__u_s_d_hydra.html#HDK_USDHydraCustomSettingsInteractive) respectively) on the options node

**Issues fixed in this pull request**
Fixes #2526 

**Additional context**
Add any other context or screenshots about the pull request here.
