### PR TITLE
Add scene index for custom maya nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Features
 
 - [usd#2645](https://github.com/Autodesk/arnold-usd/issues/2645) - Support ArnoldNodeGraph primitives when the usd files are referenced
-- [usd#2619](https://github.com/Autodesk/arnold-usd/issues/2619) - Add MtoA scene index plugin for MayaHydra support of custom attributes
+- [usd#2619](https://github.com/Autodesk/arnold-usd/issues/2619) - Add MtoA scene index plugin for MayaHydra support of custom attributes and nodes
 - [usd#2583](https://github.com/Autodesk/arnold-usd/issues/2583) - Support nested instancers with lightweight shape instancing
 - [usd#2594](https://github.com/Autodesk/arnold-usd/issues/2594) - Use a global map for shared arrays
 - [usd#2608](https://github.com/Autodesk/arnold-usd/issues/2608) - Implement preliminary support for ParticleField3DGaussianSplat.

--- a/plugins/scene_index/mtoaSIP.cpp
+++ b/plugins/scene_index/mtoaSIP.cpp
@@ -5,22 +5,45 @@
 
 #if defined(ENABLE_SCENE_INDEX) && defined(MTOA_BUILD)
 
+#include <pxr/base/gf/vec3f.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/base/vt/dictionary.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/containerDataSourceEditor.h>
 #include <pxr/imaging/hd/dataSourceLocator.h>
 #include <pxr/imaging/hd/filteringSceneIndex.h>
+#include <pxr/imaging/hd/overlayContainerDataSource.h>
 #include <pxr/imaging/hd/primvarsSchema.h>
 #include <pxr/imaging/hd/retainedDataSource.h>
 #include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/usd/usdLux/tokens.h>
 
 #include <common_utils.h>
 
 #include <cctype>
 #include <string>
+#include <unordered_set>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, ((sceneIndexPluginName, "HdArnoldMtoaSceneIndexPlugin")));
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+    ((sceneIndexPluginName, "HdArnoldMtoaSceneIndexPlugin"))
+    (mayaCustomDagNode)
+    (mayaNode)
+    (mayaTypeName)
+    (mayaAttributes)
+    (aiPhotometricLight)
+    (aiSkyDomeLight)
+    (aiAreaLight)
+    (aiStandIn)
+    (aiVolume)
+    ((ArnoldProcedural, "ArnoldProcedural"))
+    ((ArnoldVolume, "ArnoldVolume"))
+    ((arnoldFilename, "arnold:filename")));
 
 TF_REGISTRY_FUNCTION(TfType) { HdSceneIndexPluginRegistry::Define<HdArnoldMtoaSceneIndexPlugin>(); }
 
@@ -52,6 +75,266 @@ TfToken _RemapMtoaAiName(const TfToken& name)
     const std::string& s = name.GetString();
     std::string stripped = s.substr(2);
     return TfToken(std::string("arnold:") + ArnoldUsdMakeSnakeCase(stripped));
+}
+
+// Wraps an opaque VtValue as an HdSampledDataSource so it can be stored as a
+// primvar value without double-wrapping (unlike HdRetainedTypedSampledDataSource<VtValue>).
+class _VtValueDataSource : public HdSampledDataSource {
+public:
+    static HdSampledDataSourceHandle New(const VtValue& v)
+    {
+        return TfCreateRefPtr(new _VtValueDataSource(v));
+    }
+    bool GetContributingSampleTimesForInterval(float, float, std::vector<float>*) override { return false; }
+    VtValue GetValue(float) override { return _value; }
+
+private:
+    _VtValueDataSource(VtValue v) : _value(std::move(v)) {}
+    VtValue _value;
+};
+
+// Builds a "primvars" container data source from all "ai<Upper>..." entries in
+// mayaAttrs that are NOT listed in 'skip', remapping them via _RemapMtoaAiName.
+// Returns nullptr when there are no matching entries.
+HdDataSourceBaseHandle _BuildAiPrimvarsFromAttrs(
+    const VtDictionary& mayaAttrs, const std::unordered_set<std::string>& skip)
+{
+    std::vector<TfToken> names;
+    std::vector<HdDataSourceBaseHandle> sources;
+    for (const auto& [key, value] : mayaAttrs) {
+        if (skip.count(key))
+            continue;
+        const TfToken keyTok(key);
+        if (!_IsMtoaAiName(keyTok))
+            continue;
+        names.push_back(_RemapMtoaAiName(keyTok));
+        sources.push_back(
+            HdPrimvarSchema::Builder()
+                .SetPrimvarValue(_VtValueDataSource::New(value))
+                .SetInterpolation(
+                    HdPrimvarSchema::BuildInterpolationDataSource(HdPrimvarSchemaTokens->constant))
+                .Build());
+    }
+    if (names.empty())
+        return nullptr;
+    return HdRetainedContainerDataSource::New(names.size(), names.data(), sources.data());
+}
+
+// Translates a mayaCustomDagNode of type aiPhotometricLight to a sphereLight
+// prim with the standard UsdLux attribute mapping from the reference
+// maya-hydra custom-node-translation scene index.  Any "ai<Upper>..." attrs
+// not covered by the explicit mapping are passed through as primvars:arnold:*
+// so the render delegate can forward them to Arnold.
+HdSceneIndexPrim _TranslatePhotometricLight(
+    const HdSceneIndexPrim& inputPrim, const VtDictionary& mayaAttrs)
+{
+    auto getAttr = [&](const char* key, auto def) {
+        using T = decltype(def);
+        auto it = mayaAttrs.find(key);
+        if (it == mayaAttrs.end())
+            return def;
+        if (it->second.IsHolding<T>())
+            return it->second.UncheckedGet<T>();
+        if constexpr (std::is_same_v<T, float>) {
+            if (it->second.IsHolding<double>())
+                return static_cast<float>(it->second.UncheckedGet<double>());
+        }
+        return def;
+    };
+
+    const float       intensity   = getAttr("intensity",     1.0f);
+    const GfVec3f     color       = getAttr("color",         GfVec3f(1.0f));
+    const float       exposure    = getAttr("aiExposure",    0.0f);
+    const std::string iesFile     = getAttr("aiFilename",    std::string());
+    const float       radius      = getAttr("aiRadius",      0.0f);
+    const bool        normalize   = getAttr("aiNormalize",   true);
+    const float       diffuse     = getAttr("aiDiffuse",     1.0f);
+    const float       specular    = getAttr("aiSpecular",    1.0f);
+    const bool        castShadows = getAttr("aiCastShadows", true);
+    const GfVec3f     shadowColor = getAttr("aiShadowColor", GfVec3f(0.0f));
+
+    // Attributes consumed above — excluded from the catch-all ai primvar pass.
+    static const std::unordered_set<std::string> s_explicit{
+        "aiExposure", "aiFilename", "aiRadius",      "aiNormalize",
+        "aiDiffuse",  "aiSpecular", "aiCastShadows", "aiShadowColor"};
+
+    HdSceneIndexPrim result;
+    result.primType = HdPrimTypeTokens->sphereLight;
+
+    auto lightDs = HdRetainedContainerDataSource::New(
+        UsdLuxTokens->inputsIntensity,    HdRetainedTypedSampledDataSource<float>::New(intensity),
+        UsdLuxTokens->inputsColor,        HdRetainedTypedSampledDataSource<GfVec3f>::New(color),
+        UsdLuxTokens->inputsExposure,     HdRetainedTypedSampledDataSource<float>::New(exposure),
+        UsdLuxTokens->inputsShapingIesFile,
+                                          HdRetainedTypedSampledDataSource<SdfAssetPath>::New(SdfAssetPath(iesFile)),
+        UsdLuxTokens->inputsRadius,       HdRetainedTypedSampledDataSource<float>::New(radius),
+        UsdLuxTokens->inputsNormalize,    HdRetainedTypedSampledDataSource<bool>::New(normalize),
+        UsdLuxTokens->inputsDiffuse,      HdRetainedTypedSampledDataSource<float>::New(diffuse),
+        UsdLuxTokens->inputsSpecular,     HdRetainedTypedSampledDataSource<float>::New(specular),
+        UsdLuxTokens->inputsShadowEnable, HdRetainedTypedSampledDataSource<bool>::New(castShadows),
+        UsdLuxTokens->inputsShadowColor,  HdRetainedTypedSampledDataSource<GfVec3f>::New(shadowColor));
+
+    result.dataSource = HdOverlayContainerDataSource::New(lightDs, inputPrim.dataSource);
+
+    if (auto aiPrimvarsDs = _BuildAiPrimvarsFromAttrs(mayaAttrs, s_explicit)) {
+        result.dataSource = HdOverlayContainerDataSource::New(
+            HdRetainedContainerDataSource::New(HdPrimvarsSchemaTokens->primvars, aiPrimvarsDs),
+            result.dataSource);
+    }
+
+    return result;
+}
+
+HdSceneIndexPrim _TranslateSkyDomeLight(
+    const HdSceneIndexPrim& inputPrim, const VtDictionary& mayaAttrs)
+{
+    auto getAttr = [&](const char* key, auto def) {
+        using T = decltype(def);
+        auto it = mayaAttrs.find(key);
+        if (it == mayaAttrs.end())
+            return def;
+        if (it->second.IsHolding<T>())
+            return it->second.UncheckedGet<T>();
+        if constexpr (std::is_same_v<T, float>) {
+            if (it->second.IsHolding<double>())
+                return static_cast<float>(it->second.UncheckedGet<double>());
+        }
+        return def;
+    };
+
+    const float   intensity   = getAttr("intensity",     1.0f);
+    const GfVec3f color       = getAttr("color",         GfVec3f(1.0f));
+    const float   exposure    = getAttr("exposure",      0.0f);
+    const bool    normalize   = getAttr("aiNormalize",   true);
+    const float   diffuse     = getAttr("aiDiffuse",     1.0f);
+    const float   specular    = getAttr("aiSpecular",    1.0f);
+    const bool    castShadows = getAttr("aiCastShadows", true);
+    const GfVec3f shadowColor = getAttr("aiShadowColor", GfVec3f(0.0f));
+
+    static const std::unordered_set<std::string> s_explicit{
+        "aiNormalize", "aiDiffuse", "aiSpecular", "aiCastShadows", "aiShadowColor"};
+
+    HdSceneIndexPrim result;
+    result.primType = HdPrimTypeTokens->domeLight;
+
+    auto lightDs = HdRetainedContainerDataSource::New(
+        UsdLuxTokens->inputsIntensity,    HdRetainedTypedSampledDataSource<float>::New(intensity),
+        UsdLuxTokens->inputsColor,        HdRetainedTypedSampledDataSource<GfVec3f>::New(color),
+        UsdLuxTokens->inputsExposure,     HdRetainedTypedSampledDataSource<float>::New(exposure),
+        UsdLuxTokens->inputsNormalize,    HdRetainedTypedSampledDataSource<bool>::New(normalize),
+        UsdLuxTokens->inputsDiffuse,      HdRetainedTypedSampledDataSource<float>::New(diffuse),
+        UsdLuxTokens->inputsSpecular,     HdRetainedTypedSampledDataSource<float>::New(specular),
+        UsdLuxTokens->inputsShadowEnable, HdRetainedTypedSampledDataSource<bool>::New(castShadows),
+        UsdLuxTokens->inputsShadowColor,  HdRetainedTypedSampledDataSource<GfVec3f>::New(shadowColor));
+
+    result.dataSource = HdOverlayContainerDataSource::New(lightDs, inputPrim.dataSource);
+
+    if (auto aiPrimvarsDs = _BuildAiPrimvarsFromAttrs(mayaAttrs, s_explicit)) {
+        result.dataSource = HdOverlayContainerDataSource::New(
+            HdRetainedContainerDataSource::New(HdPrimvarsSchemaTokens->primvars, aiPrimvarsDs),
+            result.dataSource);
+    }
+
+    return result;
+}
+
+HdSceneIndexPrim _TranslateAreaLight(
+    const HdSceneIndexPrim& inputPrim, const VtDictionary& mayaAttrs)
+{
+    auto getAttr = [&](const char* key, auto def) {
+        using T = decltype(def);
+        auto it = mayaAttrs.find(key);
+        if (it == mayaAttrs.end())
+            return def;
+        if (it->second.IsHolding<T>())
+            return it->second.UncheckedGet<T>();
+        if constexpr (std::is_same_v<T, float>) {
+            if (it->second.IsHolding<double>())
+                return static_cast<float>(it->second.UncheckedGet<double>());
+        }
+        return def;
+    };
+
+    const std::string translator  = getAttr("aiTranslator", std::string());
+    const float       intensity   = getAttr("intensity",     1.0f);
+    const GfVec3f     color       = getAttr("color",         GfVec3f(1.0f));
+    const float       exposure    = getAttr("exposure",      0.0f);
+    const bool        normalize   = getAttr("aiNormalize",   true);
+    const float       diffuse     = getAttr("aiDiffuse",     1.0f);
+    const float       specular    = getAttr("aiSpecular",    1.0f);
+    const bool        castShadows = getAttr("aiCastShadows", true);
+    const GfVec3f     shadowColor = getAttr("aiShadowColor", GfVec3f(0.0f));
+
+    // aiTranslator drives the prim type but is not an Arnold light parameter.
+    static const std::unordered_set<std::string> s_explicit{
+        "aiTranslator", "aiNormalize", "aiDiffuse", "aiSpecular", "aiCastShadows", "aiShadowColor"};
+
+    HdSceneIndexPrim result;
+    if (translator == "cylinder")
+        result.primType = HdPrimTypeTokens->cylinderLight;
+    else if (translator == "quad")
+        result.primType = HdPrimTypeTokens->rectLight;
+    else if (translator == "disk")
+        result.primType = HdPrimTypeTokens->diskLight;
+    else
+        return inputPrim;
+
+    auto lightDs = HdRetainedContainerDataSource::New(
+        UsdLuxTokens->inputsIntensity,    HdRetainedTypedSampledDataSource<float>::New(intensity),
+        UsdLuxTokens->inputsColor,        HdRetainedTypedSampledDataSource<GfVec3f>::New(color),
+        UsdLuxTokens->inputsExposure,     HdRetainedTypedSampledDataSource<float>::New(exposure),
+        UsdLuxTokens->inputsNormalize,    HdRetainedTypedSampledDataSource<bool>::New(normalize),
+        UsdLuxTokens->inputsDiffuse,      HdRetainedTypedSampledDataSource<float>::New(diffuse),
+        UsdLuxTokens->inputsSpecular,     HdRetainedTypedSampledDataSource<float>::New(specular),
+        UsdLuxTokens->inputsShadowEnable, HdRetainedTypedSampledDataSource<bool>::New(castShadows),
+        UsdLuxTokens->inputsShadowColor,  HdRetainedTypedSampledDataSource<GfVec3f>::New(shadowColor));
+
+    result.dataSource = HdOverlayContainerDataSource::New(lightDs, inputPrim.dataSource);
+
+    if (auto aiPrimvarsDs = _BuildAiPrimvarsFromAttrs(mayaAttrs, s_explicit)) {
+        result.dataSource = HdOverlayContainerDataSource::New(
+            HdRetainedContainerDataSource::New(HdPrimvarsSchemaTokens->primvars, aiPrimvarsDs),
+            result.dataSource);
+    }
+
+    return result;
+}
+
+HdSceneIndexPrim _TranslateStandIn(
+    const HdSceneIndexPrim& inputPrim, const VtDictionary& mayaAttrs)
+{
+    std::string dso;
+    auto it = mayaAttrs.find("dso");
+    if (it != mayaAttrs.end() && it->second.IsHolding<std::string>())
+        dso = it->second.UncheckedGet<std::string>();
+
+    HdSceneIndexPrim result;
+    result.primType = _tokens->ArnoldProcedural;
+    result.dataSource = HdOverlayContainerDataSource::New(
+        HdRetainedContainerDataSource::New(
+            _tokens->arnoldFilename, HdRetainedTypedSampledDataSource<std::string>::New(dso)),
+        inputPrim.dataSource);
+    return result;
+}
+
+HdSceneIndexPrim _TranslateVolume(
+    const HdSceneIndexPrim& inputPrim, const VtDictionary& mayaAttrs)
+{
+    std::vector<TfToken> names;
+    std::vector<HdDataSourceBaseHandle> sources;
+    names.reserve(mayaAttrs.size());
+    sources.reserve(mayaAttrs.size());
+    for (const auto& [key, value] : mayaAttrs) {
+        names.push_back(TfToken("arnold:" + key));
+        sources.push_back(_VtValueDataSource::New(value));
+    }
+
+    HdSceneIndexPrim result;
+    result.primType = _tokens->ArnoldVolume;
+    result.dataSource = HdOverlayContainerDataSource::New(
+        HdRetainedContainerDataSource::New(names.size(), names.data(), sources.data()),
+        inputPrim.dataSource);
+    return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -124,6 +407,36 @@ public:
         HdSceneIndexPrim prim = _GetInputSceneIndex()->GetPrim(primPath);
         if (!prim.dataSource) {
             return prim;
+        }
+        // MtoA emits Maya DAG nodes with no built-in Hydra representation as
+        // generic "mayaCustomDagNode" prims, tagging the Maya type name on a
+        // nested "mayaNode/mayaTypeName" data source. Dispatch Arnold node
+        // types ("ai<UpperCase>...") to their dedicated translators.
+        if (prim.primType == _tokens->mayaCustomDagNode) {
+            if (auto mayaNodeDs = HdContainerDataSource::Cast(prim.dataSource->Get(_tokens->mayaNode))) {
+                if (auto typeNameDs =
+                        HdTypedSampledDataSource<TfToken>::Cast(mayaNodeDs->Get(_tokens->mayaTypeName))) {
+                    const TfToken mayaTypeName = typeNameDs->GetTypedValue(0.0f);
+                    if (_IsMtoaAiName(mayaTypeName)) {
+                        VtDictionary mayaAttrs;
+                        if (auto attrsDs = HdTypedSampledDataSource<VtDictionary>::Cast(
+                                mayaNodeDs->Get(_tokens->mayaAttributes))) {
+                            mayaAttrs = attrsDs->GetTypedValue(0.0f);
+                        }
+                        if (mayaTypeName == _tokens->aiPhotometricLight) {
+                            return _TranslatePhotometricLight(prim, mayaAttrs);
+                        } else if (mayaTypeName == _tokens->aiSkyDomeLight) {
+                            return _TranslateSkyDomeLight(prim, mayaAttrs);
+                        } else if (mayaTypeName == _tokens->aiAreaLight) {
+                            return _TranslateAreaLight(prim, mayaAttrs);
+                        } else if (mayaTypeName == _tokens->aiStandIn) {
+                            return _TranslateStandIn(prim, mayaAttrs);
+                        } else if (mayaTypeName == _tokens->aiVolume) {
+                            return _TranslateVolume(prim, mayaAttrs);
+                        }
+                    }
+                }
+            }
         }
         // Compose MtoA-compat data-source wrappers here. New fixups layer on
         // top by wrapping the previous result.


### PR DESCRIPTION
**Changes proposed in this pull request**
To continue the work done previously for arnold attributes in maya nodes, we extend the scene index plugin to support custom maya nodes known as being arnold nodes (aiStandIn, aiSkyDomeLight, etc...)

**Issues fixed in this pull request**
Fixes #2619 

**Additional context**
Add any other context or screenshots about the pull request here.
