### PR TITLE
MAXTOA-2033: bind volume shaders on step-size meshes

### DIFF
--- a/libs/translator/reader/utils.cpp
+++ b/libs/translator/reader/utils.cpp
@@ -202,46 +202,42 @@ AtArray *ReadLocalMatrix(const UsdPrim &prim, const TimeSettings &time)
     return array;
 
 }
-void GetMaterialTargets(const UsdShadeMaterial &mat, UsdPrim& shaderPrim, UsdPrim *dispPrim)
+void GetMaterialTargets(const UsdShadeMaterial &mat, UsdPrim& shaderPrim, UsdPrim *dispPrim, bool isVolume)
 {
-    // First search the material attachment in the arnold scope, then in the mtlx one
-    // Finally, ComputeSurfaceSource will look into the universal scope
+    // Resolve both the surface and the volume terminals. We search the arnold
+    // scope first, then the mtlx one; ComputeSurfaceSource / ComputeVolumeSource
+    // also look into the universal scope as a fallback.
 #if PXR_VERSION >= 2108
     TfTokenVector contextList {str::t_arnold, str::t_mtlx};
     UsdShadeShader surface = mat.ComputeSurfaceSource(contextList);
+    UsdShadeShader volume = mat.ComputeVolumeSource(contextList);
 #else
     // old method, we need to ask for each context explicitely
-    // First search the material attachment in the arnold scope
     UsdShadeShader surface = mat.ComputeSurfaceSource(str::t_arnold);
-    if (!surface) { // not found, check in the mtlx scope
+    if (!surface) // not found, check in the mtlx scope
         surface = mat.ComputeSurfaceSource(str::t_mtlx);
-    }
-    if (!surface) {// not found, search in the global scope
+    if (!surface) // not found, search in the global scope
         surface = mat.ComputeSurfaceSource();
-    }
 
-#endif
-    
-    if (surface) {
-        // Found a surface shader, let's add a connection to it (to be processed later)
-        shaderPrim = surface.GetPrim();
-    } else {
-        // No surface found in USD primitives
-
-        // We have a single "shader" binding in arnold, whereas USD has "surface"
-        // and "volume" For now we export volume only if surface is empty.
-#if PXR_VERSION >= 2108
-        UsdShadeShader volume = mat.ComputeVolumeSource(contextList);
-#else
-        // old method, we need to ask for each context explicitely
-        UsdShadeShader volume = mat.ComputeVolumeSource(str::t_arnold);
-        if (!volume)
-            volume = mat.ComputeVolumeSource();
+    UsdShadeShader volume = mat.ComputeVolumeSource(str::t_arnold);
+    if (!volume) // not found, search in the global scope
+        volume = mat.ComputeVolumeSource();
 #endif
 
-        if (volume)
-            shaderPrim = volume.GetPrim();
-    }
+    // Arnold shapes have a single "shader" slot, whereas USD distinguishes the
+    // "surface" and "volume" terminals. For a shape that is rendered as a volume
+    // (a native volume node, or a polymesh with step_size > 0) we must prefer the
+    // volume terminal: otherwise a universal / preview surface terminal (e.g. a
+    // UsdPreviewSurface authored for DCC interop) would shadow the actual volume
+    // shader, and the volume would be rendered as a (black) surface. For regular
+    // shapes we keep preferring the surface terminal, only falling back to the
+    // volume terminal when no surface is bound.
+    UsdShadeShader primary = isVolume ? volume : surface;
+    UsdShadeShader fallback = isVolume ? surface : volume;
+    if (primary)
+        shaderPrim = primary.GetPrim();
+    else if (fallback)
+        shaderPrim = fallback.GetPrim();
 
     if (dispPrim) { 
         // first check displacement in the arnold scope, then in the mtlx one,
@@ -282,7 +278,7 @@ void GetMaterialTargets(const UsdShadeMaterial &mat, UsdPrim& shaderPrim, UsdPri
         }
     }
 }
