### PR TITLE
Changing material terminal not updated with hydra2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## [7.5.1.0] (Unreleased)
+
+### Bug Fixes
+
+- [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
+
 ## [7.5.0.0] (Unreleased)
 
 ### Features

--- a/libs/render_delegate/node_graph.h
+++ b/libs/render_delegate/node_graph.h
@@ -194,7 +194,7 @@ protected:
         /// @param terminalName Name of the terminal.
         /// @param terminal Arnold node at the terminal.
         /// @return True if the terminal has changed, false otherwise.
-        bool UpdateTerminal(const TfToken& terminalName, AtNode* terminal)
+        bool UpdateTerminal(const TfToken& terminalName, AtNode* terminal, AtNode*& oldTerminal)
         {
             // TODO if a node changes and it was stored in a terminal, 
             // it needs to be removed from this list
@@ -205,7 +205,7 @@ protected:
                 terminals.push_back({terminalName, terminal});
                 return true;
             } else {
-                auto* oldTerminal = it->second;
+                oldTerminal = it->second;
                 it->second = terminal;
                 return oldTerminal != terminal;
             }


### PR DESCRIPTION
**Changes proposed in this pull request**
When we update a terminal and we see that the terminal node has changed, we call `AiNodeReplace` so that arnold replaces the shader connection in all assigned geometries without having to go through another `Sync` call.
I could have called it directly, but I don't think we maintain properly the terminals when a node is deleted, so I add a loop over `_previousNodes` to ensure this node still exists in the scene, and to avoid a crash.

**Issues fixed in this pull request**
Fixes #2547
