### PR TITLE
Fix dependency cache

### DIFF
--- a/plugins/procedural/asset_utils.cpp
+++ b/plugins/procedural/asset_utils.cpp
@@ -171,9 +171,11 @@ inline void AddDependency(const std::string& ref, USDDependency::Type type,
     std::string resolvedPath;
 
     // the reference was already processed, use the resolved paths
-    if (data.seenReferences.find(ref) != data.seenReferences.end())
+    std::string layerName = data.layer ? data.layer->GetIdentifier() : std::string();
+    std::string refId = layerName + "#" + ref;
+    if (data.seenReferences.find(refId) != data.seenReferences.end())
     {
-        auto refPaths = data.seenReferences[ref];
+        auto refPaths = data.seenReferences[refId];
         anchoredPath = refPaths.first;
         resolvedPath = refPaths.second;
     }
@@ -191,7 +193,7 @@ inline void AddDependency(const std::string& ref, USDDependency::Type type,
             if (!relativeToRoot.empty() && relativeToRoot.at(0) != '.')
                 anchoredPath = relativeToRoot;
         }
-        data.seenReferences[ref] = std::make_pair(anchoredPath, resolvedPath);
+        data.seenReferences[refId] = std::make_pair(anchoredPath, resolvedPath);
     }
 
     // create a dependency


### PR DESCRIPTION
**Changes proposed in this pull request**
We were storing only the reference in our dependency cache, which is not enough to identify a dependency. The PR adds the layer ID to the key as well.

**Issues fixed in this pull request**
Fixes #2578
