### PR TITLE
HTOA-2655 | | Houdini op: / opdef: path support

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -75,6 +75,7 @@ ASTR2(constantString, "constant STRING");
 ASTR2(deformKeys, "arnold:deform_keys");
 ASTR2(houdiniFps, "houdini:fps");
 ASTR2(houdiniFrame, "houdini:frame");
+ASTR2(houdiniCopTextureChanged, "houdini:cop_texture_changed");
 ASTR2(hydraPrimId, "hydra_primId");
 ASTR2(inputs_code, "inputs:code");
 ASTR2(inputs_file, "inputs:file");

--- a/libs/render_delegate/node_graph.cpp
+++ b/libs/render_delegate/node_graph.cpp
@@ -451,10 +451,32 @@ AtNode* HdArnoldNodeGraph::ReadMaterialNetwork(const HdMaterialNetwork& network,
         inputAttrs.reserve(node.parameters.size() + ((connections) ? connections->size() : size_t(0)));
         // build the input attributes map, where they keys are the attribute names.
         for (const auto& p : node.parameters) {
-            // Store this attribute VtValue
+            std::string val = VtValueGetString(p.second);
+            if (val.substr(0, 3) == "op:") {
+                // Strip any UDIM/tile suffix that Houdini's MaterialX system appends
+                // (e.g. "op:/stage/copnet2/OUT[1]" -> "op:/stage/copnet2/OUT").
+                auto bracket = val.rfind('[');
+                std::string cleanPath = (bracket != std::string::npos) ? val.substr(0, bracket) : val;
+                // Pre-register with OIIO so MaterialX/OSL shaders that bypass
+                // AiTextureHandleAccess can still find the creator.
+                AiTexturePreregisterSchemeFile(cleanPath.c_str());
+                inputAttrs[p.first].value = VtValue(cleanPath);
+                continue;
+            }
+            if (val.find("opdef:") != std::string::npos) {
+                // Strip any @...@ wrappers before storing so Arnold's prefix matching fires.
+                std::string cleanPath = val;
+                if (cleanPath.size() >= 2 && cleanPath.front() == '@' && cleanPath.back() == '@')
+                    cleanPath = cleanPath.substr(1, cleanPath.size() - 2);
+                // Pre-register with OIIO so MaterialX/OSL shaders that bypass
+                // AiTextureHandleAccess can still find the creator.
+                AiTexturePreregisterSchemeFile(cleanPath.c_str());
+                inputAttrs[p.first].value = VtValue(cleanPath);
+                continue;
+            }
             inputAttrs[p.first].value = p.second;
             if (isCameraProjection && p.first == str::t_camera) {
-                _renderDelegate->TrackDependencies(GetId(), 
+                _renderDelegate->TrackDependencies(GetId(),
                     HdArnoldRenderDelegate::PathSetWithDirtyBits {
                     {SdfPath(VtValueGetString(p.second)), HdChangeTracker::AllDirty}
                     });

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -680,6 +680,16 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         // We want to restart a new render in that case.
         _renderParam->Restart();
     }
+    
+    // See the HDK hydra docs for more details
+    //   https://www.sidefx.com/docs/hdk/_h_d_k__u_s_d_hydra.html#HDK_USDHydraCopTextures
+    if (_key == str::t_houdiniCopTextureChanged) {
+        // COP textures need updating, flush the texture cache to trigger a refresh
+        // of all the image_cop nodes
+        _renderParam->Pause();
+        AiUniverseCacheFlush(_universe, AI_CACHE_TEXTURE);
+        _renderParam->Restart();
+    }
 
     // Special setting that describes custom output, like deep AOVs or other arnold drivers #1422.
     if (_key == _tokens->delegateRenderProducts) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Handle `houdini:cop_texture_changed` render var changes - this will trigger a texture flush and automatically invoke the op: texture plugin update in htoa

**Issues fixed in this pull request**
Fixes #
Fixes #

**Additional context**
Add any other context or screenshots about the pull request here.
