### PR TITLE
Better support for changing the root shader in IPR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
 - [usd#2566](https://github.com/Autodesk/arnold-usd/issues/2566) - Fixed crashes when a render delegate is deleted while another is rendering
+- [usd#2568](https://github.com/Autodesk/arnold-usd/issues/2568) - Changing the root shader in IPR is not updated when it was present in the previous shading tree 
 
 ## [7.5.0.0] (Unreleased)
 

--- a/libs/render_delegate/node_graph.cpp
+++ b/libs/render_delegate/node_graph.cpp
@@ -212,13 +212,22 @@ void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
                     AiUniverseCacheFlush(_renderDelegate->GetUniverse(), AI_CACHE_BACKGROUND);
                 }
                 if (nodeGraphChanged && node && oldTerminal && oldTerminal != node) {
-                    for (const auto& previousNode : _previousNodes) {
-                        if (previousNode.second == oldTerminal) {
-                            // Tell arnold to replace all links to the previous node with links to the new node
-                            AiNodeReplace(oldTerminal, node, false);
-                            break;
+                    
+                    auto replaceOldTerminal = [&](std::unordered_map<std::string, AtNode*> &nodesList) -> bool {
+                        for (const auto& n : nodesList) {
+                            if (n.second == oldTerminal) {
+                                // Tell arnold to replace all links to the previous node with links to the new node
+                                AiNodeReplace(oldTerminal, node, false);
+                                return true;
+                            }
                         }
-                    }
+                        return false;
+                    };                        
+
+                    // Search for the node to be replaced in the previous nodes list, 
+                    // but also in the new one, in case the old is still part of the shading tree #2568
+                    if (!replaceOldTerminal(_previousNodes))
+                        replaceOldTerminal(_nodes);
                 }
             }
             // Loop through previous AtNodes that were created for this node graph.


### PR DESCRIPTION
**Changes proposed in this pull request**
In the code handling interactive changes of the root shader, we were assuming that the old shader was no longer in the shading tree, which is not necessarily true. So now we search in both lists. 

Note that the reason we search in those list in the first place is to ensure we're not calling AiNodeReplace on a node that was previously deleted for some reason. In theory this is not supposed to happen but it would cause a crash if it did

**Issues fixed in this pull request**
Fixes #2568
