### PR TITLE
Support custom implicit nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 - [usd#2569](https://github.com/Autodesk/arnold-usd/issues/2569) - Support husk tokens for frame replacement
 - [usd#2435](https://github.com/Autodesk/arnold-usd/issues/2435) - Report USD warning and errors as Arnold warning and errors.
+- [usd#2597](https://github.com/Autodesk/arnold-usd/issues/2597) - Export custom implicit shapes as ArnoldProceduralCustom primitives
 
 ### Bug Fixes
 

--- a/libs/translator/writer/registry.cpp
+++ b/libs/translator/writer/registry.cpp
@@ -128,6 +128,12 @@ UsdArnoldWriterRegistry::UsdArnoldWriterRegistry(bool writeBuiltin)
             entryName != "alembic" && entryName != "usd") {
             // For custom procedurals, we want a dedicated schema "ArnoldProceduralCustom"
             RegisterWriter(entryName, new UsdArnoldWriteProceduralCustom(entryName));
+        } else if (
+            AiNodeEntryGetType(nodeEntry) == AI_NODE_SHAPE &&
+            AiNodeEntryGetDerivedType(nodeEntry) == AI_NODE_SHAPE_IMPLICIT && entryName != "volume_implicit" &&
+            entryName != "implicit") {
+            // For custom implicit nodes, we use "ArnoldProceduralCustom"
+            RegisterWriter(entryName, new UsdArnoldWriteProceduralCustom(entryName));
         } else {
             // Generic writer for arnold nodes.
             usdName = std::string("Arnold") + usdName;


### PR DESCRIPTION
**Changes proposed in this pull request**
In order to support custom implicit nodes, we start by using ArnoldProceduralCustom schemas. 
In the long term we could use a separate schema, or rename it as a more generic ArnoldCustomShape , but for now we can unblock things using this existing schema

**Issues fixed in this pull request**
Fixes #2597


**Additional context**
Add any other context or screenshots about the pull request here.
