### PR TITLE
Guard vlistArray null deref when reserving mesh normals capacity

### DIFF
--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -394,7 +394,7 @@ AtNode* UsdArnoldReadMesh::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
 
         std::vector<GfVec3f> normalsArray;
         std::vector<unsigned int> nidxs; // Flattened array that we are going to pass to arnold
-        normalsArray.reserve(vListKeys*AiArrayGetNumElements(vlistArray));
+        normalsArray.reserve(vListKeys * (vlistArray ? AiArrayGetNumElements(vlistArray) : 0));
         unsigned int normalsElemCount = -1;
 
         UsdGeomPrimvar normalsPrimvar(normalsAttr);


### PR DESCRIPTION
## Summary
- In `UsdArnoldReadMesh::Read`, the line above already treats `vlistArray` as possibly null (`vListKeys = (vlistArray) ? AiArrayGetNumKeys(vlistArray) : 1`), but the immediately following `normalsArray.reserve(vListKeys * AiArrayGetNumElements(vlistArray))` dereferenced it unconditionally.
- On a mesh whose Arnold node has no `vlist` array set, `AiArrayGetNumElements(nullptr)` is undefined behavior / crash.
- Guarded the size hint with the same null check so the reserve becomes 0 when there is no vlist.

## Test plan
- [ ] Read a mesh with authored normals and a populated `vlist` — normals are still loaded as before.
- [ ] Read a mesh that hits the (rare) path where `vlist` has not been set on the Arnold node and confirm no crash.