### PR TITLE
Don't reset lights at every IPR iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - [usd#2673](https://github.com/Autodesk/arnold-usd/issues/2673) - Remove spurious warnings "Arnold attribute not recognized"
+- [usd#255](https://github.com/Autodesk/arnold-usd/issues/255) - Do not reset lights during IPR iterations
 
 ## [7.5.2.0] (Unreleased)
 

--- a/libs/render_delegate/light.cpp
+++ b/libs/render_delegate/light.cpp
@@ -165,8 +165,14 @@ void iterateParams(
         if (pentry == nullptr) {
             continue;
         }
-
-        HdArnoldSetParameter(light, pentry, delegate->GetLightParamValue(id, param.hdName), renderDelegate);
+        // Reset the parameter to its default when Hydra reports no value, so that
+        // attributes removed since the previous Sync don't leak across renders.
+        const VtValue value = delegate->GetLightParamValue(id, param.hdName);
+        if (value.IsEmpty()) {
+            AiNodeResetParameter(light, param.arnoldName);
+        } else {
+            HdArnoldSetParameter(light, pentry, value, renderDelegate);
+        }
     }
 }
 
@@ -601,10 +607,13 @@ void HdArnoldGenericLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* r
                 }
             }
         }
-        // We need to force dirtying the transform, because AiNodeReset resets the transformation.
-        *dirtyBits |= HdLight::DirtyTransform;
-        AiNodeReset(_light);
-                
+        // Clear any incoming connections on parameters that can be driven by a node
+        // graph (color, filters). The subsequent value writes and shader/texture
+        // links below depend on starting from a disconnected state, and Arnold's
+        // AiNodeSetRGB/SetArray do not implicitly remove existing links.
+        AiNodeResetParameter(_light, str::color);
+        AiNodeResetParameter(_light, str::filters);
+
         // convert the generic lights parameters
         iterateParams(_light, nentry, id, sceneDelegate, _delegate, genericParams);
         // convert the light specific attributes


### PR DESCRIPTION
**Changes proposed in this pull request**
In this PR we no longer reset the whole light parameters at every IPR iteration.
We just translate the parameters that have been changed, as for other nodes. We no longer need a special treatment for the light's transforms

**Issues fixed in this pull request**
Fixes #255 
