### PR TITLE
Pair AiArrayMapConst with AiArrayUnmapConst in prim writer

### DIFF
--- a/libs/translator/writer/prim_writer.cpp
+++ b/libs/translator/writer/prim_writer.cpp
@@ -752,7 +752,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->UCharArray;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_INT: {
@@ -791,7 +791,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->BoolArray;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_FLOAT: {
@@ -817,7 +817,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->Color3fArray;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_VECTOR: {
@@ -830,7 +830,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->Vector3fArray;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_RGBA: {
@@ -843,7 +843,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->Color4fArray;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_VECTOR2: {
@@ -856,7 +856,7 @@ static inline bool convertArnoldAttribute(
                 }
                 typeName = SdfValueTypeNames->Float2Array;
                 attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
             case AI_TYPE_STRING: {
@@ -887,7 +887,7 @@ static inline bool convertArnoldAttribute(
                     typeName = SdfValueTypeNames->Matrix4dArray;
                     attrWriter.ProcessAttributeKeys(writer, primWriter, typeName, vtMotionArray, motionStart, motionEnd);
                 }
-                AiArrayUnmap(array);
+                AiArrayUnmapConst(array);
                 break;
             }
 


### PR DESCRIPTION
## Summary
- In `UsdArnoldPrimWriter::_WriteArnoldParameters`, the per-type branches read array data via `AiArrayMapConst(array)` but seven branches unmapped it with the non-const `AiArrayUnmap(array)`: `AI_TYPE_BYTE`, `AI_TYPE_BOOLEAN`, `AI_TYPE_RGB`, `AI_TYPE_VECTOR`, `AI_TYPE_RGBA`, `AI_TYPE_VECTOR2`, `AI_TYPE_MATRIX`.
- The remaining branches (`AI_TYPE_INT`, `AI_TYPE_UINT`, `AI_TYPE_FLOAT`) already used the matching `AiArrayUnmapConst`.
- Mismatching the const / non-const pair flags the array as modified even though it was only read, which can trigger spurious copies or write-backs on shared array data.
- Switched the seven mismatched sites to `AiArrayUnmapConst`. The only remaining non-const `AiArrayMap`/`AiArrayUnmap` pair in the file (the `shidxs` write site) is unchanged.

## Test plan
- [ ] Export a scene that exercises the affected attribute types (byte/bool/rgb/vec/rgba/vec2/matrix arrays — e.g. instance visibility, color/normal/uv arrays, instance matrices) via the USD writer and confirm the written values match what's written today.
- [ ] No new warnings/asserts from the Arnold core around array map/unmap.