### PR TITLE
Fix crashes when a render delegate is deleted while others are rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
+- [usd#2566](https://github.com/Autodesk/arnold-usd/issues/2566) - Fixed crashes when a render delegate is deleted while another is rendering
 
 ## [7.5.0.0] (Unreleased)
 

--- a/libs/render_delegate/nodes/nodes.cpp
+++ b/libs/render_delegate/nodes/nodes.cpp
@@ -67,11 +67,4 @@ void hdArnoldInstallNodes()
     }
 }
 
-void hdArnoldUninstallNodes()
-{
-    for (const auto& it : builtInNodes()) {
-        AiNodeEntryUninstall(it.name);
-    }
-}
-
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/libs/render_delegate/nodes/nodes.h
+++ b/libs/render_delegate/nodes/nodes.h
@@ -75,7 +75,4 @@ struct DriverMainData {
 /// Installs Arnold nodes that are used by the Render Delegate.
 void hdArnoldInstallNodes();
 
-/// Uninstalls Arnold nodes that are used by the Render Delegate.
-void hdArnoldUninstallNodes();
-
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -830,7 +830,6 @@ private:
     TfToken _context;
     bool _isBatch = false; // are we in a batch rendering context (e.g. Husk)
     int _verbosityLogFlags = AI_LOG_WARNINGS | AI_LOG_ERRORS;
-    bool _isArnoldActive = false;
     std::unordered_set<AtString, AtStringHash> _cryptomatteDrivers;
     std::string _outputOverride;
     int _mask = AI_NODE_ALL;  // mask for node types to be translated


### PR DESCRIPTION
A render delegate should not uninstall any nodes, as this can instantaneously delete nodes of this type from other universes. This was happening with the HdArnoldDriverMain driver node, which ended up being deleted while another render was in progress. 
Also, in general it's better not to call AiEnd at all from the render delegate. There could be situations where this would lead to crashes. For example create a first delegate that will call AiBegin and set _isArnoldActive = true, then create a second one, then delete the first. This would call AiEnd while the second is still rendering. 

**Issues fixed in this pull request**
Fixes #2566

**Additional context**
Add any other context or screenshots about the pull request here.
