### PR TITLE
Arnold disabled nodes should not be authored to usd files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## [7.5.2.0] (Unreleased)
+
+### Bug Fixes
+
+- [usd#2582](https://github.com/Autodesk/arnold-usd/issues/2582) - Arnold-disabled nodes should not be authored to USD
+
 ## [7.5.1.0] (Unreleased)
 
 ### Features

--- a/libs/translator/writer/writer.cpp
+++ b/libs/translator/writer/writer.cpp
@@ -221,7 +221,7 @@ void UsdArnoldWriter::Write(const AtUniverse *universe)
  **/
 void UsdArnoldWriter::WritePrimitive(const AtNode *node)
 {
-    if (node == nullptr) {
+    if (node == nullptr || AiNodeIsDisabled(node)) {
         return;
     }
 


### PR DESCRIPTION
In the usd writer, we should skip arnold nodes that have been disabled with `AiNodeSetDisabled`

**Issues fixed in this pull request**
Fixes #2582
