### PR TITLE
Arnold product types not working if drivers:parameter:aov:name is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+- [usd#2572](https://github.com/Autodesk/arnold-usd/issues/2572) - Arnold product types not working if drivers:parameter:aov:name is not defined
 - [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
 - [usd#2566](https://github.com/Autodesk/arnold-usd/issues/2566) - Fixed crashes when a render delegate is deleted while another is rendering
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -995,8 +995,11 @@ void HdArnoldRenderDelegate::_ParseDelegateRenderProducts(const VtValue& value)
                         TfToken arnoldFormatToken = VtValue::Cast<TfToken>(*arnoldFormat).UncheckedGet<TfToken>();
                         renderVar.format = _GetHdFormatFromToken(arnoldFormatToken);
                     }
-                    // Any other cases should have good/reasonable defaults.
-                    if (!renderVar.sourceName.empty() && !renderVar.name.empty()) {
+
+                    if (!renderVar.sourceName.empty()) {
+                        // if drivers:parameters:aov:name is not defined, use sourceName instead #2572
+                        if (renderVar.name.empty())
+                            renderVar.name = renderVar.sourceName;
                         product.renderVars.emplace_back(std::move(renderVar));
                     }
                 }


### PR DESCRIPTION
When the attribute `drivers:parameter:aov:name` is not set in a render product that has the arnold product type, we use `sourceName` as being the AOV name in order to skip the render product

**Issues fixed in this pull request**
Fixes #2572
