### PR TITLE
Fix IPR issue when changing AOVs with render outputs

### DIFF
--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -384,21 +384,6 @@ HdArnoldRenderPass::~HdArnoldRenderPass()
             }
         }
     }
-#if ARNOLD_VERSION_NUM >= 70405
-    // With Arnold 7.4.5.0 and up, arnold converts the options outputs strings as render_output nodes.
-    // Here we are destroying the filters & drivers, but we also have to destroy the render_outputs
-    // in order to avoid possible crashes during interactive updates. This can go away when we directly
-    // create render outputs here
-    if (!_renderDelegate->GetProceduralParent()) {
-        AtNodeIterator* nodeIter = AiUniverseGetNodeIterator(_renderDelegate->GetUniverse(), AI_NODE_RENDER_OUTPUT);
-        while (!AiNodeIteratorFinished(nodeIter))
-        {
-           AtNode *node = AiNodeIteratorGetNext(nodeIter);
-           AiNodeDestroy(node);
-        }
-        AiNodeIteratorDestroy(nodeIter);
-    }
-#endif
     _ClearRenderBuffers();
 }
 
@@ -1154,6 +1139,26 @@ bool HdArnoldRenderPass::_RenderBuffersChanged(const HdRenderPassAovBindingVecto
 
 void HdArnoldRenderPass::_ClearRenderBuffers()
 {
+#if ARNOLD_VERSION_NUM >= 70405
+    
+    if (_mainDriver)
+        AiNodeResetParameter(_mainDriver, str::render_outputs);
+    AiNodeResetParameter(_renderDelegate->GetOptions(), str::drivers);
+    // With Arnold 7.4.5.0 and up, arnold converts the options outputs strings as render_output nodes.
+    // Here we are destroying the filters & drivers, but we also have to destroy the render_outputs
+    // in order to avoid possible crashes during interactive updates. This can go away when we directly
+    // create render outputs here
+    if (!_renderDelegate->GetProceduralParent()) {
+        AtNodeIterator* nodeIter = AiUniverseGetNodeIterator(_renderDelegate->GetUniverse(), AI_NODE_RENDER_OUTPUT);
+        while (!AiNodeIteratorFinished(nodeIter))
+        {
+           AtNode *node = AiNodeIteratorGetNext(nodeIter);
+           AiNodeDestroy(node);
+        }
+        AiNodeIteratorDestroy(nodeIter);
+    }
+#endif
+
 
     for (auto& buffer : _renderBuffers) {
         if (buffer.second.filter != nullptr) {


### PR DESCRIPTION
**Changes proposed in this pull request**
Another fix for a regression due to render outputs in 7.4.5.0. We must ensure the render outputs are properly cleared between renders when the list of aov bindings changes

**Issues fixed in this pull request**
Fixes HTOA-3170