### PR TITLE
String per-instance primvars cannot resolve indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [usd#2547](https://github.com/Autodesk/arnold-usd/issues/2547) - Changing material terminal is not updated with Hydra 2
 - [usd#2566](https://github.com/Autodesk/arnold-usd/issues/2566) - Fixed crashes when a render delegate is deleted while another is rendering
 - [usd#2568](https://github.com/Autodesk/arnold-usd/issues/2568) - Changing the root shader in IPR is not updated when it was present in the previous shading tree 
+- [usd#2580](https://github.com/Autodesk/arnold-usd/issues/2580) - String per-instance primvars cannot resolve indices
 
 ## [7.5.0.0] (Unreleased)
 

--- a/libs/common/shape_utils.cpp
+++ b/libs/common/shape_utils.cpp
@@ -327,7 +327,7 @@ bool FlattenIndexedValue(const VtValue& in, const VtIntArray& idx, VtValue& out)
         return false;
 
     return _FlattenIndexedValue<float, double, GfVec2f, GfVec2d, GfVec3f, 
-                GfVec3d, GfVec4f, GfVec4d, int, unsigned int, unsigned char, bool,
+                GfVec3d, GfVec4f, GfVec4d, int, unsigned int, unsigned char, bool, std::string,
                 TfToken, GfHalf, GfVec2h, GfVec3h, GfVec4h, GfMatrix4f, GfMatrix4d>(in, idx, out);
 
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
We simply had to add `std::string` to the list of primvar types that we can flatten if they have per-instance indices

**Issues fixed in this pull request**
Fixes #2580

