### PR TITLE
Fix invalid null shader being authored to USD from Maya

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - [usd#2641](https://github.com/Autodesk/arnold-usd/issues/2641) - Animate instanced lights driven by an animated Point Instancer in Hydra
 - [usd#2695](https://github.com/Autodesk/arnold-usd/issues/2695) - Fix MaterialX boolean shaders through USD
 - [usd#2628](https://github.com/Autodesk/arnold-usd/issues/2628) - Fix crash happening after changing the purpose in hydra
+- [usd#2621](https://github.com/Autodesk/arnold-usd/issues/2621) - Fix invalid null shader being authored to USD from Maya
+
 
 ## [7.5.2.0] (Unreleased)
 

--- a/libs/translator/writer/prim_writer.cpp
+++ b/libs/translator/writer/prim_writer.cpp
@@ -915,7 +915,7 @@ static inline bool convertArnoldAttribute(
                 }
 
                 if (strcmp(paramName, "shader") == 0 && numElements == 1) {
-                    if (vtArr[0] == "ai_default_reflection_shader") {
+                    if (vtArr[0] == "ai_default_reflection_shader" || vtArr[0].empty()) {
                         break;
                     }
                 }


### PR DESCRIPTION
When we author the arnold shader attribute, we skip authoring it if it's empty. But when the shader is an unknown one then the shaders array has 1 element that has a null value.. In that case we also want to skip authoring it, since it overrides an eventual material binding

**Issues fixed in this pull request**
Fixes #2621 
