### PR TITLE
Various cleanup and fixes

### DIFF
--- a/libs/render_delegate/light.cpp
+++ b/libs/render_delegate/light.cpp
@@ -179,7 +179,7 @@ void readUserData(
     HdArnoldGetPrimvars(delegate, id, dirtyBits, primvars, &interpolations);
     for (const auto &p : primvars) {
         // Get the parameter name, removing the arnold:prefix if any
-        std::string paramName(TfStringStartsWith(p.first.GetString(), str::arnold) ? p.first.GetString().substr(7) : p.first.GetString());
+        std::string paramName(TfStringStartsWith(p.first.GetString(), str::arnold_prefix.c_str()) ? p.first.GetString().substr(str::arnold_prefix.length()) : p.first.GetString());
         const auto* pentry = AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(light), AtString(paramName.c_str()));
         if (pentry) {
             HdArnoldSetParameter(light, pentry, p.second.value, renderDelegate);
@@ -239,9 +239,9 @@ AtString getLightType(HdSceneDelegate* delegate, const SdfPath& id, HdArnoldRend
         !isDefault(UsdLuxTokens->inputsShapingConeSoftness, 0.0f)) {
         // If usdlux_version is enabled use a point light
         AtNode* options = AiUniverseGetOptions(renderDelegate->GetUniverse());
-        if (AiNodeGetByte(options, str::usdlux_version) != 0) 
+        if (AiNodeGetInt(options, str::usdlux_version) != 0)
             return str::point_light;
-        else 
+        else
             return str::spot_light;
     }
     // Finally, we default to a point light
@@ -592,7 +592,7 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
                     _syncParams = photometricLightSync;
                 }
                 if (_lightLink != _tokens->emptyLink) {
-                    _delegate->DeregisterLightLinking(_shadowLink, this, false);
+                    _delegate->DeregisterLightLinking(_lightLink, this, false);
                     _lightLink = _tokens->emptyLink;
                 }
                 if (_shadowLink != _tokens->emptyLink) {

--- a/libs/render_delegate/native_rprim.cpp
+++ b/libs/render_delegate/native_rprim.cpp
@@ -133,7 +133,7 @@ void HdArnoldNativeRprim::Sync(
                 continue;
 
             // Get the parameter name, removing the arnold:prefix if any
-            std::string paramName(TfStringStartsWith(p.first.GetString(), str::arnold) ? p.first.GetString().substr(7) : p.first.GetString());
+            std::string paramName(TfStringStartsWith(p.first.GetString(), str::arnold_prefix.c_str()) ? p.first.GetString().substr(str::arnold_prefix.length()) : p.first.GetString());
             HdArnoldSetConstantPrimvar(node, TfToken(paramName), p.second.role, p.second.value, &_visibilityFlags,
                     nullptr, nullptr, _renderDelegate);
         }

--- a/libs/render_delegate/render_settings.cpp
+++ b/libs/render_delegate/render_settings.cpp
@@ -701,8 +701,8 @@ void HdArnoldRenderSettings::_UpdateRenderProducts(HdSceneDelegate* sceneDelegat
                 const std::string filterPrefix = "arnold:" + filterType + ":";
                 if (TfStringStartsWith(settingName, filterPrefix)) {
                     paramName = settingName.substr(filterPrefix.size());
-                } else if (TfStringStartsWith(settingName, "arnold:globals:")) {
-                    paramName = settingName.substr(15); // strlen("arnold:globals:")
+                } else if (TfStringStartsWith(settingName, "arnold:global:")) {
+                    paramName = settingName.substr(14); // strlen("arnold:global:")
                 } else if (TfStringStartsWith(settingName, "arnold:")) {
                     paramName = settingName.substr(7); // strlen("arnold:")
                 } else {

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -530,6 +530,7 @@ void HdArnoldSetRadiusFromPrimvar(AtNode* node, const SdfPath& id, HdSceneDelega
     auto* out = static_cast<float*>(AiArrayMap(arr));
     auto convertWidth = [](const float w) -> float { return w * 0.5f; };
     std::transform(v0.begin(), v0.end(), out, convertWidth);
+    AiArrayUnmap(arr);
     AiNodeSetArray(node, str::radius, arr);
 }
 

--- a/libs/translator/reader/read_light.cpp
+++ b/libs/translator/reader/read_light.cpp
@@ -210,7 +210,7 @@ AtNode *_ReadLightShaping(const UsdPrim &prim, UsdArnoldReaderContext &context)
     // If usdlux_version is enabled use a point light
     AtNode* options = AiUniverseGetOptions(context.GetReader()->GetUniverse());
     if (options && AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(options), str::usdlux_version)) {
-        if (AiNodeGetByte(options, str::usdlux_version) != 0) {
+        if (AiNodeGetInt(options, str::usdlux_version) != 0) {
             return nullptr;
         }
     }

--- a/libs/translator/reader/read_skinning.cpp
+++ b/libs/translator/reader/read_skinning.cpp
@@ -437,7 +437,7 @@ _ExtendWorldTransformTimeSamples(const UsdPrim& prim,
 
     for (UsdPrim p = prim; !p.IsPseudoRoot(); p = p.GetParent()) {
         if (p.IsA<UsdGeomXformable>()) {
-            const UsdGeomXformable xformable(prim);
+            const UsdGeomXformable xformable(p);
             const UsdGeomXformable::XformQuery query(xformable);
             if (query.GetTimeSamples(&tmpTimes)) {
                 _InsertTimesInInterval(interval, tmpTimes, times);

--- a/libs/translator/reader/utils.cpp
+++ b/libs/translator/reader/utils.cpp
@@ -609,7 +609,8 @@ void ApplyParentMatrices(AtArray *matrices, const AtArray *parentMatrices)
         }
     } else if (matrixNumKeys >= parentMatrixNumKeys) {
         for (unsigned int i = 0; i < matrixNumKeys; ++i) {
-            AtMatrix m = AiM4Mult(AiArrayGetMtx(matrices, i), AiArrayGetMtx(parentMatrices, i));
+            const float t = (float)i / AiMax(float(matrixNumKeys - 1), 1.f);
+            AtMatrix m = AiM4Mult(AiArrayGetMtx(matrices, i), AiArrayInterpolateMtx(parentMatrices, t, 0));
             AiArraySetMtx(matrices, i, m);
         }
     } else { // The number of matrices of the parent is greater than the child, it can happen on instances, we resize the current matrix


### PR DESCRIPTION
List of simple fixes in the codebase : 

- DeregisterLightLinking(_shadowLink, this, false) should pass _lightLink — the surrounding if checks _lightLink and the false (non-shadow) flag confirms it. Result: the wrong link is deregistered on light-type change, leaking the original _lightLink registration
- HdArnoldSetRadiusFromPrimvar calls AiArrayMap(arr) but never AiArrayUnmap. Added the missing unmap before AiNodeSetArray.
- usdlux_version is read with AiNodeGetByte in a couple of places, it should be AiNodeGetInt
- TfStringStartsWith(name, str::arnold) matches a 6-char prefix ("arnold"), then substr(7) strips 7 chars — drops an extra character for any primvar like arnoldFoo that doesn't have the :. Switched to str::arnold_prefix ("arnold:") for both check and length.
- libs/translator/reader/read_skinning.cpp:440_ExtendWorldTransformTimeSamples walks the parent chain with p = p.GetParent(), but every iteration constructs UsdGeomXformable(prim) (original prim) instead of UsdGeomXformable(p). All ancestors get queried as the leaf prim — skinning time samples missed any animated parent xform. Changed prim → p.
- libs/translator/reader/utils.cpp:611ApplyParentMatrices branch for matrixNumKeys > parentMatrixNumKeys indexes AiArrayGetMtx(parentMatrices, i) with i up to matrixNumKeys-1, going out of bounds when the parent has fewer keys. Switched to AiArrayInterpolateMtx(parentMatrices, t, 0) with normalized t, matching the equal-key branch above it and the reference in common_utils.cpp.
- libs/render_delegate/render_settings.cpp:704Typo: this branch checks arnold:globals: (plural) and strips 15 chars. Every other token in the codebase uses arnold:global: (singular, 14 chars). Dead branch as written. Fixed prefix and length.





