### PR TITLE
Initialize normalsElemCount to 0 instead of -1

### DIFF
--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -395,7 +395,7 @@ AtNode* UsdArnoldReadMesh::Read(const UsdPrim &prim, UsdArnoldReaderContext &con
         std::vector<GfVec3f> normalsArray;
         std::vector<unsigned int> nidxs; // Flattened array that we are going to pass to arnold
         normalsArray.reserve(vListKeys*AiArrayGetNumElements(vlistArray));
-        unsigned int normalsElemCount = -1;
+        unsigned int normalsElemCount = 0;
 
         UsdGeomPrimvar normalsPrimvar(normalsAttr);
         TfToken normalsInterp = GetNormalsInterpolation(mesh);


### PR DESCRIPTION
## Summary
- `UsdArnoldReadMesh::Read` declared `unsigned int normalsElemCount = -1;`, relying on the `if (key == 0)` branch in the time-sample loop to overwrite it before any other read.
- If `normalsAttr.Get(...)` fails at `key == 0` but succeeds at a later key, the initializer survives as `UINT_MAX` and is then used at three sites:
  - `normalsArray.insert(end, begin, begin + normalsElemCount)` on an empty vector — undefined behavior.
  - `AiArrayConvert(normalsElemCount, vListKeys, AI_TYPE_VECTOR, normalsArray.data())` — bogus element count.
  - `nidxs.resize(normalsElemCount)` — `bad_alloc` / OOM.
- Initializing to `0` is safe at all three sites (no-op range, zero-sized array/resize) and lets the existing `if (normalsArray.empty() || primIsSkinned) AiNodeResetParameter(...)` path gracefully fall through to "no normals" when the first sample couldn't be read.

## Test plan
- [ ] Read a mesh with authored animated normals and confirm output is unchanged in the common path.
- [ ] Simulate / synthesize a mesh where `normalsAttr.Get` fails at the first time sample but succeeds later, and confirm no crash (normals get reset).