### PR TITLE
Don't hide node entries in the registry when we compile against a static USD

### DIFF
--- a/plugins/node_registry/utils.cpp
+++ b/plugins/node_registry/utils.cpp
@@ -382,8 +382,12 @@ void _ReadArnoldShaderDef(UsdStageRefPtr stage, const AtNodeEntry* nodeEntry)
     }
     AiMetaDataIteratorDestroy(nodeMetadataIter);
 
+    // When we build against a static USD, we don't need to filter out shaders
+    // as we are just rendering a USD file and no UI is involved
+#ifndef PXR_STATIC
     if (hide)
         return;
+#endif
 
     auto prim = stage->DefinePrim(SdfPath(TfStringPrintf("/%s", AiNodeEntryGetName(nodeEntry))));
     const auto filename = AiNodeEntryGetFilename(nodeEntry);


### PR DESCRIPTION
When we run the node registry against a static USD, we don't need to filter out some shaders. 
This fix allows to render c4d tag shader with kick