### PR TITLE
Ignore assets from render settings when the scene is loaded in a procedural

### DIFF
--- a/plugins/procedural/asset_utils.cpp
+++ b/plugins/procedural/asset_utils.cpp
@@ -559,7 +559,7 @@ inline bool GetIgnoreMissingFromDependency(const USDDependency& dep)
  * The function collects all dependencies 
  * and converts them to Arnold assets.
  */
-bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets)
+bool CollectSceneAssets(const std::string& filename, bool isProcedural, std::vector<AtAsset*>& assets)
 {
     // open the scene file
     UsdStageRefPtr stage = UsdStage::Open(filename);
@@ -576,6 +576,18 @@ bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& asse
 
     // collect dependencies from the USD scene
     std::vector<USDDependency> dependencies = CollectDependencies(stage);
+
+    // if the scene is loaded as a procedural, we need to ignore the render settings
+    // only cameras, lights, shapes, shaders and operators are permitted
+    if (isProcedural)
+    {
+        std::vector<USDDependency> filtered;
+        std::copy_if(dependencies.begin(), dependencies.end(), std::back_inserter(filtered),
+            [](const USDDependency& dep) {
+                return dep.primTypeName != TfToken("RenderSettings");
+            });
+        dependencies = std::move(filtered);
+    }
 
     // log dependencies
     for (const USDDependency& dep : dependencies)

--- a/plugins/procedural/asset_utils.h
+++ b/plugins/procedural/asset_utils.h
@@ -77,7 +77,7 @@ std::vector<USDDependency> CollectDependencies(UsdStageRefPtr stage);
 /**
  * Returns all assets found in the given USD scene. 
  */
-bool CollectSceneAssets(const std::string& filename, std::vector<AtAsset*>& assets);
+bool CollectSceneAssets(const std::string& filename, bool isProcedural, std::vector<AtAsset*>& assets);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/plugins/procedural/main.cpp
+++ b/plugins/procedural/main.cpp
@@ -577,9 +577,13 @@ scene_write
 // static AtArray* SceneGetAssets(const char* filename, const AtParamValueMap* params)
 scene_get_assets
 {
+    bool isProcedural = false;
+    if (params)
+        AiParamValueMapGetBool(params, AtString("is_procedural"), &isProcedural);
+
     // collect assets from the scene
     std::vector<AtAsset*> assets;
-    CollectSceneAssets(filename, assets);
+    CollectSceneAssets(filename, isProcedural, assets);
 
     if (assets.empty())
         return nullptr;


### PR DESCRIPTION
**Changes proposed in this pull request**
Arnold can query assets of usd scenes that are loaded in an Arnold Usd procedural. In that case, not the entire scene is loaded, only shapes, lights, cameras and shaders. Therefore we need to ignore assets that are not relevant in this context, such as OCIO config defined in the render settings.
The PR also caches the primitive type name in the USDDependency class to simplify the implementation.

**Issues fixed in this pull request**
Fixes ARNOLD-17513
