### PR TITLE
Gracefully handle ParticleField3dGaussianSplat prims with no radiance coefficient data

### DIFF
--- a/libs/render_delegate/gaussian_splat.cpp
+++ b/libs/render_delegate/gaussian_splat.cpp
@@ -33,6 +33,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (orientations)
     (scales)
     (opacities)
+    (displayColor)
     ((shCoeffs, "radiance:sphericalHarmonicsCoefficients"))
     ((shDegree,  "radiance:sphericalHarmonicsDegree"))
 );
@@ -144,6 +145,11 @@ void HdArnoldGaussianSplat::Sync(
         param.Interrupt();
 
         bool shCoeffsUpdated = false;
+        // Fallback for Houdini's ParticleField3DGaussianSplat export, which
+        // stores the degree-0 splat color in primvars:displayColor instead of
+        // radiance:sphericalHarmonicsCoefficients. Captured here and only used
+        // after the loop if no radiance SH coefficients were provided.
+        VtVec3fArray displayColorFallback;
         for (auto& primvar : _primvars) {
             auto&         desc = primvar.second;
             if (!desc.NeedsUpdate())
@@ -258,6 +264,22 @@ void HdArnoldGaussianSplat::Sync(
             if (name == _tokens->shDegree)
                 continue;
 
+            // --- primvars:displayColor - degree-0 SH fallback ----------------
+            // Captured here; applied after the loop only if no radiance SH
+            // coefficients are present. displayColor already stores the final
+            // DC color (raw_f_dc * C0 + 0.5), so it needs no normalization.
+            if (name == _tokens->displayColor) {
+                if (desc.value.IsHolding<VtVec3fArray>()) {
+                    displayColorFallback = desc.value.UncheckedGet<VtVec3fArray>();
+                } else if (desc.value.IsHolding<VtVec3hArray>()) {
+                    const auto& vh = desc.value.UncheckedGet<VtVec3hArray>();
+                    displayColorFallback.resize(vh.size());
+                    for (size_t i = 0; i < vh.size(); ++i)
+                        displayColorFallback[i] = GfVec3f(vh[i]);
+                }
+                continue;
+            }
+
             // --- generic fall-through primvar handling ------------------------
             if (desc.interpolation == HdInterpolationConstant) {
                 HdArnoldSetConstantPrimvar(node, name, desc.role, desc.value,
@@ -268,8 +290,16 @@ void HdArnoldGaussianSplat::Sync(
             }
         }
 
-        if (shCoeffsUpdated)
+        if (shCoeffsUpdated) {
             _NormalizeShDcCoefficient(node);
+        } else if (!displayColorFallback.empty()) {
+            // No radiance SH coefficients were provided. Use displayColor as the
+            // degree-0 DC term (1 RGB per point). The values are already the final
+            // DC color (raw_f_dc * C0 + 0.5), so they are passed through directly.
+            AiNodeSetArray(node, str::gs_sh,
+                AiArrayConvert(displayColorFallback.size(), 1, AI_TYPE_RGB,
+                    displayColorFallback.cdata()));
+        }
 
         UpdateVisibilityAndSidedness();
     }

--- a/libs/translator/reader/read_geometry.cpp
+++ b/libs/translator/reader/read_geometry.cpp
@@ -998,6 +998,7 @@ AtNode* UsdArnoldReadGaussianSplat::Read(const UsdPrim &prim, UsdArnoldReaderCon
     // C0 = 0.28209479177387814 (the l=0 SH basis constant).
     // USD radiance:sphericalHarmonicsCoefficients stores raw coefficients;
     // apply the transformation here before building the Arnold atarray.
+    bool gsShSet = false;
     {
         UsdAttribute shAttr;
         bool isFloat = gs.UsesFloatRadianceCoefficients(&shAttr);
@@ -1034,7 +1035,25 @@ AtNode* UsdArnoldReadGaussianSplat::Read(const UsdPrim &prim, UsdArnoldReaderCon
                 }
                 AiNodeSetArray(node, str::gs_sh,
                     AiArrayConvert(shCoeffs.size(), 1, AI_TYPE_RGB, shCoeffs.data()));
+                gsShSet = true;
             }
+        }
+    }
+
+    // --- Spherical harmonics fallback: primvars:displayColor ----------------
+    // When Houdini's Bake GSplat SOP creates a ParticleField3DGaussianSplat prim,
+    // it stores the degree-0 splat color in primvars:displayColor instead of
+    // radiance coefficients. When no coefficients are present, use displayColor
+    // as the degree-0 DC term. The values are already the final DC color
+    // (raw_f_dc * C0 + 0.5), so they are passed through directly without normalization.
+    if (!gsShSet) {
+        UsdGeomPrimvarsAPI primvarsAPI(prim);
+        UsdGeomPrimvar displayColorPv = primvarsAPI.GetPrimvar(TfToken("displayColor"));
+        if (displayColorPv) {
+            VtArray<GfVec3f> displayColor;
+            if (displayColorPv.Get(&displayColor, frame) && !displayColor.empty())
+                AiNodeSetArray(node, str::gs_sh,
+                    AiArrayConvert(displayColor.size(), 1, AI_TYPE_RGB, displayColor.cdata()));
         }
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request**
- Fallback to the old behaviour if no radiance coefficients are set for ParticleField3dGaussianSplat prims
- Fixes points processed with [Karma Bake GSplat](https://www.sidefx.com/docs/houdini/nodes/sop/bakegsplat.html)

**Issues fixed in this pull request**
Fixes #
Fixes #

**Additional context**
This is doing the same thing we were previously doing in the points translator, just in the context of ParticleField3dGaussianSplat 