### PR TITLE
ARNOLD-17294: Fix VtValueGetInt not handling bool VtValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [usd#2673](https://github.com/Autodesk/arnold-usd/issues/2673) - Remove spurious warnings "Arnold attribute not recognized"
 - [usd#255](https://github.com/Autodesk/arnold-usd/issues/255) - Do not reset lights during IPR iterations
 - [usd#2677](https://github.com/Autodesk/arnold-usd/issues/2677) - Fix crash reading RenderSettings with empty arnold:filter on a RenderVar
+- [usd#2695](https://github.com/Autodesk/arnold-usd/issues/2695) - Fix MaterialX boolean shaders through USD
 
 ## [7.5.2.0] (Unreleased)
 

--- a/libs/common/parameters_utils.cpp
+++ b/libs/common/parameters_utils.cpp
@@ -656,7 +656,7 @@ unsigned char VtValueGetByte(const VtValue& value, unsigned char defaultValue)
 int VtValueGetInt(const VtValue& value, int defaultValue)
 {
     if (!value.IsEmpty())
-        VtValueGet<int, long, unsigned int, unsigned char, char, unsigned long>(value, defaultValue);
+        VtValueGet<int, bool, long, unsigned int, unsigned char, char, unsigned long>(value, defaultValue);
 
     return defaultValue;
 }


### PR DESCRIPTION
MaterialX boolean nodes (e.g. ND_ifequal_color3B) generate OSL parameters as AI_TYPE_INT, but USD stores their inputs as bool VtValues. VtValueGetInt had no bool in its type cast list, so bool inputs always resolved to the default value (0).

**Issues fixed in this pull request**
Fixes AROLD-17294
