### PR TITLE
Fix resolving Arnold-specific relative paths

### DIFF
--- a/plugins/procedural/asset_utils.cpp
+++ b/plugins/procedural/asset_utils.cpp
@@ -157,6 +157,36 @@ struct DependencyData
 
 void TraversePrimSpecs(const SdfPrimSpecHandle& prim, DependencyData& data);
 
+bool GetAttributeCustomDataBool(const SdfLayerHandle& layer, const SdfPath& attrPath, 
+    const TfToken& key, bool defaultValue)
+{
+    if (!layer || !attrPath.IsPropertyPath())
+        return defaultValue;
+
+    SdfSpecHandle spec = layer->GetObjectAtPath(attrPath);
+    SdfAttributeSpecHandle attr = TfDynamic_cast<SdfAttributeSpecHandle>(spec);
+    if (!attr)
+        return defaultValue;
+
+    VtDictionary dict = attr->GetCustomData();
+
+    auto it = dict.find(key);
+    if (it == dict.end())
+        return defaultValue;
+
+    VtValue& v = it->second;
+
+    // defined as bool 
+    if (v.IsHolding<bool>())
+        return v.UncheckedGet<bool>();
+
+    // defined as int
+    if (v.IsHolding<int>())
+        return v.UncheckedGet<int>() != 0;
+
+    return defaultValue;
+}
+
 /**
  * Adds the given dependency to our list.
  */
@@ -182,8 +212,24 @@ inline void AddDependency(const std::string& ref, USDDependency::Type type,
     else
     {
         // resolve the reference to an absolute path
-        std::string relRef = SdfComputeAssetPathRelativeToLayer(data.layer, ref);
-        resolvedPath = data.resolver.Resolve(relRef);
+        std::string refPath = SdfComputeAssetPathRelativeToLayer(data.layer, ref);
+        resolvedPath = data.resolver.Resolve(refPath);
+        // If USD can not resolve the path this could be an Arnold specific path, like UDIM.
+        // If the asset comes from a prim attribute, check if the "arnold_relative_path" metadata 
+        // is defined on an attribute, which means Arnold needs to resolve the relative path.
+        // If not defined, then use the absolute path returned by SdfComputeAssetPathRelativeToLayer.
+        if (resolvedPath.empty() && TfIsRelativePath(ref))
+        {
+            bool remap = true;
+            if (type == USDDependency::Type::Attribute)
+            {
+                bool isArnoldRelativePath = GetAttributeCustomDataBool(data.layer, attribute, TfToken("arnold_relative_path"), false);
+                remap = !isArnoldRelativePath;
+            }
+
+            if (remap)
+                resolvedPath = refPath;
+        }
         anchoredPath = ref;
         // convert a relative reference relative to the main scene
         if (!resolvedPath.empty() && TfIsRelativePath(ref))


### PR DESCRIPTION
**Changes proposed in this pull request**
There could be Arnold specific paths in the scene, such as UDIM textures, which USD can not resolve. If the path is relative, USD needs to first convert it to an absolute path via `SdfComputeAssetPathRelativeToLayer`, before passing it to Arnold. 

We now also handle the "arnold_relative_path" custom data. If it's defined, then we need to pass the relative path to Arnold.

**Issues fixed in this pull request**
Fixes ARNOLD-17588
