### PR TITLE
Fix husk -o/-j argument bounds check in batch command line

### DIFF
--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -879,13 +879,13 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             const VtStringArray &commandLine = value.UncheckedGet<VtArray<std::string>>();
             for (unsigned int i = 0; i < commandLine.size(); ++i) {
                 // husk argument for output image
-                if (commandLine[i] == "-o" && i < commandLine.size() - 2) {
+                if (commandLine[i] == "-o" && i + 1 < commandLine.size()) {
                     _outputOverride = commandLine[++i];
                     continue;
                 }
                 // husk argument for thread count (#1077)
-                if ((commandLine[i] == "-j" || commandLine[i] == "--threads") 
-                        && i < commandLine.size() - 2) {
+                if ((commandLine[i] == "-j" || commandLine[i] == "--threads")
+                        && i + 1 < commandLine.size()) {
                     // if for some reason the argument value is not a number, atoi should return 0
                     // which is also the default arnold value. 
                     AiNodeSetInt(_options, str::threads, std::atoi(commandLine[++i].c_str()));


### PR DESCRIPTION
## Summary
- In `HdArnoldRenderDelegate::_SetRenderSetting` (batchCommandLine handling), the guard `i < commandLine.size() - 2` was off by one: with a valid trailing pair like `{"-o", "out.exr"}` (size 2, `i = 0`) the check is `0 < 0` and the override is silently dropped.
- `commandLine.size()` is unsigned, so `size() - 2` also underflows when `size() < 2`, which would make `i < HUGE` trivially true and lead to an out-of-bounds access after `++i`.
- Rewrote both occurrences (`-o` and `-j`/`--threads`) as `i + 1 < commandLine.size()` — same intent, no off-by-one, no unsigned underflow.

## Test plan
- [ ] Render via husk passing `-o out.exr` and confirm the output path override is applied.
- [ ] Render via husk passing `-j N` / `--threads N` and confirm thread count is set on the options node.
- [ ] Sanity-check that an empty / single-element batch command line no longer triggers an OOB read.