### PR TITLE
Fix end-iterator dereference when pruning source-to-targets map

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1758,9 +1758,9 @@ bool HdArnoldRenderDelegate::HasPendingChanges(HdRenderIndex* renderIndex, const
                 auto sourceIt = _sourceToTargetsMap.find(source);
                 if (sourceIt != _sourceToTargetsMap.end()) {
                     sourceIt->second.erase(id);
-                }
-                if (sourceIt->second.empty()) {
-                    _sourceToTargetsMap.erase(sourceIt);
+                    if (sourceIt->second.empty()) {
+                        _sourceToTargetsMap.erase(sourceIt);
+                    }
                 }
                 // This source primitive needs to be updated
                 auto bits = _dependencyToDirtyBitsMap[{id, source}];


### PR DESCRIPTION
## Summary
- In `HdArnoldRenderDelegate::HasPendingChanges`, when handling the `_dependencyRemovalQueue`, the `empty()` check and the subsequent `_sourceToTargetsMap.erase(sourceIt)` ran outside the `sourceIt != _sourceToTargetsMap.end()` guard.
- If the dependency was already absent from the map, `find` returned `end()` and we then dereferenced/erased that end iterator — undefined behavior.
- Moved both calls inside the existing validity check so the prune only happens when the lookup actually found an entry.

## Test plan
- [ ] Render a scene that triggers dependency changes (e.g., reassign a material/light link), confirm no crash and dirty propagation still works.
- [ ] Existing render_delegate testsuite passes.