### PR TITLE
Remove legacy code

### DIFF
--- a/libs/render_delegate/render_buffer.cpp
+++ b/libs/render_delegate/render_buffer.cpp
@@ -199,7 +199,6 @@ WriteBucketFunctionMap writeBucketFunctions{
 
 HdArnoldRenderBuffer::HdArnoldRenderBuffer(const SdfPath& id) : HdRenderBuffer(id)
 {
-    _hasUpdates.store(false, std::memory_order_release);
 }
 
 bool HdArnoldRenderBuffer::Allocate(const GfVec3i& dimensions, HdFormat format, bool multiSampled)
@@ -274,7 +273,6 @@ void HdArnoldRenderBuffer::WriteBucket(
     if (ye == yo) {
         return;
     }
-    _hasUpdates.store(true, std::memory_order_release);
     const auto dataWidth = (xe - xo);
     // Single component formats can be:
     //  - HdFormatUNorm8

--- a/libs/render_delegate/render_buffer.h
+++ b/libs/render_delegate/render_buffer.h
@@ -101,13 +101,7 @@ public:
     void WriteBucket(
         unsigned int bucketXO, unsigned int bucketYo, unsigned int bucketWidth, unsigned int bucketHeight,
         HdFormat format, const void* bucketData);
-
-    /// Return wether or not the buffer has any updates. The function also resets the internal counter tracking the
-    /// if there has been any updates.
-    ///
-    /// @return True if the buffer has any updates, false otherwise.
-    bool HasUpdates() { return _hasUpdates.exchange(false, std::memory_order_acq_rel); }
-
+    
     /// Utility class for storing render buffers.
     struct BufferDefinition {
         HdAovSettingsMap settings;              ///< Filter and AOV settings for the Render Buffer.
@@ -118,15 +112,7 @@ public:
 
         /// Default constructor.
         BufferDefinition() = default;
-
-        /// Constructor.
-        ///
-        /// @param _buffer Pointer to the HdArnoldRenderBuffer.
-        /// @param _settings Hash map storing the render settings.
-        BufferDefinition(HdArnoldRenderBuffer* _buffer, const HdAovSettingsMap& _settings)
-            : settings(_settings), buffer(_buffer)
-        {
-        }
+        
     };
 
 private:
@@ -140,7 +126,6 @@ private:
     unsigned int _height = 0;                        ///< Buffer height.
     HdFormat _format = HdFormat::HdFormatUNorm8Vec4; ///< Internal format of the buffer.
     bool _converged = false;                         ///< Store if the render buffer has converged.
-    std::atomic<bool> _hasUpdates;                   ///< If the render buffer has any updates.
 };
 
 using HdArnoldRenderBufferStorage =

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -829,9 +829,8 @@ private:
     bool _forceIgnoreMotionBlur = false;
     std::unordered_map<std::string, AtNode *> _nodeNames;
 
-    // We store a list of functions that must be run once all the prims are synced and have filled the 
-    // vectors like 
-    // They will be ran in the _Execute function
+    // We store a list of functions that must be run once all the prims are synced
+    // They will be ran in HasPendingChanges
     std::mutex _deferredFunctionCallsMutex;
     std::vector<std::function<void()>> _deferredFunctionCalls;
     HydraArnoldReader *_reader = nullptr;

--- a/libs/render_delegate/render_pass.cpp
+++ b/libs/render_delegate/render_pass.cpp
@@ -427,9 +427,6 @@ static std::string ResolveFilenameTokens(const std::string &in, float frameF)
 HdArnoldRenderPass::HdArnoldRenderPass(
     HdArnoldRenderDelegate* renderDelegate, HdRenderIndex* index, const HdRprimCollection& collection)
     : HdRenderPass(index, collection),
-      _fallbackColor(SdfPath::EmptyPath()),
-      _fallbackDepth(SdfPath::EmptyPath()),
-      _fallbackPrimId(SdfPath::EmptyPath()),
       _renderDelegate(renderDelegate)
 {
     auto* universe = _renderDelegate->GetUniverse();
@@ -466,26 +463,7 @@ HdArnoldRenderPass::HdArnoldRenderPass(
     AiNodeSetStr(_primIdReader, str::attribute, str::hydraPrimId);
     AiNodeLink(_primIdReader, str::aov_input, _primIdWriter);
 
-    // Even though we are not displaying the prim id buffer, we still need it to detect background pixels.
-    // clang-format off
-    _fallbackBuffers = {{HdAovTokens->color, {&_fallbackColor, {}}},
-                        {HdAovTokens->depth, {&_fallbackDepth, {}}},
-                        {HdAovTokens->primId, {&_fallbackPrimId, {}}}};
-    // clang-format on
-    _fallbackOutputs = AiArrayAllocate(3, 1, AI_TYPE_STRING);
-    // Setting up the fallback outputs when no
-    const auto beautyString =
-        TfStringPrintf("RGBA RGBA %s %s", AiNodeGetName(_defaultFilter), AiNodeGetName(_mainDriver));
-    const auto positionString =
-        TfStringPrintf("%s %s %s", _depthOutputValue, AiNodeGetName(_closestFilter), AiNodeGetName(_mainDriver));
-    const auto idString = TfStringPrintf(
-        "%s INT %s %s", str::hydraPrimId.c_str(), AiNodeGetName(_closestFilter), AiNodeGetName(_mainDriver));
-    AiArraySetStr(_fallbackOutputs, 0, beautyString.c_str());
-    AiArraySetStr(_fallbackOutputs, 1, positionString.c_str());
-    AiArraySetStr(_fallbackOutputs, 2, idString.c_str());
-    _fallbackAovShaders = AiArrayAllocate(1, 1, AI_TYPE_POINTER);
-    AiArraySetPtr(_fallbackAovShaders, 0, _primIdWriter);
-
+    
     const auto& config = HdArnoldConfig::GetInstance();
     AiNodeSetFlt(_camera, str::shutter_start, config.shutter_start);
     AiNodeSetFlt(_camera, str::shutter_end, config.shutter_end);
@@ -500,9 +478,6 @@ HdArnoldRenderPass::~HdArnoldRenderPass()
     _renderDelegate->DestroyArnoldNode(_mainDriver);
     _renderDelegate->DestroyArnoldNode(_primIdWriter);
     _renderDelegate->DestroyArnoldNode(_primIdReader);
-    // We are not assigning this array to anything, so needs to be manually destroyed.
-    AiArrayDestroy(_fallbackOutputs);
-    AiArrayDestroy(_fallbackAovShaders);
     
     for (auto& customProduct : _customProducts) {
         if (customProduct.driver != nullptr) {
@@ -857,10 +832,6 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
 
     // We are checking if the current aov bindings match the ones we already created, if not,
     // then rebuild the driver setup.
-    // If AOV bindings are empty, we are only setting up color and depth for basic opengl composition. This should
-    // not happen often.
-    // TODO(pal): Remove bindings to P and RGBA. Those are used for other buffers. Or add support for writing to
-    //  these in the driver.
     HdRenderPassAovBindingVector aovBindings = renderPassState->GetAovBindings();
     // These buffers are not supported, but we still need to allocate and set them up for hydra.
     aovBindings.erase(
@@ -891,8 +862,8 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
     const bool needsDelegateProductsUpdate = _renderDelegate->NeedsDelegateProductsUpdate();
     
     if (_RenderBuffersChanged(aovBindings) || needsDelegateProductsUpdate ||
-        _usingFallbackBuffers || updateAovs || updateImagers) {
-        _usingFallbackBuffers = false;
+        updateAovs || updateImagers) {
+        
         renderParam->Interrupt();
         if (_mainDriver)
             AiNodeResetParameter(_mainDriver, str::render_outputs);
@@ -1317,7 +1288,6 @@ void HdArnoldRenderPass::_Execute(const HdRenderPassStateSharedPtr& renderPassSt
                 buffer.second.buffer->SetConverged(_isConverged);
             }
         }
-        // If the buffers are empty, we have to blit the data from the fallback buffers to OpenGL.
     }
 }
 

--- a/libs/render_delegate/render_pass.h
+++ b/libs/render_delegate/render_pass.h
@@ -106,12 +106,6 @@ protected:
 
 private:
     HdArnoldRenderBufferStorage _renderBuffers;   ///< Render buffer storage.
-    HdArnoldRenderBufferStorage _fallbackBuffers; ///< Render buffer storage if there are no aov bindings.
-    HdArnoldRenderBuffer _fallbackColor;          ///< Color render buffer if there are no aov bindings.
-    HdArnoldRenderBuffer _fallbackDepth;          ///< Depth render buffer if there are no aov bindings.
-    HdArnoldRenderBuffer _fallbackPrimId;         ///< Prim ID buffer if there are no aov bindings.
-    AtArray* _fallbackOutputs;                    ///< AtArray storing the fallback outputs definitions.
-    AtArray* _fallbackAovShaders;                 ///< AtArray storing the fallback AOV shaders.
     std::vector<AtNode*> _aovShaders;             ///< Pointer to list of user aov shaders
 
     HdArnoldRenderDelegate* _renderDelegate; ///< Pointer to the Render Delegate.
@@ -152,7 +146,6 @@ private:
     GfVec4f _windowNDC =  GfVec4f(0.f, 0.f, 1.f, 1.f);
 
     bool _isConverged = false;          ///< State of the render convergence.
-    bool _usingFallbackBuffers = false; ///< If the render pass is using the fallback buffers.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
This PR removes dead code, that is no longer used.

1. _fallbackOutputs and _fallbackAovShaders
Built in the constructor, destroyed in the destructor, never read after 71dae5dba removed the aovBindings.empty() path.

    _fallbackOutputs = AiArrayAllocate(3, 1, AI_TYPE_STRING);
    ...
    AiArraySetPtr(_fallbackAovShaders, 0, _primIdWriter);
Same strings are rebuilt live when wiring Hydra AOV bindings; these arrays are redundant.

2. _usingFallbackBuffers
Only ever set to false; never true. The || _usingFallbackBuffers in the rebuild condition is always false — leftover from the removed fallback path.

3. BufferDefinition two-argument constructor (render_buffer.h)
Never called; only the default constructor + field assignment in _Execute is used.