### PR TITLE
Fix camera name in RenderVar prim

### DIFF
--- a/libs/translator/writer/write_options.cpp
+++ b/libs/translator/writer/write_options.cpp
@@ -478,7 +478,15 @@ void UsdArnoldWriteOptions::Write(const AtNode *node, UsdArnoldWriter &writer)
                     renderVarPrim.CreateAttribute(_tokens->aovSettingName, SdfValueTypeNames->String), output.layerName);
             }
             if (output.camera) {
-                std::string cameraName = UsdArnoldPrimWriter::GetArnoldNodeName(output.camera, writer);
+                // Use the raw Arnold node name so the value matches what the
+                // node will be called after readback (when primvars:arnold:name
+                // is round-tripped). Arnold core parses this string directly
+                // when resolving the AOV output line, bypassing the reader's
+                // path-to-node remapping map. Fall back to the sanitized USD
+                // path only if the node has no name (#2654).
+                std::string cameraName = AiNodeGetName(output.camera);
+                if (cameraName.empty())
+                    cameraName = UsdArnoldPrimWriter::GetArnoldNodeName(output.camera, writer);
                 writer.SetAttribute(
                     renderVarPrim.CreateAttribute(_tokens->aovSettingCamera, SdfValueTypeNames->String), cameraName);
             }


### PR DESCRIPTION
**Issue**

AiSceneWrite exports a RenderVar.arnold:camera AOV reference using the sanitized USD path (e.g. /uv_camera__Sphere), but also authors primvars:arnold:name on the camera prim with the raw Arnold name (e.g. uv_camera__Sphere, no leading slash). On readback, the procedural renames the camera Arnold node to match primvars:arnold:name, so the AOV reference no longer resolves — Arnold core reports [aov] output references a non-camera node: /uv_camera__Sphere.

**Fix**

In libs/translator/writer/write_options.cpp:480, write the AOV's camera attribute using AiNodeGetName(output.camera) instead of GetArnoldNodeName(...), so the string matches the Arnold node name that will exist after readback. Fall back to GetArnoldNodeName only if the node has no name. This makes RenderVar.arnold:camera consistent with what ArnoldRenderOutput.arnold:camera already does and with how the render delegate (render_settings.cpp:796-798) resolves the camera at read time.

**Issues fixed in this pull request**
Fixes #2654
