### PR TITLE
MTOA-2714: Keep primvars on drivers

### DIFF
--- a/libs/common/rendersettings_utils.cpp
+++ b/libs/common/rendersettings_utils.cpp
@@ -18,6 +18,7 @@
 #include <pxr/usd/usd/primRange.h>
 #include <pxr/usd/usd/attribute.h>
 #include <pxr/usd/usdGeom/camera.h>
+#include <pxr/usd/usdGeom/primvarsAPI.h>
 
 #include <ai.h>
 
@@ -202,6 +203,24 @@ static inline void UsdArnoldNodeGraphAovConnection(AtNode *options, const UsdPri
     }
 }
 
+static void ReadPrimvarsAsUserData(const UsdPrim &prim, AtNode *node, const TimeSettings &time, ArnoldAPIAdapter &context)
+{
+    UsdGeomPrimvarsAPI primvarsAPI(prim);
+    if (!primvarsAPI)
+        return;
+
+    for (const UsdGeomPrimvar &primvar : primvarsAPI.GetAuthoredPrimvars()) {
+        if (TfStringStartsWith(primvar.GetName().GetString(), str::t_primvars_arnold.GetString()))
+            continue;
+
+        VtValue value;
+        if (!primvar.Get(&value, time.frame) || value.IsEmpty())
+            continue;
+
+        DeclareAndAssignParameter(node, primvar.GetPrimvarName(), str::t_constant, value, context);
+    }
+}
+
 // Encapsulate the logic to extract driver type and settings from a UsdProduct prim
 // The function can return nullptr if it wasn't able to find the driver
 AtNode * ReadDriverFromRenderProduct(const UsdRenderProduct &renderProduct, ArnoldAPIAdapter &context, const TimeSettings &time) {
@@ -254,6 +273,7 @@ AtNode * ReadDriverFromRenderProduct(const UsdRenderProduct &renderProduct, Arno
     }
     // Check if an imager is connected to this driver
     UsdArnoldNodeGraphConnection(driver, renderProductPrim, renderProductPrim.GetAttribute(TfToken(driverParamPrefix + std::string("input"))), "input", context, time);
+    ReadPrimvarsAsUserData(renderProductPrim, driver, time, context);
     return driver;
 }
 
@@ -312,6 +332,7 @@ AtNode * DeduceDriverFromFilename(const UsdRenderProduct &renderProduct, ArnoldA
                         context, paramType, arrayType);
         }
     }
+    ReadPrimvarsAsUserData(renderProductPrim, driver, time, context);
     return driver;
 }
 

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 
 #include <constant_strings.h>
+#include <parameters_utils.h>
 
 #include "camera.h"
 #include "config.h"
@@ -1114,6 +1115,15 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                 // Then we read parameters prefixed with arnold:{driverType}: (e.g. arnold:driver_exr:)
                 std::string driverPrefix = std::string("arnold:") + product.productType.GetString() + std::string(":");
                 _ReadNodeParameters(customProduct.driver, TfToken(driverPrefix.c_str()), product.settings, _renderDelegate);
+
+                // Read generic primvars as Arnold user data on the driver
+                for (const auto& setting : product.settings) {
+                    if (!TfStringStartsWith(setting.first, "primvars:") ||
+                        TfStringStartsWith(setting.first, "primvars:arnold:"))
+                        continue;
+                    TfToken name(setting.first.GetText() + 9); // strip "primvars:"
+                    DeclareAndAssignParameter(customProduct.driver, name, str::t_constant, setting.second, _renderDelegate->GetAPIAdapter());
+                }
 
                 // Arnold supports multiple deepexr settings per AOV, by setting the parameters
                 // layer_tolerance, layer_half_precision, layer_enable_filtering.

--- a/libs/render_delegate/render_settings.cpp
+++ b/libs/render_delegate/render_settings.cpp
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <string>
 #include "../common/rendersettings_utils.h"
+#include <parameters_utils.h>
 #include "camera.h"
 
 #include "render_delegate.h"
@@ -612,6 +613,16 @@ void HdArnoldRenderSettings::_UpdateRenderProducts(HdSceneDelegate* sceneDelegat
                 .Msg("Set driver parameter %s on %s\n", paramName.c_str(), driverNodeName);
         }
         
+        // Read generic primvars on the RenderProduct as Arnold user data on the driver
+        for (const auto& pair : productSettings) {
+            const std::string& settingName = pair.first;
+            if (!TfStringStartsWith(settingName, "primvars:") ||
+                TfStringStartsWith(settingName, "primvars:arnold:"))
+                continue;
+            TfToken name(settingName.substr(9)); // strip "primvars:"
+            DeclareAndAssignParameter(driver, name, str::t_constant, pair.second, renderDelegate->GetAPIAdapter());
+        }
+
         // If the driver was renamed using arnold:name, we want to use its new name
         driverNodeName = AiNodeGetName(driver);
         


### PR DESCRIPTION
**Check for and convert primvars to userdata for RenderProducts**
- 
- 
