### PR TITLE
Update FindUSD.cmake to remove architecture restriction

### DIFF
--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -108,9 +108,6 @@ if (MAYA_LOCATION AND MAYAUSD_LOCATION)
         find_usd_version(${PXR_INCLUDE_DIRS}) 
         message(STATUS "USD version ${USD_VERSION}")
 
-        # The mayausd libraries are only x86_64 on osx for the moment
-        set(CMAKE_OSX_ARCHITECTURES x86_64;arm64)
-
         set(USD_MONOLITHIC_BUILD OFF)
 
         # Variable for running usdGenSchema


### PR DESCRIPTION
Removed x86_64 architecture restriction for OSX.


**Issues fixed in this pull request**
Fixes Builds with arm64 only usd 
