### PR TITLE
Various fixes in render_param

### DIFF
--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -43,25 +43,29 @@ TF_DEBUG_CODES(HDARNOLD_RENDER_SETTINGS);
 
 namespace {
 
-std::string cachedLogMsg = "";
-std::mutex cachedLogMutex;
-
 void _MsgStatusCallback(int logmask, int severity, const char* msgString, AtParamValueMap* metadata, void* userPtr)
 {
-    std::lock_guard<std::mutex> guard(cachedLogMutex);
-
-    cachedLogMsg = std::string(msgString);
+    if (msgString == nullptr || userPtr == nullptr) {
+        return;
+    }
+    static_cast<HdArnoldRenderParam*>(userPtr)->SetCachedLogMessage(msgString);
 }
 
 } // namespace
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_DEBUG_SCENE, "", "Optionally save out the arnold scene before rendering.");
 
+HdArnoldRenderParam::~HdArnoldRenderParam()
+{
+    StopRenderMsgLog();
+}
+
 HdArnoldRenderParam::HdArnoldRenderParam(HdArnoldRenderDelegate* delegate) : _delegate(delegate)
 
 {
     _needsRestart.store(false, std::memory_order::memory_order_release);
     _aborted.store(false, std::memory_order::memory_order_release);
+    _paused.store(false, std::memory_order::memory_order_release);
 
     ResetStartTimer();
 
@@ -72,6 +76,13 @@ HdArnoldRenderParam::HdArnoldRenderParam(HdArnoldRenderDelegate* delegate) : _de
 
 HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
 {
+    // Mirror the null check Interrupt() now performs. Without it any caller
+    // that ends up with a null _delegate crashes on the first GetRenderSession
+    // dereference below; Aborted is a safer, observable signal that something
+    // is wrong with the setup.
+    if (_delegate == nullptr) {
+        return Status::Aborted;
+    }
     const auto aborted = _aborted.load(std::memory_order_acquire);
     // Checking early if the render was aborted earlier.
     if (aborted) {
@@ -84,6 +95,12 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
 
         case AI_RENDER_STATUS_RESTARTING:
         case AI_RENDER_STATUS_RENDERING:
+            if (needsRestart) {
+                _needsRestart.store(true, std::memory_order_release);
+            }
+            if (paused) {
+                _paused.store(true, std::memory_order_release);
+            }
             return Status::Converging;
         
         case AI_RENDER_STATUS_FINISHED:
@@ -110,6 +127,8 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
                 if (!_debugScene.empty())
                     WriteDebugScene();
                 AiRenderRestart(_delegate->GetRenderSession());
+                RestartRenderMsgLog();
+                ResetStartTimer();
             } else if (!paused) {
                 AiRenderResume(_delegate->GetRenderSession());
                 ResetStartTimer();
@@ -117,8 +136,12 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             return Status::Converging;
 
         case AI_RENDER_STATUS_FAILED:
-            _aborted.store(true, std::memory_order_release);
+            // Write _errorCode BEFORE publishing _aborted with a release store.
+            // The release semantics on _aborted ensure that any thread which
+            // observes _aborted == true via acquire load also sees the writes
+            // performed before the release — including the new _errorCode.
             _errorCode = AiRenderEnd(_delegate->GetRenderSession());
+            _aborted.store(true, std::memory_order_release);
             if (_errorCode == AI_ABORT) {
                 TF_WARN("[arnold-usd] Render was aborted.");
             } else if (_errorCode == AI_ERROR_NO_CAMERA) {
@@ -140,9 +163,19 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             } else if (_errorCode == AI_ERROR) {
                 TF_WARN("[arnold-usd] Generic error.");
             }
+            StopRenderMsgLog();
             return Status::Aborted;
         
         case AI_RENDER_STATUS_NOT_STARTED:
+            // If the caller already requested a pause before the render even
+            // begins (e.g., a viewport that opens in a paused state), honour
+            // it: do not call AiRenderBegin, and put `_paused` back so the
+            // next UpdateRender iterations continue to see the pause request
+            // until Resume() / Restart() clears it.
+            if (paused) {
+                _paused.store(true, std::memory_order_release);
+                return Status::Converging;
+            }
             if (!_debugScene.empty())
                 WriteDebugScene();
             AiRenderBegin(_delegate->GetRenderSession());
@@ -158,9 +191,11 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
 
 void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus)
 {
-    if (_delegate && _delegate->IsBatchContext()) return;
+    if (_delegate == nullptr || _delegate->IsBatchContext()) return;
     const auto status = AiRenderGetStatus(_delegate->GetRenderSession());
-    if (status != AI_RENDER_STATUS_NOT_STARTED) {
+    if (status == AI_RENDER_STATUS_RENDERING ||
+        status == AI_RENDER_STATUS_RESTARTING ||
+        status == AI_RENDER_STATUS_PAUSED) {
         AiRenderInterrupt(_delegate->GetRenderSession(), AI_BLOCKING);
     }
     if (needsRestart) {
@@ -173,14 +208,21 @@ void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus)
 
 void HdArnoldRenderParam::Pause()
 {
-    Interrupt(false, false);
+    // Publish the pause intent before issuing the interrupt. Interrupt blocks
+    // until Arnold transitions the render status away from RENDERING; if the
+    // store happened *after* that transition, a concurrent UpdateRender call
+    // could see status == PAUSED with `_paused == false` and immediately take
+    // the `!paused` branch, calling AiRenderResume and silently undoing the
+    // pause that was just requested.
     _paused.store(true, std::memory_order_release);
+    Interrupt(false, false);
 }
 
 void HdArnoldRenderParam::Resume() { _paused.store(false, std::memory_order_release); }
 
 void HdArnoldRenderParam::Restart()
 {
+    _aborted.store(false, std::memory_order_release);
     _paused.store(false, std::memory_order_release);
     _needsRestart.store(true, std::memory_order_release);
 }
@@ -210,16 +252,27 @@ void HdArnoldRenderParam::WriteDebugScene() const
 
     AiMsgWarning("Saving debug arnold scene as \"%s\"", _debugScene.c_str());
     AtParamValueMap* params = AiParamValueMap();
-    AiParamValueMapSetBool(params, str::binary, false);
-    AiSceneWrite(_delegate->GetUniverse(), AtString(_debugScene.c_str()), params);
-    AiParamValueMapDestroy(params);
+    const AtString filename(_debugScene.c_str());
+    bool ok = false;
+    if (params == nullptr) {
+        ok = AiSceneWrite(_delegate->GetUniverse(), filename, nullptr);
+    } else {
+        AiParamValueMapSetBool(params, str::binary, false);
+        ok = AiSceneWrite(_delegate->GetUniverse(), filename, params);
+        AiParamValueMapDestroy(params);
+    }
+    if (!ok) {
+        AiMsgWarning("Failed to save debug arnold scene as \"%s\"", _debugScene.c_str());
+    }
 }
 
 double HdArnoldRenderParam::GetElapsedRenderTime() const
 {
-    _renderTimeMutex.lock();
-    const auto t0 = _renderStartTime;
-    _renderTimeMutex.unlock();
+    std::chrono::time_point<std::chrono::system_clock> t0;
+    {
+        std::lock_guard<std::mutex> guard(_renderTimeMutex);
+        t0 = _renderStartTime;
+    }
     const auto t1 = std::chrono::system_clock::now();
     const auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
 
@@ -231,7 +284,16 @@ void HdArnoldRenderParam::StartRenderMsgLog()
 
     // The "Status" logs mask was introduced in Arnold 7.1.3.0
 #if ARNOLD_VERSION_NUM >= 70103
-    _msgLogCallback = AiMsgRegisterCallback(_MsgStatusCallback, AI_LOG_STATUS, nullptr);
+    // Deregister any previously registered callback before installing a new
+    // one. Otherwise repeated Start/Start sequences (without an intervening
+    // Stop) would overwrite `_msgLogCallback`, leaking the previous handle:
+    // the callback function would remain registered with Arnold but we'd no
+    // longer hold a handle to deregister it.
+    if (_msgLogCallback != 0) {
+        AiMsgDeregisterCallback(_msgLogCallback);
+        _msgLogCallback = 0;
+    }
+    _msgLogCallback = AiMsgRegisterCallback(_MsgStatusCallback, AI_LOG_STATUS, this);
 #endif
 }
 
@@ -254,11 +316,20 @@ std::string HdArnoldRenderParam::GetRenderStatusString() const
     // Use unique_lock + try_to_lock so the mutex is always released — including
     // when the std::string copy below throws (e.g., bad_alloc). The previous
     // manual lock/unlock would deadlock all future callers if the copy threw.
-    std::unique_lock<std::mutex> lock(cachedLogMutex, std::try_to_lock);
+    std::unique_lock<std::mutex> lock(_cachedLogMutex, std::try_to_lock);
     if (lock.owns_lock()) {
-        return cachedLogMsg;
+        return _cachedLogMsg;
     }
     return "";
+}
+
+void HdArnoldRenderParam::SetCachedLogMessage(const char* msg)
+{
+    if (msg == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> guard(_cachedLogMutex);
+    _cachedLogMsg = msg;
 }
 
 void HdArnoldRenderParam::SetHydraRenderSettingsPrimPath(SdfPath const &path)

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -65,8 +65,11 @@ public:
 
     /// Constructor for HdArnoldRenderParam.
     HdArnoldRenderParam(HdArnoldRenderDelegate* delegate);
-    /// Destructor for HdArnoldRenderParam.
-    ~HdArnoldRenderParam() override = default;
+    /// Destructor for HdArnoldRenderParam. Must explicitly stop the message-log
+    /// callback so the registration is removed from Arnold's global table —
+    /// the defaulted destructor would leak the callback slot otherwise.
+    HDARNOLD_API
+    ~HdArnoldRenderParam() override;
 
     /// Starts or continues rendering.
     ///
@@ -140,6 +143,11 @@ public:
     /// @return render details, i.e. 'Rendering' or '[gpu] compiling shaders'
     std::string GetRenderStatusString() const;
 
+    /// Updates the per-instance cached log message from the Arnold message
+    /// callback. Public so the file-scope `_MsgStatusCallback` free function can
+    /// route into the correct instance via its userPtr argument.
+    void SetCachedLogMessage(const char* msg);
+
     /// Calculates the total render time. This will reset if the scene is dirtied (i.e. tthe camera changes)
     ///
     /// @return elapsed render time in ms
@@ -165,24 +173,39 @@ public:
 private:
     inline void ResetStartTimer()
     {
-        _renderTimeMutex.lock();
+        // Use std::lock_guard so the mutex is released even if the time_point
+        // assignment or system_clock::now() throws. The previous manual
+        // lock()/unlock() would deadlock every future caller of any method
+        // protected by _renderTimeMutex if an exception escaped.
+        std::lock_guard<std::mutex> guard(_renderTimeMutex);
         _renderStartTime = std::chrono::system_clock::now();
-        _renderTimeMutex.unlock();
     }
 
     /// The render delegate
     const HdArnoldRenderDelegate* _delegate;
     /// Indicate if render needs restarting, in case interrupt is called after rendering has finished.
-    std::atomic<bool> _needsRestart;
+    std::atomic<bool> _needsRestart{false};
     /// Indicate if rendering has been aborted at one point or another.
-    std::atomic<bool> _aborted;
-    /// Indicate if rendering has been paused.
-    std::atomic<bool> _paused;
+    std::atomic<bool> _aborted{false};
+    /// Indicate if rendering has been paused. Prior to C++20 std::atomic<bool>'s
+    /// default constructor leaves the value indeterminate, and the cpp file's
+    /// constructor explicitly stores false into _needsRestart and _aborted but
+    /// not into _paused — so the first UpdateRender call read uninitialized
+    /// memory. Initialize all three here for safety.
+    std::atomic<bool> _paused{false};
 
     std::chrono::time_point<std::chrono::system_clock> _renderStartTime;
     mutable std::mutex _renderTimeMutex;
 
     unsigned int _msgLogCallback = 0;
+
+    /// Per-instance cached log message and its mutex. These were previously
+    /// file-scope globals shared across every HdArnoldRenderParam instance, so
+    /// concurrent renders (multiple delegates) overwrote each other's status
+    /// strings and GetRenderStatusString could return a message that came from
+    /// a different instance entirely.
+    mutable std::mutex _cachedLogMutex;
+    std::string _cachedLogMsg;
 
     /// Shutter range.
     GfVec2f _shutter = {0.0f, 0.0f};
@@ -208,7 +231,11 @@ public:
     /// Only calls interrupt once per created instance of HdArnoldRenderParamInterrupt.
     void Interrupt()
     {
-        if (!_hasInterrupted) {
+        // _param is initialized in the constructor via reinterpret_cast from the
+        // HdRenderParam* the caller passes in. If the caller passes nullptr
+        // (legal at the HdRenderParam* interface), _param is also nullptr and
+        // dereferencing it crashes. Guard against that here.
+        if (_param != nullptr && !_hasInterrupted) {
             _hasInterrupted = true;
             _param->Interrupt();
         }


### PR DESCRIPTION
Various fixes in libs/render_delegate/render_param.cpp.
In particular it allows to have several render delegates in parallel
