### PR TITLE
Allow c4d_texture_tag shaders

### DIFF
--- a/libs/common/constant_strings.h
+++ b/libs/common/constant_strings.h
@@ -238,6 +238,8 @@ ASTR(buffer_pointers);
 ASTR(cache_id);
 ASTR(camera);
 ASTR(cast_shadows);
+ASTR(c4d_texture_tag);
+ASTR(c4d_texture_tag_rgba);
 ASTR(catclark);
 ASTR(clamp);
 ASTR(clearcoat);

--- a/plugins/node_registry/utils.cpp
+++ b/plugins/node_registry/utils.cpp
@@ -382,8 +382,14 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
     }
     AiMetaDataIteratorDestroy(nodeMetadataIter);
 
-    if (hide)
-        return;
+    if (hide) {
+        // c4d_texture_tag and c4d_texture_tag_rgba carry hide=true metadata, 
+        // so they don't appear in DCC material browsers. They must still be 
+        // registered here so that USD scenes exported by C4DtoA can be rendered.
+        const AtString nodeName = AiNodeEntryGetNameAtString(nodeEntry);
+        if (nodeName != str::c4d_texture_tag && nodeName != str::c4d_texture_tag_rgba)
+            return;
+    }
 
     auto prim = stage->DefinePrim(SdfPath(TfStringPrintf("/%s", AiNodeEntryGetName(nodeEntry))));
     const auto filename = AiNodeEntryGetFilename(nodeEntry);


### PR DESCRIPTION
The `c4d_texture_tag` shader defines the `hide=true` meta data, as it's not listed as a standard Arnold shader and not visible in the node editor in DCCs. That's why the shader is not registered as an Arnold shader in _ReadArnoldShaderDef and ignored when rendering. The PR adds an exception for this specific shader.

**Issues fixed in this pull request**
Fixes #2700
