### PR TITLE
Fix crash when changing the render purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [usd#2677](https://github.com/Autodesk/arnold-usd/issues/2677) - Fix crash reading RenderSettings with empty arnold:filter on a RenderVar
 - [usd#2641](https://github.com/Autodesk/arnold-usd/issues/2641) - Animate instanced lights driven by an animated Point Instancer in Hydra
 - [usd#2695](https://github.com/Autodesk/arnold-usd/issues/2695) - Fix MaterialX boolean shaders through USD
+- [usd#2628](https://github.com/Autodesk/arnold-usd/issues/2628) - Fix crash happening after changing the purpose in hydra
 
 ## [7.5.2.0] (Unreleased)
 

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -289,19 +289,19 @@ void HdArnoldRenderParam::StartRenderMsgLog()
     // Stop) would overwrite `_msgLogCallback`, leaking the previous handle:
     // the callback function would remain registered with Arnold but we'd no
     // longer hold a handle to deregister it.
-    if (_msgLogCallback != 0) {
-        AiMsgDeregisterCallback(_msgLogCallback);
-        _msgLogCallback = 0;
+    if (_msgLogCallback >= 0) {
+        AiMsgDeregisterCallback(static_cast<unsigned int>(_msgLogCallback));
+        _msgLogCallback = -1;
     }
-    _msgLogCallback = AiMsgRegisterCallback(_MsgStatusCallback, AI_LOG_STATUS, this);
+    _msgLogCallback = static_cast<int>(AiMsgRegisterCallback(_MsgStatusCallback, AI_LOG_STATUS, this));
 #endif
 }
 
 void HdArnoldRenderParam::StopRenderMsgLog()
 {
-    if (_msgLogCallback) {
-        AiMsgDeregisterCallback(_msgLogCallback);
-        _msgLogCallback = 0;
+    if (_msgLogCallback >=0) {
+        AiMsgDeregisterCallback(static_cast<unsigned int>(_msgLogCallback));
+        _msgLogCallback = -1;
     }
 }
 

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -197,7 +197,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock> _renderStartTime;
     mutable std::mutex _renderTimeMutex;
 
-    unsigned int _msgLogCallback = 0;
+    int _msgLogCallback = -1;
 
     /// Per-instance cached log message and its mutex. These were previously
     /// file-scope globals shared across every HdArnoldRenderParam instance, so


### PR DESCRIPTION
**Changes proposed in this pull request**
- The message callback id returned by AiMsgRegisterCallback is an unsigned int which can be zero. However we used the zero value to indicate no callback is set and never destroy the callback with id 0. So when the render is stopped/restarted after a render purpose change for example, the render param is destroyed but the pointer is still kept in Arnold memory and arnold ends up calling the callback function with invalid memory, which crashes the application/arnold.
- We use -1 to indicate that no callback is set. We use integer assuming the number of callbacks will be lower that INT_MAX which is a reasonable assumption.

**Issues fixed in this pull request**
Fixes #2628

