### PR TITLE
Add env variable for flattened instancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [usd#2687](https://github.com/Autodesk/arnold-usd/issues/2687) - Support double-precision primvars
 - [usd#2691](https://github.com/Autodesk/arnold-usd/issues/2691) - Support mesh normals updates interactively
 - [usd#2686](https://github.com/Autodesk/arnold-usd/issues/2686) - Prevent subdivisionScheme from being written as timeSamples in USD export
+- [usd#2712](https://github.com/Autodesk/arnold-usd/pull/2712) - Add env variable HDARNOLD_FLATTEN_INSTANCING to flatten the nested instancers
 
 ### Bug Fixes
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -135,6 +135,9 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     ARNOLD_XSTR(PXR_MAJOR_VERSION) "." ARNOLD_XSTR(PXR_MINOR_VERSION) "." ARNOLD_XSTR(PXR_PATCH_VERSION)
 
 TF_DEFINE_ENV_SETTING(HDARNOLD_SHAPE_INSTANCING, "", "Set to 0 to disable inner shape instancing");
+TF_DEFINE_ENV_SETTING(
+    HDARNOLD_FLATTEN_INSTANCING, "",
+    "Set to 1 to flatten nested instances into shape instancing instead of using nested arnold instancer nodes");
 
 namespace {
 
@@ -663,7 +666,12 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
     _supportShapeInstancing = envShapeInstancing != std::string("0");
 #else
     _supportShapeInstancing = false;
-#endif    
+#endif
+
+    // When enabled, nested instances are flattened into shape instancing instead of
+    // being handled by a chain of nested arnold instancer nodes. Defaults to disabled.
+    std::string envFlattenInstancing = TfGetEnvSetting(HDARNOLD_FLATTEN_INSTANCING);
+    _flattenInstancing = envFlattenInstancing == std::string("1");
     
 }
 

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -710,6 +710,10 @@ public:
     // Return true if the render delegate supports shape instancing
     bool SupportShapeInstancing () const {return _supportShapeInstancing;}
 
+    // Return true if nested instances should be flattened into shape instancing
+    // instead of using nested arnold instancer nodes
+    bool FlattenInstancing () const {return _flattenInstancing;}
+
     HydraArnoldReader *GetReader() {return _reader;} 
     void SetReader(HydraArnoldReader *r) {_reader = r;} 
     bool HasCryptomatte() const {return _hasCryptomatte;}
@@ -843,6 +847,7 @@ private:
     bool _renderDelegateOwnsUniverse;
     bool _enableNodesDestruction = true;
     bool _supportShapeInstancing = true;
+    bool _flattenInstancing = false;
     bool _forceIgnoreMotionBlur = false;
     bool _useHydraRenderSettings = false;
     std::unordered_map<std::string, AtNode *> _nodeNames;

--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -140,12 +140,15 @@ static bool UseArnoldInstancer(HdSceneDelegate* sceneDelegate, HdArnoldRenderDel
         return true;
 
     // If we have a nested instancer configuration, we'll use an arnold instancer node.
-    // Nested instances are now handled by a chain of arnold instancer nodes
+    // Nested instances are handled by a chain of arnold instancer nodes
     // (see HdArnoldInstancer::CreateArnoldInstancer) rather than being flattened into
-    // shape instancing.
-    HdInstancer* parentInstancer = sceneDelegate->GetRenderIndex().GetInstancer(instancer->GetParentId());
-    if (parentInstancer)
-        return true;
+    // shape instancing. Unless HDARNOLD_FLATTEN_INSTANCING is enabled, in which case we
+    // skip this test and flatten the nested instances into shape instancing.
+    if (!renderDelegate->FlattenInstancing()) {
+        HdInstancer* parentInstancer = sceneDelegate->GetRenderIndex().GetInstancer(instancer->GetParentId());
+        if (parentInstancer)
+            return true;
+    }
 
     // Procedural nodes do not currently support shapes inner instancing
     return AiNodeEntryGetDerivedType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE_PROCEDURAL;

--- a/libs/render_delegate/shape.cpp
+++ b/libs/render_delegate/shape.cpp
@@ -139,6 +139,14 @@ static bool UseArnoldInstancer(HdSceneDelegate* sceneDelegate, HdArnoldRenderDel
     if (!renderDelegate->SupportShapeInstancing())
         return true;
 
+    // If we have a nested instancer configuration, we'll use an arnold instancer node.
+    // Nested instances are now handled by a chain of arnold instancer nodes
+    // (see HdArnoldInstancer::CreateArnoldInstancer) rather than being flattened into
+    // shape instancing.
+    HdInstancer* parentInstancer = sceneDelegate->GetRenderIndex().GetInstancer(instancer->GetParentId());
+    if (parentInstancer)
+        return true;
+
     // Procedural nodes do not currently support shapes inner instancing
     return AiNodeEntryGetDerivedType(AiNodeGetNodeEntry(node)) == AI_NODE_SHAPE_PROCEDURAL;
 }


### PR DESCRIPTION
**Changes proposed in this pull request**
Instead of forcing flattened instancing as done in 7.5.2.0 we want to add an env variable to control it. 
This variable defaults to false as we don't want the flattening to happen by default