### PR TITLE
Add mtoa scene index plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+- [usd#2619](https://github.com/Autodesk/arnold-usd/issues/2619) - Add MtoA scene index plugin for MayaHydra support of custom attributes
 - [usd#2583](https://github.com/Autodesk/arnold-usd/issues/2583) - Support nested instancers with lightweight shape instancing
 - [usd#2594](https://github.com/Autodesk/arnold-usd/issues/2594) - Use a global map for shared arrays
 - [usd#2549](https://github.com/Autodesk/arnold-usd/issues/2549) - Support matte in hydra2 render passes

--- a/SConstruct
+++ b/SConstruct
@@ -119,6 +119,7 @@ vars.AddVariables(
     BoolVariable('BUILD_NDR_PLUGIN', 'Whether or not to build the node registry plugin.', True),
     BoolVariable('BUILD_USD_IMAGING_PLUGIN', 'Whether or not to build the usdImaging plugin.', True),
     BoolVariable('BUILD_SCENE_INDEX_PLUGIN', 'Whether or not to build the scene index plugin.', False),
+    BoolVariable('MTOA_BUILD', 'Build MtoA-specific scene index plugin.', False),
     BoolVariable('BUILD_PROCEDURAL', 'Whether or not to build the arnold procedural.', True),
     BoolVariable('BUILD_TESTSUITE', 'Whether or not to build the testsuite.', True),
     BoolVariable('BUILD_DOCS', 'Whether or not to build the documentation.', True),

--- a/cmake/utils/build.cmake
+++ b/cmake/utils/build.cmake
@@ -138,6 +138,11 @@ endfunction()
 function(install_sceneindex_arnold_pluginfo LIB_PATH PLUGINFO CONFIG_ROOT)
     # LIB_PATH is used in the plugInfo.json.in, do not rename
     set(LIB_EXTENSION ${CMAKE_SHARED_LIBRARY_SUFFIX})
+    if (MTOA_BUILD)
+        set(MTOA_ENTRY ",\n                    \"HdArnoldMtoaSceneIndexPlugin\" : {\n                        \"bases\": [\"HdSceneIndexPlugin\"],\n                        \"loadWithRenderer\": \"Arnold\",\n                        \"priority\": 0,\n                        \"displayName\": \"Arnold: MtoA compatibility\"\n                    }")
+    else()
+        set(MTOA_ENTRY "")
+    endif()
     configure_file(
         "${SCENEINDEXARNOLD_PLUGINFO_SRC}"
         "${PLUGINFO}"

--- a/cmake/utils/options.cmake
+++ b/cmake/utils/options.cmake
@@ -51,6 +51,11 @@ option(ENABLE_HYDRA_IN_USD_PROCEDURAL "Enable hydra in the procedural" ON)
 option(ENABLE_SHARED_ARRAYS "Enable using shared arrays" OFF)
 option(ENABLE_HYDRA2_RENDERSETTINGS "Enable using RenderSetting hydra prim" OFF)
 option(ENABLE_SCENE_INDEX_IN_BUNDLE "Add the scene index filters in the bundle" OFF)
+option(MTOA_BUILD "Build MtoA-specific plugins (e.g. the ai<Name> primvar remap scene index)" OFF)
+if (MTOA_BUILD AND BUILD_BUNDLE)
+    # The MtoA primvar remap SIP is useful only if the scene index ships in the bundle.
+    set(ENABLE_SCENE_INDEX_IN_BUNDLE ON CACHE BOOL "Add the scene index filters in the bundle" FORCE)
+endif()
 option(HYDRA_NORMALIZE_DEPTH "If true, return a normalized depth by using the P AOV. Otherwise, simply return the Z AOV for the depth" OFF)
 
 set(USD_OVERRIDE_PLUGINPATH_NAME "PXR_PLUGINPATH_NAME" CACHE STRING "Override the plugin path name for the USD libraries. Used when running the testsuite with a static procedural")

--- a/libs/common/common_utils.cpp
+++ b/libs/common/common_utils.cpp
@@ -42,6 +42,21 @@ std::string ArnoldUsdMakeCamelCase(const std::string &in)
 }
 
 
+std::string ArnoldUsdMakeSnakeCase(const std::string &in)
+{
+    std::string out;
+    out.reserve(in.length() + 4);
+    for (size_t i = 0; i < in.length(); ++i) {
+        const unsigned char c = in[i];
+        if (i > 0 && c >= 'A' && c <= 'Z') {
+            out += '_';
+        }
+        out += static_cast<char>(tolower(c));
+    }
+    return out;
+}
+
+
 int ArnoldUsdGetLogVerbosityFromFlags(int flags)
 {
     // This isn't an exact mapping, as verbosity can't emcompass all possible

--- a/libs/common/common_utils.h
+++ b/libs/common/common_utils.h
@@ -51,6 +51,13 @@ static const int AI_NODE_IMAGER = AI_NODE_DRIVER;
 ARCH_HIDDEN
 std::string ArnoldUsdMakeCamelCase(const std::string &in);
 
+// convert from "CamelCase" or "camelCase" to "snake_case"
+// an underscore is inserted before each uppercase letter (except at the very
+// start of the string) and the letter is lowercased.
+//
+ARCH_HIDDEN
+std::string ArnoldUsdMakeSnakeCase(const std::string &in);
+
 template <typename F>
 ARCH_HIDDEN
 void ArnoldUsdCheckForSdfPathValue(const VtValue& value, F&& f)

--- a/plugins/bundle/CMakeLists.txt
+++ b/plugins/bundle/CMakeLists.txt
@@ -39,6 +39,10 @@ if (ENABLE_SCENE_INDEX_IN_BUNDLE)
 	target_compile_definitions(${BUNDLE_NAME} PUBLIC ENABLE_SCENE_INDEX=1)
 endif()
 
+if (MTOA_BUILD)
+	target_compile_definitions(${BUNDLE_NAME} PUBLIC MTOA_BUILD=1)
+endif()
+
 target_link_libraries(${BUNDLE_NAME} PRIVATE translator common usdImaging ndrObjects usdImagingArnoldObjects)
 target_link_libraries(${BUNDLE_NAME} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,render_delegate>")
   if (${USD_VERSION} VERSION_GREATER_EQUAL "0.25.5")

--- a/plugins/scene_index/CMakeLists.txt
+++ b/plugins/scene_index/CMakeLists.txt
@@ -26,6 +26,11 @@ set(HDR
     meshLightResolvingSIP.h
 )
 
+if (MTOA_BUILD)
+    list(APPEND SRC mtoaSIP.cpp)
+    list(APPEND HDR mtoaSIP.h)
+endif()
+
 # Add objects for the hydra procedural
 add_library(sceneIndexArnoldObjects OBJECT ${SRC})
 target_compile_definitions(sceneIndexArnoldObjects PRIVATE "HDSCENEINDEX_EXPORTS=1")
@@ -33,11 +38,17 @@ add_common_includes(TARGET_NAME sceneIndexArnoldObjects DEPENDENCIES common)
 if (BUILD_SCENE_INDEX_PLUGIN OR ENABLE_SCENE_INDEX_IN_BUNDLE)
     target_compile_definitions(sceneIndexArnoldObjects PUBLIC ENABLE_SCENE_INDEX=1)
 endif()
+if (MTOA_BUILD)
+    target_compile_definitions(sceneIndexArnoldObjects PUBLIC MTOA_BUILD=1)
+endif()
 
 # If we want a sceneIndexArnold shared plugin
 if (BUILD_SCENE_INDEX_PLUGIN)
     if (NOT BUILD_WITH_USD_STATIC)
         add_library(sceneIndexArnold SHARED ${SRC})
+        if (MTOA_BUILD)
+            target_compile_definitions(sceneIndexArnold PRIVATE MTOA_BUILD=1)
+        endif()
 
         if (BUILD_HEADERS_AS_SOURCES)
             target_sources(sceneIndexArnold PRIVATE ${HDR})

--- a/plugins/scene_index/SConscript
+++ b/plugins/scene_index/SConscript
@@ -32,6 +32,10 @@ source_files = [
     'renderPassSIP.cpp',
 ]
 
+if local_env.get('MTOA_BUILD'):
+    source_files.append('mtoaSIP.cpp')
+    local_env.Append(CPPDEFINES=['MTOA_BUILD'])
+
 if not system.is_windows:
     local_env.Append(CXXFLAGS = Split('-fPIC'))
     local_env.Append(CXXFLAGS = Split('-Wno-deprecated -Wno-deprecated-declarations -Wno-deprecated-builtins'))

--- a/plugins/scene_index/mtoaSIP.cpp
+++ b/plugins/scene_index/mtoaSIP.cpp
@@ -1,0 +1,184 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "mtoaSIP.h"
+
+#if defined(ENABLE_SCENE_INDEX) && defined(MTOA_BUILD)
+
+#include <pxr/base/tf/token.h>
+#include <pxr/imaging/hd/containerDataSourceEditor.h>
+#include <pxr/imaging/hd/dataSourceLocator.h>
+#include <pxr/imaging/hd/filteringSceneIndex.h>
+#include <pxr/imaging/hd/primvarsSchema.h>
+#include <pxr/imaging/hd/retainedDataSource.h>
+#include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+
+#include <common_utils.h>
+
+#include <cctype>
+#include <string>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens, ((sceneIndexPluginName, "HdArnoldMtoaSceneIndexPlugin")));
+
+TF_REGISTRY_FUNCTION(TfType) { HdSceneIndexPluginRegistry::Define<HdArnoldMtoaSceneIndexPlugin>(); }
+
+TF_REGISTRY_FUNCTION(HdSceneIndexPlugin)
+{
+    const HdSceneIndexPluginRegistry::InsertionPhase insertionPhase = 0;
+
+    HdSceneIndexPluginRegistry::GetInstance().RegisterSceneIndexForRenderer(
+        "Arnold", _tokens->sceneIndexPluginName, nullptr, insertionPhase,
+        HdSceneIndexPluginRegistry::InsertionOrderAtStart);
+}
+
+namespace {
+
+// Matches an MtoA-style primvar name: starts with "ai" followed by an
+// uppercase letter. Rejects "ai_foo", "ai2", "aifoo", etc.
+inline bool _IsMtoaAiName(const TfToken& name)
+{
+    const std::string& s = name.GetString();
+    return s.size() >= 3 && s[0] == 'a' && s[1] == 'i' && s[2] >= 'A' && s[2] <= 'Z';
+}
+
+// aiSubdivIterations -> arnold:subdiv_iterations
+// (The "primvars:" scope is a USD-side namespace that UsdImaging strips when
+// translating to Hydra, so the render delegate expects the plain "arnold:"
+// prefix on primvars inside HdPrimvarsSchema.)
+TfToken _RemapMtoaAiName(const TfToken& name)
+{
+    const std::string& s = name.GetString();
+    std::string stripped = s.substr(2);
+    return TfToken(std::string("arnold:") + ArnoldUsdMakeSnakeCase(stripped));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// A data source wrapping a prim. When "primvars" is requested we overlay a
+// rewritten primvars container; other fields pass through untouched.
+///////////////////////////////////////////////////////////////////////////////
+class _MtoaPrimvarRemapDataSource : public HdContainerDataSource {
+public:
+    HD_DECLARE_DATASOURCE(_MtoaPrimvarRemapDataSource);
+
+    TfTokenVector GetNames() override { return _inputPrimDs ? _inputPrimDs->GetNames() : TfTokenVector{}; }
+
+    HdDataSourceBaseHandle Get(const TfToken& name) override
+    {
+        if (!_inputPrimDs) {
+            return nullptr;
+        }
+        HdDataSourceBaseHandle result = _inputPrimDs->Get(name);
+        if (name == HdPrimvarsSchemaTokens->primvars) {
+            if (HdPrimvarsSchema primvars = HdPrimvarsSchema::GetFromParent(_inputPrimDs)) {
+                return _RemapPrimvars(primvars);
+            }
+        }
+        return result;
+    }
+
+private:
+    _MtoaPrimvarRemapDataSource(const HdContainerDataSourceHandle& inputDs) : _inputPrimDs(inputDs) {}
+
+    HdDataSourceBaseHandle _RemapPrimvars(HdPrimvarsSchema primvars)
+    {
+        HdContainerDataSourceEditor editor(primvars.GetContainer());
+        for (const TfToken& name : primvars.GetPrimvarNames()) {
+            if (!_IsMtoaAiName(name)) {
+                continue;
+            }
+            const TfToken remapped = _RemapMtoaAiName(name);
+            // If a primvar already exists at the target name, leave it alone
+            // rather than stomping on an authored value.
+            if (primvars.GetPrimvar(remapped)) {
+                continue;
+            }
+            HdPrimvarSchema src = primvars.GetPrimvar(name);
+            editor.Overlay(
+                HdDataSourceLocator(remapped),
+                HdPrimvarSchema::Builder()
+                    .SetPrimvarValue(src.GetPrimvarValue())
+                    .SetInterpolation(src.GetInterpolation())
+                    .SetRole(src.GetRole())
+                    .Build());
+            editor.Set(HdDataSourceLocator(name), HdBlockDataSource::New());
+        }
+        return editor.Finish();
+    }
+
+    HdContainerDataSourceHandle _inputPrimDs;
+};
+
+TF_DECLARE_REF_PTRS(_MtoaSceneIndex);
+
+class _MtoaSceneIndex : public HdSingleInputFilteringSceneIndexBase {
+public:
+    static _MtoaSceneIndexRefPtr New(const HdSceneIndexBaseRefPtr& inputSceneIndex)
+    {
+        return TfCreateRefPtr(new _MtoaSceneIndex(inputSceneIndex));
+    }
+
+    HdSceneIndexPrim GetPrim(const SdfPath& primPath) const override
+    {
+        HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
+        if (!prim.dataSource) {
+            return prim;
+        }
+        // Compose MtoA-compat data-source wrappers here. New fixups layer on
+        // top by wrapping the previous result.
+        HdContainerDataSourceHandle ds = _MtoaPrimvarRemapDataSource::New(prim.dataSource);
+        return {prim.primType, ds};
+    }
+
+    SdfPathVector GetChildPrimPaths(const SdfPath& primPath) const override
+    {
+        return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
+    }
+
+protected:
+    _MtoaSceneIndex(const HdSceneIndexBaseRefPtr& inputSceneIndex)
+        : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+    {
+#if PXR_VERSION >= 2308
+        SetDisplayName("Arnold: MtoA compatibility");
+#endif
+    }
+
+    void _PrimsAdded(const HdSceneIndexBase&, const HdSceneIndexObserver::AddedPrimEntries& entries) override
+    {
+        if (_IsObserved()) {
+            _SendPrimsAdded(entries);
+        }
+    }
+
+    void _PrimsRemoved(const HdSceneIndexBase&, const HdSceneIndexObserver::RemovedPrimEntries& entries) override
+    {
+        if (_IsObserved()) {
+            _SendPrimsRemoved(entries);
+        }
+    }
+
+    void _PrimsDirtied(const HdSceneIndexBase&, const HdSceneIndexObserver::DirtiedPrimEntries& entries) override
+    {
+        if (_IsObserved()) {
+            _SendPrimsDirtied(entries);
+        }
+    }
+};
+
+} // namespace
+
+HdArnoldMtoaSceneIndexPlugin::HdArnoldMtoaSceneIndexPlugin() = default;
+HdArnoldMtoaSceneIndexPlugin::~HdArnoldMtoaSceneIndexPlugin() = default;
+
+HdSceneIndexBaseRefPtr HdArnoldMtoaSceneIndexPlugin::_AppendSceneIndex(
+    const HdSceneIndexBaseRefPtr& inputScene, const HdContainerDataSourceHandle& inputArgs)
+{
+    TF_UNUSED(inputArgs);
+    return _MtoaSceneIndex::New(inputScene);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // ENABLE_SCENE_INDEX && MTOA_BUILD

--- a/plugins/scene_index/mtoaSIP.h
+++ b/plugins/scene_index/mtoaSIP.h
@@ -1,0 +1,35 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <pxr/pxr.h>
+#if defined(ENABLE_SCENE_INDEX) && defined(MTOA_BUILD)
+
+#include <pxr/imaging/hd/sceneIndexPlugin.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class HdArnoldMtoaSceneIndexPlugin
+///
+/// MtoA-specific scene index fixups applied before the Arnold render delegate
+/// consumes the scene. Currently rewrites primvars whose name starts with
+/// "ai" followed by an uppercase letter (as emitted by MtoA, e.g.
+/// aiSubdivIterations) into the form the render delegate expects: snake_case
+/// with an "arnold:" prefix (e.g. arnold:subdiv_iterations). Additional
+/// MtoA-compat fixups can be layered into the same filtering scene index as
+/// the need arises.
+///
+class HdArnoldMtoaSceneIndexPlugin : public HdSceneIndexPlugin {
+public:
+    HdArnoldMtoaSceneIndexPlugin();
+    ~HdArnoldMtoaSceneIndexPlugin() override;
+
+protected:
+    HdSceneIndexBaseRefPtr _AppendSceneIndex(
+        const HdSceneIndexBaseRefPtr& inputScene, const HdContainerDataSourceHandle& inputArgs) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // ENABLE_SCENE_INDEX && MTOA_BUILD

--- a/plugins/scene_index/plugInfo.json.in
+++ b/plugins/scene_index/plugInfo.json.in
@@ -74,7 +74,7 @@
                         "loadWithRenderer": "Arnold",
                         "priority": 0,
                         "displayName": "Arnold: render passes"
-                    }
+                    }${MTOA_ENTRY}
                 }
             },
             "LibraryPath": "${LIB_PATH}${LIB_EXTENSION}",

--- a/tools/utils/configure.py
+++ b/tools/utils/configure.py
@@ -56,10 +56,23 @@ def configure_procedural_usd_imaging_plug_info(source, target, env):
         'REGISTER_ARNOLD_TYPES': register_arnold_types
     })
 
+_MTOA_ENTRY = (
+    ',\n                    "HdArnoldMtoaSceneIndexPlugin" : {\n'
+    '                        "bases": ["HdSceneIndexPlugin"],\n'
+    '                        "loadWithRenderer": "Arnold",\n'
+    '                        "priority": 0,\n'
+    '                        "displayName": "Arnold: MtoA compatibility"\n'
+    '                    }'
+)
+
+def _mtoa_entry(env):
+    return _MTOA_ENTRY if env.get('MTOA_BUILD') else ''
+
 def configure_scene_index_plug_info(source, target, env):
     configure(source, target, env, {
         'LIB_PATH' : '../sceneIndexArnold',
         'LIB_EXTENSION': system.LIB_EXTENSION,
+        'MTOA_ENTRY': _mtoa_entry(env),
     })
 
 def configure_procedural_scene_index_plug_info(source, target, env):
@@ -67,6 +80,7 @@ def configure_procedural_scene_index_plug_info(source, target, env):
     configure(source, target, env, {
         'LIB_PATH': '../../usd_proc',
         'LIB_EXTENSION': system.LIB_EXTENSION,
+        'MTOA_ENTRY': _mtoa_entry(env),
     })
 
 def configure_ndr_plug_info(source, target, env):


### PR DESCRIPTION
**Changes proposed in this pull request**
This PR adds a scene index plugin that will only be compiled through MtoA. It allows to convert maya-named arnold attributes (e.g. aiSubdivIterations) into the name expected in the render delegate (arnold:subdiv_iterations)

**Issues fixed in this pull request**
Fixes #2619
