### PR TITLE
Fix regression in husk with dataWindowNDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [usd#2557](https://github.com/Autodesk/arnold-usd/issues/2557) - Fix regression when a geometry has an instancer without any instances
 - [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
 - [usd#2536](https://github.com/Autodesk/arnold-usd/issues/2536) - ArnoldUsd procedural filename is not reported as an asset
+- [usd#2561](https://github.com/Autodesk/arnold-usd/issues/2561) - Fix regression in husk with dataWindow NDC
 
 ## [7.4.5.0] 2026-02-10
 

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -1095,7 +1095,19 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
             aovShaders.empty()
                 ? AiArray(0, 1, AI_TYPE_NODE)
                 : AiArrayConvert(static_cast<uint32_t>(aovShaders.size()), 1, AI_TYPE_NODE, aovShaders.data()));
-        clearBuffers(_renderBuffers, true, width, height);
+        int bufferWidth = width;
+        int bufferHeight = height;
+        if (hasWindowNDC) {
+            int regionMinX = AiNodeGetInt(options, str::region_min_x);
+            int regionMaxX = AiNodeGetInt(options, str::region_max_x);
+            int regionMinY = AiNodeGetInt(options, str::region_min_y);
+            int regionMaxY = AiNodeGetInt(options, str::region_max_y);
+            if (regionMaxX - regionMinX > 0 && regionMaxY - regionMinY > 0) {
+                bufferWidth = regionMaxX - regionMinX + 1;
+                bufferHeight = regionMaxY - regionMinY + 1;
+            }                
+        }
+        clearBuffers(_renderBuffers, true, bufferWidth, bufferHeight);
     }
 
     // Check if hydra still has pending changes that will be processed in the next iteration.


### PR DESCRIPTION
**Changes proposed in this pull request**
In hydra "raster" product types, the render buffer was being reset to the width/height, without taking into account the region min / max

**Issues fixed in this pull request**
Fixes #2561 