-static void _GetMaterialTargets(const UsdPrim &prim, UsdPrim& shaderPrim, UsdPrim *dispPrim = nullptr)
+static void _GetMaterialTargets(const UsdPrim &prim, UsdPrim& shaderPrim, UsdPrim *dispPrim = nullptr, bool isVolume = false)
 {
     // We want to get the material assignment for the "full" purpose, which is meant for rendering
     UsdShadeMaterial mat = UsdShadeMaterialBindingAPI(prim).ComputeBoundMaterial(UsdShadeTokens->full);
@@ -290,7 +286,7 @@ static void _GetMaterialTargets(const UsdPrim &prim, UsdPrim& shaderPrim, UsdPri
     if (!mat) {
         return;
     }
-    GetMaterialTargets(mat, shaderPrim, dispPrim);
+    GetMaterialTargets(mat, shaderPrim, dispPrim, isVolume);
 }
 
 // Read the materials / shaders assigned to a shape (node)
@@ -306,10 +302,10 @@ void ReadMaterialBinding(const UsdPrim &prim, AtNode *node, UsdArnoldReaderConte
         materialBoundPrim = prim.GetStage()->GetPrimAtPath(pathConsidered);
     }
     UsdPrim shaderPrim, dispPrim;
-    _GetMaterialTargets(materialBoundPrim, shaderPrim, isPolymesh ? &dispPrim : nullptr);
+    _GetMaterialTargets(materialBoundPrim, shaderPrim, isPolymesh ? &dispPrim : nullptr, IsVolume(node, prim));
 
     if (shaderPrim) {
-        context.AddConnection(node, "shader", shaderPrim.GetPath().GetString(), 
+        context.AddConnection(node, "shader", shaderPrim.GetPath().GetString(),
             ArnoldAPIAdapter::CONNECTION_PTR);
     } else if (assignDefault) {
         AiNodeSetPtr(node, str::shader, context.GetReader()->GetDefaultShader(IsVolume(node, prim)));
@@ -347,7 +343,7 @@ void ReadSubsetsMaterialBinding(
         shaderStr.clear();
         dispStr.clear();
 
-        _GetMaterialTargets(subset.GetPrim(), shaderPrim, isPolymesh ? &dispPrim : nullptr);
+        _GetMaterialTargets(subset.GetPrim(), shaderPrim, isPolymesh ? &dispPrim : nullptr, IsVolume(node, prim));
         if (shaderPrim)
             shaderStr = shaderPrim.GetPath().GetString();
         else if (assignDefault) {
@@ -400,7 +396,7 @@ void ReadSubsetsMaterialBinding(
         shaderStr.clear();
         dispStr.clear();
         UsdPrim shaderPrim, dispPrim;
-        _GetMaterialTargets(prim, shaderPrim, isPolymesh ? &dispPrim : nullptr);
+        _GetMaterialTargets(prim, shaderPrim, isPolymesh ? &dispPrim : nullptr, IsVolume(node, prim));
 
         if (shaderPrim) {
             shaderStr = shaderPrim.GetPath().GetString();

--- a/libs/translator/reader/utils.h
+++ b/libs/translator/reader/utils.h
@@ -101,7 +101,7 @@ void ApplyParentMatrices(AtArray *matrices, const AtArray *parentMatrices);
 void ReadLightShaders(const UsdPrim& prim, const UsdAttribute &attr, AtNode *node, UsdArnoldReaderContext &context);
 void ReadCameraShaders(const UsdPrim& prim, AtNode *node, UsdArnoldReaderContext &context);
 
-void GetMaterialTargets(const UsdShadeMaterial &mat, UsdPrim& shaderPrim, UsdPrim *dispPrim = nullptr);
+void GetMaterialTargets(const UsdShadeMaterial &mat, UsdPrim& shaderPrim, UsdPrim *dispPrim = nullptr, bool isVolume = false);
 
 // The normals can be set on primvars:normals or just normals. 
 // primvars:normals takes "precedence" over "normals"

--- a/libs/translator/writer/prim_writer.cpp
+++ b/libs/translator/writer/prim_writer.cpp
@@ -1258,6 +1258,20 @@ void UsdArnoldPrimWriter::_WriteMatrix(UsdGeomXformable& xformable, const AtNode
     AiArrayUnmapConst(array);
 }
 
+// A shape is rendered as a volume either when it's a native volume node, or when
+// it's a polymesh with a positive step_size (an implicit / mesh volume). This must
+// stay consistent with the reader's IsVolume() (see reader/read_geometry.cpp),
+// otherwise volume shaders get wired into the surface slot and are dropped at import
+// (falling back to _fallbackVolume).
+static bool IsVolumeShape(const AtNode* node)
+{
+    if (AiNodeIs(node, str::volume))
+        return true;
+    if (AiNodeIs(node, str::polymesh))
+        return AiNodeGetFlt(node, str::step_size) > AI_EPSILON;
+    return false;
+}
+
 static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim& prim, UsdArnoldWriter& writer, bool isVolume = false)
 {
    
@@ -1429,7 +1443,7 @@ void UsdArnoldPrimWriter::_WriteMaterialBinding(
                 UsdPrim subsetPrim = subset.GetPrim();
 
                 // Process the material binding on the subset primitive
-                processMaterialBinding(shader, displacement, subsetPrim, writer);
+                processMaterialBinding(shader, displacement, subsetPrim, writer, IsVolumeShape(node));
             }
             AiArrayUnmap(shidxsArray);
             return;
@@ -1441,5 +1455,5 @@ void UsdArnoldPrimWriter::_WriteMaterialBinding(
     static const AtString polymesh_str("polymesh");
     AtNode* displacement = (AiNodeIs(node, polymesh_str)) ? (AtNode*)AiNodeGetPtr(node, AtString("disp_map")) : nullptr;
 
-    processMaterialBinding(shader, displacement, prim, writer, AiNodeIs(node, str::volume));
+    processMaterialBinding(shader, displacement, prim, writer, IsVolumeShape(node));
 }

--- a/libs/translator/writer/prim_writer.cpp
+++ b/libs/translator/writer/prim_writer.cpp
@@ -1332,6 +1332,27 @@ static void processMaterialBinding(AtNode* shader, AtNode* displacement, UsdPrim
         UsdShadeMaterialBindingAPI::Apply(prim).Bind(mat);
     }
 
+    // A shape rendered as a volume uses only the volume terminal. If the bound
+    // material already exposes a surface terminal (e.g. a UsdPreviewSurface that
+    // MaxUSD authors for interop), strip it: UsdImaging's Hydra-1 material
+    // adapter builds the surface terminal and then SKIPS the volume one
+    // ("surface XOR volume" in UsdImagingMaterialAdapter::GetMaterialResource),
+    // so the volume shape would get no shader and render black. Removing the
+    // surface terminal lets ComputeSurfaceSource return empty, so the volume
+    // terminal is built for all code paths. See MAXTOA-2033.
+    if (isVolume && mat) {
+        static const TfToken s_surfaceOutputs[] = {
+            TfToken("outputs:surface"),         // universal render context
+            TfToken("outputs:arnold:surface"),  // arnold render context
+            TfToken("outputs:mtlx:surface")     // materialx render context
+        };
+        UsdPrim matPrim = mat.GetPrim();
+        for (const TfToken& outputName : s_surfaceOutputs) {
+            if (matPrim.HasProperty(outputName))
+                matPrim.RemoveProperty(outputName);
+        }
+    }
+
     // Now bind the eventual surface shader and displacement to the material.
 
     // Store the previous writer scope, and set a new one based on the material name.

--- a/testsuite/test_17642.1/README
+++ b/testsuite/test_17642.1/README
@@ -1,0 +1,10 @@
+A polymesh rendered as an implicit volume (step_size > 0) with a standard_volume
+shader must export the shader through the material's volume output, not the
+surface output. Otherwise the shape is treated as a volume on import, the
+surface-bound shader is dropped, and it falls back to _fallbackVolume (a black,
+non-emissive volume).
+
+Follow-up to #2615 (ARNOLD-17642), which only handled native volume nodes.
+See MAXTOA-2033.
+
+author: zap.andersson and Claude

--- a/testsuite/test_17642.1/data/test.py
+++ b/testsuite/test_17642.1/data/test.py
@@ -1,0 +1,85 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['ARNOLD_PATH'], 'python'))
+from arnold import *
+
+# A polymesh with step_size > 0 is rendered as an implicit volume. Its
+# standard_volume shader must be exported through the material's *volume* output,
+# not the surface output. Otherwise, on import the shape is treated as a volume,
+# the surface-bound shader is not picked up, and it falls back to _fallbackVolume
+# (a black / non-emissive volume).
+#
+# #2615 (ARNOLD-17642) added volume-context export but only for native volume
+# nodes; this covers the mesh-implicit-volume case. See MAXTOA-2033.
+
+usdScene = 'test_resaved.usda'
+
+AiBegin()
+universe = AiUniverse()
+
+camera = AiNode(universe, 'persp_camera', '/persp')
+options = AiUniverseGetOptions(universe)
+AiNodeSetStr(options, 'camera', '/persp')
+
+vol_shader = AiNode(universe, 'standard_volume', '/mtl/volume_mtl/standard_volume0')
+AiNodeSetFlt(vol_shader, 'density', 1.0)
+AiNodeSetStr(vol_shader, 'emission_mode', 'density')
+AiNodeSetFlt(vol_shader, 'emission', 1.0)
+AiNodeSetRGB(vol_shader, 'emission_color', 1.0, 0.5, 0.1)
+
+# A box rendered as an implicit volume (step_size > 0)
+box = AiNode(universe, 'polymesh', '/volume_box')
+AiNodeSetArray(box, 'vlist', AiArray(8, 1, AI_TYPE_VECTOR,
+    AtVector(-1, -1, -1), AtVector(1, -1, -1),
+    AtVector(-1,  1, -1), AtVector(1,  1, -1),
+    AtVector(-1, -1,  1), AtVector(1, -1,  1),
+    AtVector(-1,  1,  1), AtVector(1,  1,  1)))
+AiNodeSetArray(box, 'nsides', AiArray(6, 1, AI_TYPE_UINT, 4, 4, 4, 4, 4, 4))
+AiNodeSetArray(box, 'vidxs', AiArray(24, 1, AI_TYPE_UINT,
+    0, 1, 3, 2,  4, 6, 7, 5,  0, 4, 5, 1,
+    2, 3, 7, 6,  0, 2, 6, 4,  1, 5, 7, 3))
+AiNodeSetFlt(box, 'step_size', 0.25)
+AiNodeSetPtr(box, 'shader', vol_shader)
+
+params = AiParamValueMap()
+AiParamValueMapSetBool(params, 'binary', False)
+success = AiSceneWrite(universe, usdScene, params)
+AiParamValueMapDestroy(params)
+AiUniverseDestroy(universe)
+AiEnd()
+
+if not success:
+    print('ERROR: Scene export failed')
+    sys.exit(-1)
+
+# ---------------------------------------------------------------------------
+#  Validate the resulting USD file
+# ---------------------------------------------------------------------------
+with open(usdScene, 'r') as f:
+    lines = f.readlines()
+
+errors = []
+
+# sanity: the mesh must have been exported as a step-size volume
+if not any('primvars:arnold:step_size' in line for line in lines):
+    errors.append('step_size was not exported on the mesh')
+
+# the volume shader must be connected to the material's volume output ...
+if not any('outputs:arnold:volume.connect' in line and 'standard_volume0' in line
+           for line in lines):
+    errors.append('volume shader not connected to the material volume output')
+
+# ... and must NOT be wired into the surface output
+if any('outputs:arnold:surface.connect' in line and 'standard_volume0' in line
+       for line in lines):
+    errors.append('volume shader wired into the surface output')
+
+if errors:
+    for e in errors:
+        print('FAIL: %s' % e)
+    print('\n--- Generated USD file ---')
+    print(''.join(lines))
+    sys.exit(-1)
+
+print('SUCCESS')

--- a/testsuite/test_17642.2/README
+++ b/testsuite/test_17642.2/README
@@ -1,0 +1,10 @@
+When a shape is rendered as a volume (a native volume node, or a polymesh with
+step_size > 0), the reader must resolve the material's volume terminal with
+priority over the surface terminal. Otherwise a universal / preview surface
+terminal (e.g. a UsdPreviewSurface authored by MaxUSD for interop) shadows the
+real volume shader via ComputeSurfaceSource's universal-scope fallback, and the
+volume is bound a surface shader and renders black.
+
+Companion (reader side) to test_17642.1. See MAXTOA-2033.
+
+author: zap.andersson and Claude

--- a/testsuite/test_17642.2/data/test.py
+++ b/testsuite/test_17642.2/data/test.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['ARNOLD_PATH'], 'python'))
+from arnold import *
+
+# Load a scene where a step-size volume mesh is bound to a material carrying both
+# an arnold:volume terminal (standard_volume) and a universal surface terminal
+# (UsdPreviewSurface). The reader must prefer the volume terminal for the volume
+# shape, so the mesh ends up with the standard_volume as its shader - not the
+# preview surface (which would render the volume black). See MAXTOA-2033.
+
+AiBegin()
+universe = AiUniverse()
+AiSceneLoad(universe, 'test.usda', None)
+
+# Find the polymesh (the implicit volume)
+mesh = None
+it = AiUniverseGetNodeIterator(universe, AI_NODE_SHAPE)
+while not AiNodeIteratorFinished(it):
+    n = AiNodeIteratorGetNext(it)
+    if AiNodeIs(n, 'polymesh'):
+        mesh = n
+        break
+AiNodeIteratorDestroy(it)
+
+errors = []
+if mesh is None:
+    errors.append('no polymesh found in the scene')
+else:
+    shader = AiNodeGetPtr(mesh, 'shader')
+    if not shader:
+        errors.append('no shader bound to the volume mesh')
+    else:
+        entry = AiNodeEntryGetName(AiNodeGetNodeEntry(shader))
+        if entry != 'standard_volume':
+            errors.append('expected standard_volume bound to the volume mesh, got "%s" (%s)'
+                          % (entry, AiNodeGetName(shader)))
+
+AiUniverseDestroy(universe)
+AiEnd()
+
+if errors:
+    for e in errors:
+        print('FAIL: %s' % e)
+    sys.exit(-1)
+
+print('SUCCESS')

--- a/testsuite/test_17642.2/data/test.usda
+++ b/testsuite/test_17642.2/data/test.usda
@@ -1,0 +1,46 @@
+#usda 1.0
+(
+    doc = """Reader regression for MAXTOA-2033.
+
+A polymesh rendered as an implicit volume (step_size > 0) is bound to a material
+that has BOTH an arnold:volume terminal (the real volume shader) AND a universal
+'surface' terminal wired to a UsdPreviewSurface (as MaxUSD authors for interop).
+The reader must bind the standard_volume to the shape, not the preview surface -
+otherwise the volume renders as a (black) surface."""
+    defaultPrim = "volume_box"
+)
+
+def Mesh "volume_box"
+{
+    float3[] extent = [(-1, -1, -1), (1, 1, 1)]
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 1, 3, 2,  4, 6, 7, 5,  0, 4, 5, 1,
+                               2, 3, 7, 6,  0, 2, 6, 4,  1, 5, 7, 3]
+    point3f[] points = [(-1, -1, -1), (1, -1, -1), (-1, 1, -1), (1, 1, -1),
+                        (-1, -1, 1),  (1, -1, 1),  (-1, 1, 1),  (1, 1, 1)]
+    float primvars:arnold:step_size = 0.25
+    rel material:binding = </mtl/volume_mtl>
+}
+
+def Scope "mtl"
+{
+    def Material "volume_mtl"
+    {
+        token outputs:arnold:volume.connect = </mtl/volume_mtl/vol_shader.outputs:out>
+        token outputs:surface.connect = </mtl/volume_mtl/preview.outputs:surface>
+
+        def Shader "vol_shader"
+        {
+            uniform token info:id = "arnold:standard_volume"
+            float inputs:density = 1
+            token outputs:out
+        }
+
+        def Shader "preview"
+        {
+            uniform token info:id = "UsdPreviewSurface"
+            color3f inputs:diffuseColor = (0.8, 0.1, 0.1)
+            token outputs:surface
+        }
+    }
+}


### PR DESCRIPTION
A polymesh with step_size > 0 renders as an implicit volume, but the writer only routed shaders to the material's volume terminal for native volume nodes, so a mesh-volume's standard_volume landed on the surface terminal. On read-back the shape is treated as a volume and the surface-bound shader is dropped (falling back to _fallbackVolume), rendering black.

- Writer: treat a polymesh with step_size > 0 as a volume (matching the reader's IsVolume) so its shader is written to the volume terminal.
- Reader: for volume shapes, resolve the volume terminal with priority over the surface terminal, so a universal/preview surface (e.g. a UsdPreviewSurface from MaxUSD) can't shadow it.
- Add writer (test_17642.1) and reader (test_17642.2) regression tests.

- 

**Issues fixed in this pull request**
Fixes MAXTOA-2033: FlowRender: Differences in Volume Rendering

**Additional context**
Add any other context or screenshots about the pull request here.
