### PR TITLE
Support pausing the render in the render delegate (#2719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Changelog
 
+## [7.5.4.0 Tentative] (Unreleased)
+
+- [usd#2719](https://github.com/Autodesk/arnold-usd/issues/2719) - Add support for resumable rendering in the render delegate.
 
 ## [7.5.3.1] (Unreleased)
 

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -1953,7 +1953,9 @@ bool HdArnoldRenderDelegate::IsPauseSupported() const
 #endif
 }
 
+#if PXR_VERSION >= 2203
 bool HdArnoldRenderDelegate::IsPaused() const { return _renderParam->IsPaused(); }
+#endif
 
 bool HdArnoldRenderDelegate::IsStopSupported() const { return true; }
 
@@ -1963,9 +1965,9 @@ bool HdArnoldRenderDelegate::Stop(bool blocking)
 bool HdArnoldRenderDelegate::Stop()
 #endif
 {
-    // A hard stop: fully interrupt the render rather than the resumable pause
-    // gate used by Pause() below.
-    _renderParam->Interrupt(false, false);
+    // A hard stop: fully interrupt the render, and keep it stopped until Restart(),
+    // rather than parking it at the resumable pause gate used by Pause() below.
+    _renderParam->Stop();
     return true;
 }
 
@@ -1989,7 +1991,13 @@ bool HdArnoldRenderDelegate::Restart()
 
 #if PXR_VERSION >= 2203
 bool HdArnoldRenderDelegate::IsStopped() const
-{   
+{
+    // A render parked at the AiRenderPause() gate keeps reporting AI_RENDER_STATUS_RENDERING, so the Arnold status
+    // alone would miss it. That is intentional here -- paused is not stopped, and IsPaused() reports that instead --
+    // but a Stop() has to be reported even before the next UpdateRender() tick observes the interrupted status.
+    if (_renderParam->IsStopped()) {
+        return true;
+    }
     int status = AiRenderGetStatus(GetRenderSession());
     return (status != AI_RENDER_STATUS_RENDERING && status != AI_RENDER_STATUS_RESTARTING);
 }

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -737,8 +737,10 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
     //   https://www.sidefx.com/docs/hdk/_h_d_k__u_s_d_hydra.html#HDK_USDHydraCopTextures
     if (_key == str::t_houdiniCopTextureChanged) {
         // COP textures need updating, flush the texture cache to trigger a refresh
-        // of all the image_cop nodes
-        _renderParam->Pause();
+        // of all the image_cop nodes. Use Interrupt() directly rather than Pause(),
+        // which now issues a resumable AiRenderPause() on newer Arnold versions --
+        // this needs a hard stop so the cache flush below is safe.
+        _renderParam->Interrupt(false, false);
         AiUniverseCacheFlush(_universe, AI_CACHE_TEXTURE);
         _renderParam->Restart();
     }
@@ -1942,7 +1944,16 @@ bool HdArnoldRenderDelegate::HasPendingChanges(HdRenderIndex* renderIndex, const
     return changes;
 }
 
-bool HdArnoldRenderDelegate::IsPauseSupported() const { return false; }
+bool HdArnoldRenderDelegate::IsPauseSupported() const
+{
+#if ARNOLD_VERSION_NUM >= 70504
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool HdArnoldRenderDelegate::IsPaused() const { return _renderParam->IsPaused(); }
 
 bool HdArnoldRenderDelegate::IsStopSupported() const { return true; }
 
@@ -1951,6 +1962,14 @@ bool HdArnoldRenderDelegate::Stop(bool blocking)
 #else
 bool HdArnoldRenderDelegate::Stop()
 #endif
+{
+    // A hard stop: fully interrupt the render rather than the resumable pause
+    // gate used by Pause() below.
+    _renderParam->Interrupt(false, false);
+    return true;
+}
+
+bool HdArnoldRenderDelegate::Pause()
 {
     _renderParam->Pause();
     return true;
@@ -2178,8 +2197,10 @@ HdCommandDescriptors HdArnoldRenderDelegate::GetCommandDescriptors() const
 bool HdArnoldRenderDelegate::InvokeCommand(const TfToken& command, const HdCommandArgs& args)
 {
     if (command == TfToken("flush_texture")) {
-        // Stop render
-        _renderParam->Pause();
+        // Stop render. Use Interrupt() directly rather than Pause(), which now
+        // issues a resumable AiRenderPause() on newer Arnold versions -- this
+        // needs a hard stop so the cache flush below is safe.
+        _renderParam->Interrupt(false, false);
         // Flush texture
         AiUniverseCacheFlush(_universe, AI_CACHE_TEXTURE);
         // Restart the render

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -368,12 +368,20 @@ public:
         _delegateRenderProductsDirty = true;
     }
     /// Advertise whether this delegate supports pausing and resuming of
-    /// background render threads. Default implementation returns false.
+    /// background render threads. True when Arnold provides the resumable
+    /// AiRenderPause()/AiRenderResume() API, false otherwise.
     ///
-    /// @return True if pause/restart is supported.
+    /// @return True if pause/resume is supported.
     HDARNOLD_API
     bool IsPauseSupported() const override;
-    
+
+    /// Query the delegate's pause state.
+    ///
+    /// @return True if a Pause() call is currently in effect (i.e. no Resume(),
+    ///  Restart(), or scene edit has cancelled it since).
+    HDARNOLD_API
+    bool IsPaused() const override;
+
     /// Advertise whether this delegate supports stopping and restarting of
     /// background render threads. Default implementation returns false.
     ///
@@ -406,9 +414,18 @@ public:
     HDARNOLD_API
     bool Restart() override;
 
+    /// Pause all of this delegate's background rendering threads. Only takes
+    /// effect when IsPauseSupported() returns true; preserves render progress
+    /// via AiRenderPause() rather than interrupting the render.
+    ///
+    /// @return True if successful.
+    HDARNOLD_API
+    bool Pause() override;
+
     /// Resume all of this delegate's background rendering threads previously
-    /// paused by a call to Pause. Default implementation does nothing. This is
-    /// currently doing the same as restart
+    /// paused by a call to Pause.
+    ///
+    /// @return True if successful.
     HDARNOLD_API
     bool Resume() override;
 

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -375,12 +375,15 @@ public:
     HDARNOLD_API
     bool IsPauseSupported() const override;
 
+    // HdRenderDelegate::IsPaused()/IsStopped() were only added in USD 22.03.
+#if PXR_VERSION >= 2203
     /// Query the delegate's pause state.
     ///
     /// @return True if a Pause() call is currently in effect (i.e. no Resume(),
     ///  Restart(), or scene edit has cancelled it since).
     HDARNOLD_API
     bool IsPaused() const override;
+#endif
 
     /// Advertise whether this delegate supports stopping and restarting of
     /// background render threads. Default implementation returns false.

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -66,6 +66,7 @@ HdArnoldRenderParam::HdArnoldRenderParam(HdArnoldRenderDelegate* delegate) : _de
     _needsRestart.store(false, std::memory_order::memory_order_release);
     _aborted.store(false, std::memory_order::memory_order_release);
     _paused.store(false, std::memory_order::memory_order_release);
+    _stopped.store(false, std::memory_order::memory_order_release);
 
     ResetStartTimer();
 
@@ -89,7 +90,11 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
         return Status::Aborted;
     }
     const bool needsRestart = _needsRestart.exchange(false, std::memory_order_acq_rel);
-    const bool paused = _paused.exchange(false, std::memory_order_acq_rel);
+    // _paused and _stopped are plain state, not one-shot intents: read them without consuming them, so there is no
+    // window where they read false while the render is genuinely paused/stopped, and no branch below has to
+    // remember to store them back. Only Pause()/Stop() set them and only Resume()/Restart()/Interrupt() clear them.
+    const bool paused = _paused.load(std::memory_order_acquire);
+    const bool stopped = _stopped.load(std::memory_order_acquire);
 
     const auto renderStatus = AiRenderGetStatus(_delegate->GetRenderSession());
     switch(renderStatus) {
@@ -99,26 +104,37 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             if (needsRestart) {
                 _needsRestart.store(true, std::memory_order_release);
             }
-            if (paused) {
-                _paused.store(true, std::memory_order_release);
 #if ARNOLD_VERSION_NUM >= 70504
-                // Pause() may have raced a brief RESTARTING window, during which
-                // AiRenderPause() silently no-ops (it only takes effect while the
-                // status is exactly RENDERING). Re-issue it here so the pause
-                // request isn't dropped; harmless/idempotent once already gated.
-                if (renderStatus == AI_RENDER_STATUS_RENDERING) {
-                    AiRenderPause(_delegate->GetRenderSession());
-                }
-#endif
+            // A gated render keeps reporting AI_RENDER_STATUS_RENDERING, so the status alone cannot tell us whether
+            // the pause request already took effect: ask Arnold directly. AiRenderPause() only takes effect while
+            // the status is exactly RENDERING and silently no-ops otherwise, so this is where a Pause() that raced
+            // a RESTARTING window, or one issued while the session was sitting interrupt-PAUSED, actually gets
+            // established -- and doing it here rather than unconditionally avoids re-issuing AiRenderPause() on
+            // every single tick of the poll loop for the whole duration of the pause.
+            if (paused && renderStatus == AI_RENDER_STATUS_RENDERING &&
+                !AiRenderIsPaused(_delegate->GetRenderSession())) {
+                AiRenderPause(_delegate->GetRenderSession());
             }
+#endif
             return Status::Converging;
 
         case AI_RENDER_STATUS_FINISHED:
             // If render restart is true, it means the Render Delegate received an update after rendering has finished
             // and AiRenderInterrupt does not change the status anymore.
             // For the atomic operations we are using a release-acquire model.
-            
+
+            if (stopped) {
+                // Stop() is in effect: keep the restart request queued for the Restart() that lifts it, rather
+                // than relaunching a render the host asked us to stop.
+                if (needsRestart) {
+                    _needsRestart.store(true, std::memory_order_release);
+                }
+                return Status::Converging;
+            }
             if (needsRestart) {
+                // Restarting from FINISHED is a real restart, exactly like the pause-cancelling Interrupt() that
+                // usually precedes it, so the pause is no longer in effect -- clear it instead of leaving a stale
+                // flag behind (there is nothing left to unpause: the gated threads are long gone).
                 _paused.store(false, std::memory_order_release);
                 if (!_debugScene.empty())
                     WriteDebugScene();
@@ -133,6 +149,16 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             return Status::Converged;
         
         case AI_RENDER_STATUS_PAUSED:
+            // Arnold reports PAUSED after an AiRenderInterrupt(), i.e. the render threads are parked and progress
+            // has been discarded. Left to itself this branch resumes the render on the very next tick, which is
+            // what a scene edit wants -- but not what Stop() wants, so honour a stop before anything else and keep
+            // any pending restart queued for the Restart() that lifts it.
+            if (stopped) {
+                if (needsRestart) {
+                    _needsRestart.store(true, std::memory_order_release);
+                }
+                return Status::Converging;
+            }
             if (needsRestart) {
                 if (!_debugScene.empty())
                     WriteDebugScene();
@@ -177,13 +203,16 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             return Status::Aborted;
         
         case AI_RENDER_STATUS_NOT_STARTED:
-            // If the caller already requested a pause before the render even
-            // begins (e.g., a viewport that opens in a paused state), honour
-            // it: do not call AiRenderBegin, and put `_paused` back so the
-            // next UpdateRender iterations continue to see the pause request
-            // until Resume() / Restart() clears it.
-            if (paused) {
-                _paused.store(true, std::memory_order_release);
+            // If the caller already requested a pause or a stop before the render even begins (e.g., a viewport
+            // that opens in a paused state), honour it: do not call AiRenderBegin. Arnold cannot help here --
+            // AiRenderPause() silently no-ops on a session that has not started -- so this relies entirely on
+            // `_paused`/`_stopped`, which stay set until Resume() / Restart() clears them. Keep any pending restart
+            // request queued for then; it is inert before the render begins (AiRenderBegin picks up every edit
+            // anyway), but dropping it would lose the signal for anything else that polls it.
+            if (paused || stopped) {
+                if (needsRestart) {
+                    _needsRestart.store(true, std::memory_order_release);
+                }
                 return Status::Converging;
             }
             if (!_debugScene.empty())
@@ -208,12 +237,10 @@ void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus, bool cl
         status == AI_RENDER_STATUS_PAUSED) {
         AiRenderInterrupt(_delegate->GetRenderSession(), AI_BLOCKING);
         if (clearPaused) {
-            // A real interrupt tears down or fully unparks any in-flight render, including
-            // one gated by AiRenderPause(): Arnold's pause gate has no mechanism to discard
-            // accumulated samples across a scene edit (AiRenderResume()/AiRenderRestart() are
-            // equivalent while gated, see Resume()), so a restart driven by this interrupt
-            // will actually resume rendering. Clear _paused so it doesn't keep claiming
-            // "paused" once the render is active again -- otherwise it gets stuck true
+            // A real interrupt unparks any in-flight render, including one gated by AiRenderPause(): it clears
+            // Arnold's own pause flag (AiRenderIsPaused() goes false) and parks the session at
+            // AI_RENDER_STATUS_PAUSED, from where UpdateRender() resumes or restarts it. Clear _paused to match, so
+            // it doesn't keep claiming "paused" once the render is active again -- otherwise it gets stuck true
             // forever, since nothing else clears it on this path.
             _paused.store(false, std::memory_order_release);
         }
@@ -232,6 +259,9 @@ void HdArnoldRenderParam::Pause()
     // Arnold 7.5.4+ can pause render threads at a gate without terminating
     // them, preserving render progress, instead of the old interrupt-based
     // approach below which fully tears down the in-flight render.
+    // AiRenderPause() is issued unconditionally rather than guarded on the render status like Interrupt() is: it
+    // only takes effect while the status is exactly RENDERING and silently no-ops in every other state, and the
+    // `_paused` store below is what makes the request stick until UpdateRender() can establish the gate.
     _paused.store(true, std::memory_order_release);
     if (_delegate != nullptr && !_delegate->IsBatchContext()) {
         AiRenderPause(_delegate->GetRenderSession());
@@ -253,7 +283,8 @@ void HdArnoldRenderParam::Pause()
 
 void HdArnoldRenderParam::Resume()
 {
-    _paused.store(false, std::memory_order_release);
+    const bool wasPaused = _paused.exchange(false, std::memory_order_acq_rel);
+    const bool wasStopped = _stopped.exchange(false, std::memory_order_acq_rel);
 #if ARNOLD_VERSION_NUM >= 70504
     // Explicitly lift the pause gate here rather than waiting for the next
     // UpdateRender poll, since AiRenderGetStatus() keeps reporting RENDERING
@@ -262,12 +293,33 @@ void HdArnoldRenderParam::Resume()
         AiRenderResume(_delegate->GetRenderSession());
     }
 #endif
+    if (wasPaused || wasStopped) {
+        // Restart the clock so the time spent parked at the gate is not billed to the render: the elapsed time is
+        // reported as render statistics, and UpdateRender()'s own resume path resets it for the same reason.
+        ResetStartTimer();
+    }
+}
+
+void HdArnoldRenderParam::Stop()
+{
+    // A hard stop: interrupt the render for real (discarding progress) rather than parking it at the resumable
+    // AiRenderPause() gate, and latch `_stopped` so UpdateRender() keeps it stopped. Without that latch the
+    // interrupt only leaves the session at AI_RENDER_STATUS_PAUSED, which the very next UpdateRender() tick
+    // resumes -- so the render would restart on its own, one frame after being stopped.
+    // Publish the stop before issuing the interrupt, for the same reason Pause() does: Interrupt() blocks until
+    // Arnold transitions the render status away from RENDERING, so a store afterwards leaves a window where a
+    // concurrent UpdateRender call sees status == PAUSED with `_stopped == false` and resumes the render we were
+    // asked to stop. Note this also latches when there is no render to interrupt, which is intended: a stop
+    // requested before AiRenderBegin() has to keep UpdateRender() from starting one.
+    _stopped.store(true, std::memory_order_release);
+    Interrupt(false, false);
 }
 
 void HdArnoldRenderParam::Restart()
 {
     _aborted.store(false, std::memory_order_release);
     _paused.store(false, std::memory_order_release);
+    _stopped.store(false, std::memory_order_release);
     _needsRestart.store(true, std::memory_order_release);
 }
 

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -91,7 +91,8 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
     const bool needsRestart = _needsRestart.exchange(false, std::memory_order_acq_rel);
     const bool paused = _paused.exchange(false, std::memory_order_acq_rel);
 
-    switch(AiRenderGetStatus(_delegate->GetRenderSession())) {
+    const auto renderStatus = AiRenderGetStatus(_delegate->GetRenderSession());
+    switch(renderStatus) {
 
         case AI_RENDER_STATUS_RESTARTING:
         case AI_RENDER_STATUS_RENDERING:
@@ -100,9 +101,18 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
             }
             if (paused) {
                 _paused.store(true, std::memory_order_release);
+#if ARNOLD_VERSION_NUM >= 70504
+                // Pause() may have raced a brief RESTARTING window, during which
+                // AiRenderPause() silently no-ops (it only takes effect while the
+                // status is exactly RENDERING). Re-issue it here so the pause
+                // request isn't dropped; harmless/idempotent once already gated.
+                if (renderStatus == AI_RENDER_STATUS_RENDERING) {
+                    AiRenderPause(_delegate->GetRenderSession());
+                }
+#endif
             }
             return Status::Converging;
-        
+
         case AI_RENDER_STATUS_FINISHED:
             // If render restart is true, it means the Render Delegate received an update after rendering has finished
             // and AiRenderInterrupt does not change the status anymore.
@@ -189,7 +199,7 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
     return Status::Converging;
 }
 
-void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus)
+void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus, bool clearPaused)
 {
     if (_delegate == nullptr || _delegate->IsBatchContext()) return;
     const auto status = AiRenderGetStatus(_delegate->GetRenderSession());
@@ -197,6 +207,16 @@ void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus)
         status == AI_RENDER_STATUS_RESTARTING ||
         status == AI_RENDER_STATUS_PAUSED) {
         AiRenderInterrupt(_delegate->GetRenderSession(), AI_BLOCKING);
+        if (clearPaused) {
+            // A real interrupt tears down or fully unparks any in-flight render, including
+            // one gated by AiRenderPause(): Arnold's pause gate has no mechanism to discard
+            // accumulated samples across a scene edit (AiRenderResume()/AiRenderRestart() are
+            // equivalent while gated, see Resume()), so a restart driven by this interrupt
+            // will actually resume rendering. Clear _paused so it doesn't keep claiming
+            // "paused" once the render is active again -- otherwise it gets stuck true
+            // forever, since nothing else clears it on this path.
+            _paused.store(false, std::memory_order_release);
+        }
     }
     if (needsRestart) {
         _needsRestart.store(true, std::memory_order_release);
@@ -208,17 +228,41 @@ void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus)
 
 void HdArnoldRenderParam::Pause()
 {
+#if ARNOLD_VERSION_NUM >= 70504
+    // Arnold 7.5.4+ can pause render threads at a gate without terminating
+    // them, preserving render progress, instead of the old interrupt-based
+    // approach below which fully tears down the in-flight render.
+    _paused.store(true, std::memory_order_release);
+    if (_delegate != nullptr && !_delegate->IsBatchContext()) {
+        AiRenderPause(_delegate->GetRenderSession());
+    }
+#else
     // Publish the pause intent before issuing the interrupt. Interrupt blocks
     // until Arnold transitions the render status away from RENDERING; if the
     // store happened *after* that transition, a concurrent UpdateRender call
     // could see status == PAUSED with `_paused == false` and immediately take
     // the `!paused` branch, calling AiRenderResume and silently undoing the
     // pause that was just requested.
+    // Pass clearPaused=false: here the interrupt itself is the mechanism used to
+    // reach the paused state, not an unrelated scene edit, so it must not undo the
+    // `_paused` store above.
     _paused.store(true, std::memory_order_release);
-    Interrupt(false, false);
+    Interrupt(false, false, false);
+#endif
 }
 
-void HdArnoldRenderParam::Resume() { _paused.store(false, std::memory_order_release); }
+void HdArnoldRenderParam::Resume()
+{
+    _paused.store(false, std::memory_order_release);
+#if ARNOLD_VERSION_NUM >= 70504
+    // Explicitly lift the pause gate here rather than waiting for the next
+    // UpdateRender poll, since AiRenderGetStatus() keeps reporting RENDERING
+    // while paused and UpdateRender has no other signal to act on.
+    if (_delegate != nullptr && !_delegate->IsBatchContext()) {
+        AiRenderResume(_delegate->GetRenderSession());
+    }
+#endif
+}
 
 void HdArnoldRenderParam::Restart()
 {

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -86,23 +86,38 @@ public:
     /// @param needsRestart Whether or not changes are applied to the scene and we need to restart rendering.
     /// @param clearStatus Clears the internal failure status. Set it to false when no scene data changed, that could
     ///  affect the aborted internal status.
-    /// @param clearPaused Clears the internal paused status. A real interrupt tears down or fully unparks any
-    ///  in-flight render, including one gated by AiRenderPause(), so any pause in effect is no longer honoured past
-    ///  this call. Set it to false only when the interrupt itself is the mechanism used to *achieve* the pause (see
-    ///  Pause()'s pre-7.5.4 fallback), not when it is caused by an unrelated scene edit.
+    /// @param clearPaused Clears the internal paused status, but only when there is an actual render to interrupt:
+    ///  AiRenderInterrupt() unparks a render gated by AiRenderPause() (it clears Arnold's own pause flag and leaves
+    ///  the session in AI_RENDER_STATUS_PAUSED), so a pause in effect is not honoured past this call and the
+    ///  bookkeeping has to follow. A pause requested before the render began survives, since there is nothing to
+    ///  unpark and UpdateRender() is still holding the render at AI_RENDER_STATUS_NOT_STARTED. Set it to false only
+    ///  when the interrupt itself is the mechanism used to *achieve* the pause (see Pause()'s pre-7.5.4 fallback),
+    ///  not when it is caused by an unrelated scene edit.
     HDARNOLD_API
     void Interrupt(bool needsRestart = true, bool clearStatus = true, bool clearPaused = true);
-    /// Pauses an ongoing render, does nothing if no render is running.
+    /// Pauses the render. On Arnold 7.5.4+ this gates the render threads via AiRenderPause() without discarding
+    /// accumulated progress; before that it falls back to interrupting the render. A pause requested before the
+    /// render has begun is remembered, and UpdateRender() then holds off on starting it.
     HDARNOLD_API
     void Pause();
-    /// Resumes an already paused render, does nothing if no render is running, or the render is not paused.
+    /// Resumes a paused render, does nothing if the render is not paused.
     HDARNOLD_API
     void Resume();
     /// Returns whether a Pause() call is currently in effect. Cleared by Resume(), Restart(), or an
-    /// Interrupt() caused by a scene edit (see Interrupt()'s clearPaused parameter).
+    /// Interrupt() cancelling the pause (see Interrupt()'s clearPaused parameter). Note this cannot be derived
+    /// from AiRenderGetStatus(), which keeps reporting AI_RENDER_STATUS_RENDERING for a gated render.
     ///
     /// @return True if paused.
     bool IsPaused() const { return _paused.load(std::memory_order_acquire); }
+    /// Stops the render, discarding any progress, and holds it stopped until Restart() (or Resume()) is called.
+    /// Unlike Pause() this does not preserve accumulated samples; unlike a bare Interrupt() the render is not
+    /// picked up again by the next UpdateRender() call.
+    HDARNOLD_API
+    void Stop();
+    /// Returns whether a Stop() call is currently in effect.
+    ///
+    /// @return True if stopped.
+    bool IsStopped() const { return _stopped.load(std::memory_order_acquire); }
     /// Resumes an already running,stopped/paused/finished render.
     HDARNOLD_API
     void Restart();
@@ -196,12 +211,18 @@ private:
     std::atomic<bool> _needsRestart{false};
     /// Indicate if rendering has been aborted at one point or another.
     std::atomic<bool> _aborted{false};
-    /// Indicate if rendering has been paused. Prior to C++20 std::atomic<bool>'s
-    /// default constructor leaves the value indeterminate, and the cpp file's
-    /// constructor explicitly stores false into _needsRestart and _aborted but
-    /// not into _paused — so the first UpdateRender call read uninitialized
-    /// memory. Initialize all three here for safety.
+    /// Indicate if rendering has been paused. This is plain state, not a one-shot intent flag: UpdateRender() reads
+    /// it without consuming it, and only Resume()/Restart()/Stop() and a pause-cancelling Interrupt() clear it. It
+    /// has to be tracked here rather than queried from Arnold because AiRenderIsPaused() only exists in 7.5.4+, and
+    /// because a pause requested before AiRenderBegin() is not something Arnold can remember.
+    /// Prior to C++20 std::atomic<bool>'s default constructor leaves the value indeterminate, and the cpp file's
+    /// constructor explicitly stores false into _needsRestart and _aborted but not into _paused — so the first
+    /// UpdateRender call read uninitialized memory. Initialize all of them here for safety.
     std::atomic<bool> _paused{false};
+    /// Indicate if rendering has been stopped by Stop() and must stay stopped until Restart()/Resume(). Distinct
+    /// from _paused: a stop discards progress (it is a real interrupt) and, unlike Arnold's own PAUSED status, it
+    /// must survive across UpdateRender() calls so the render is not silently picked up again on the next tick.
+    std::atomic<bool> _stopped{false};
 
     std::chrono::time_point<std::chrono::system_clock> _renderStartTime;
     mutable std::mutex _renderTimeMutex;

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -86,14 +86,23 @@ public:
     /// @param needsRestart Whether or not changes are applied to the scene and we need to restart rendering.
     /// @param clearStatus Clears the internal failure status. Set it to false when no scene data changed, that could
     ///  affect the aborted internal status.
+    /// @param clearPaused Clears the internal paused status. A real interrupt tears down or fully unparks any
+    ///  in-flight render, including one gated by AiRenderPause(), so any pause in effect is no longer honoured past
+    ///  this call. Set it to false only when the interrupt itself is the mechanism used to *achieve* the pause (see
+    ///  Pause()'s pre-7.5.4 fallback), not when it is caused by an unrelated scene edit.
     HDARNOLD_API
-    void Interrupt(bool needsRestart = true, bool clearStatus = true);
+    void Interrupt(bool needsRestart = true, bool clearStatus = true, bool clearPaused = true);
     /// Pauses an ongoing render, does nothing if no render is running.
     HDARNOLD_API
     void Pause();
     /// Resumes an already paused render, does nothing if no render is running, or the render is not paused.
     HDARNOLD_API
     void Resume();
+    /// Returns whether a Pause() call is currently in effect. Cleared by Resume(), Restart(), or an
+    /// Interrupt() caused by a scene edit (see Interrupt()'s clearPaused parameter).
+    ///
+    /// @return True if paused.
+    bool IsPaused() const { return _paused.load(std::memory_order_acquire); }
     /// Resumes an already running,stopped/paused/finished render.
     HDARNOLD_API
     void Restart();

--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -46,10 +46,21 @@ else:
 # per-test env override hook in Test.prepare(), so this is added to every test.cpp
 # build rather than just the one that needs it -- harmless for tests that don't
 # reference any of these symbols, since unused static library members simply aren't
-# pulled in at link time. Only done when the render delegate is actually being
-# built: skip it entirely for BUILD_RENDER_DELEGATE=0 configurations, where such a
-# test cannot link (and isn't expected to run).
-if env.get('BUILD_RENDER_DELEGATE'):
+# pulled in at link time.
+# This mirrors the condition SConstruct uses to decide whether libs/render_delegate
+# is built at all -- not just BUILD_RENDER_DELEGATE: the cmake `testsuite` target
+# runs abuild with BUILD_RENDER_DELEGATE=0 (cmake has already built the delegate
+# itself), so keying off that alone would silently produce an unlinkable test there.
+# Tests needing the library are skipped when it isn't available, see below.
+render_delegate_lib_built = bool(
+   env.get('BUILD_RENDER_DELEGATE') or
+   (env.get('BUILD_PROCEDURAL') and env.get('ENABLE_HYDRA_IN_USD_PROCEDURAL')))
+
+# Tests whose test.cpp links libs/render_delegate, and so cannot even be compiled in a
+# configuration that doesn't build it.
+render_delegate_tests = ['test_2719']
+
+if render_delegate_lib_built:
    def _add_render_delegate_test_deps(e):
       e.Append(CPPPATH = [
          os.path.join(root_path, 'libs', 'render_delegate'),
@@ -149,6 +160,14 @@ args_prepare = dict(
 
 if len(testsuite_targets) > 0:
    testsuite = Testsuite.load(**args_load)
+   if not render_delegate_lib_built:
+      # Their test.cpp links libs/render_delegate, which this configuration doesn't build, so they can't be
+      # compiled at all here. Ignore them explicitly instead of letting the link fail the whole run.
+      skipped = set(render_delegate_tests) & testsuite.tests_found
+      if skipped:
+         testsuite.skipped_tests['ignore'] |= skipped
+         print('Ignoring {} test(s) needing the render delegate library, which this '
+               'configuration does not build: {}'.format(len(skipped), ' '.join(sorted(skipped))))
    print('Found {} tests in {}'.format(len(testsuite.tests_found), testsuite.source))
    print('Filtering tests with patterns: {} ...'.format(' '.join(testsuite_targets)))
    TESTSUITE_TARGET = testsuite.prepare(**args_prepare)

--- a/testsuite/SConscript
+++ b/testsuite/SConscript
@@ -9,6 +9,7 @@ from utils.contrib.bottle import SimpleTemplate
 import utils as sa
 from utils.build_tools     import process_return_code
 from utils.system          import print_safe, is_string
+from utils                 import dependencies
 from test                  import Testsuite
 
 Import('env')
@@ -37,6 +38,52 @@ else:
    test_env.Append(CPPPATH = [env['ARNOLD_API_INCLUDES'], os.path.join(root_path, 'testsuite', 'common', 'include')])
    test_env.Append(LIBPATH = env['ARNOLD_BINARIES'])
    test_env.Append(LIBS = Split('ai'))
+
+# Tests that construct the Hydra render delegate directly in C++ (e.g. test_2719,
+# which drives HdArnoldRenderDelegate::Pause()/Resume()/Stop()/IsPaused() against a
+# live render to guard against #2719-style state bugs) additionally need the
+# render_delegate/common static libraries and their USD dependencies. There is no
+# per-test env override hook in Test.prepare(), so this is added to every test.cpp
+# build rather than just the one that needs it -- harmless for tests that don't
+# reference any of these symbols, since unused static library members simply aren't
+# pulled in at link time. Only done when the render delegate is actually being
+# built: skip it entirely for BUILD_RENDER_DELEGATE=0 configurations, where such a
+# test cannot link (and isn't expected to run).
+if env.get('BUILD_RENDER_DELEGATE'):
+   def _add_render_delegate_test_deps(e):
+      e.Append(CPPPATH = [
+         os.path.join(root_path, 'libs', 'render_delegate'),
+         os.path.join(root_path, 'libs', 'common'),
+      ])
+      # Resolve against the root env's BUILD_BASE_DIR with os.path.abspath(), not a
+      # SCons Dir()/relative-string LIBPATH entry: the latter gets re-rooted against
+      # this SConscript's own variant_dir (testsuite/build/...), which silently
+      # doubles or mis-nests the path (as seen when this used e['BUILD_BASE_DIR']
+      # directly). plugins/render_delegate/SConscript resolves it the same way.
+      e.Append(LIBPATH = [
+         os.path.abspath(os.path.join(env['BUILD_BASE_DIR'], 'libs', 'render_delegate')),
+         os.path.abspath(os.path.join(env['BUILD_BASE_DIR'], 'libs', 'common')),
+         # USD_LIB is already on the root env's LIBPATH (SConstruct appends it before
+         # testsuite/SConscript runs), but explicitly re-adding it here too: whatever
+         # is causing e['BUILD_BASE_DIR']-relative paths above to get mis-rooted under
+         # this SConscript's variant_dir may also be dropping/hiding inherited LIBPATH
+         # entries for this env by the time the test.cpp Program() actually links
+         # ("library 'usd_arch' not found" otherwise).
+         os.path.abspath(env['USD_LIB']),
+      ])
+      _, usd_deps = dependencies.render_delegate(e, [])
+      e.Append(LIBS = ['render_delegate', 'common'] + usd_deps)
+      if sa.system.is_darwin and e.get('EXTRA_FRAMEWORKS'):
+         # A static USD build's Arch library needs Foundation (NSTemporaryDirectory,
+         # objc_msgSend) on macOS. plugins/procedural/SConscript applies the same
+         # EXTRA_FRAMEWORKS setting for its own static-USD link; test.cpp needs it too.
+         e.Append(FRAMEWORKS = e['EXTRA_FRAMEWORKS'].split(';'))
+
+   if 'UNIVERSAL_ENVS' in test_env:
+      for e in test_env['UNIVERSAL_ENVS']:
+         _add_render_delegate_test_deps(e)
+   else:
+      _add_render_delegate_test_deps(test_env)
 
 os.environ['ARNOLD_TESTSUITE_COMMON'] = os.path.join(root_path, 'testsuite', 'common')
 os.environ['USD_PROCEDURAL_PATH'] = test_env['USD_PROCEDURAL_PATH']

--- a/testsuite/test_2719/README
+++ b/testsuite/test_2719/README
@@ -1,0 +1,32 @@
+HdArnoldRenderDelegate's paused state must survive/clear correctly around scene edits, Resume() and Stop()
+
+Pause() (the resumable AiRenderPause() gate added for #2719) left HdArnoldRenderParam's
+internal _paused flag stuck reporting "paused" once any scene edit (a plain Interrupt(),
+exactly what every camera/mesh/light Sync() issues) or a Stop() call resumed/tore down
+the render underneath it -- Arnold's pause gate has no mechanism to preserve accumulated
+samples across a scene edit, so such an edit always forces a real interrupt+restart, but
+nothing cleared the bookkeeping to match. HdArnoldRenderDelegate::IsPaused() (newly
+overridden here, since Houdini and other Hydra hosts query it) would therefore keep
+reporting a stale "paused" state.
+
+This test constructs HdArnoldRenderDelegate directly (rather than through a UsdStage +
+Hydra render index) and drives Pause()/Interrupt()/Resume()/Stop()/IsPaused() against a
+live render, since HdRenderDelegate::IsPaused() isn't reachable from a normal
+scene.usda-driven test (not exposed through UsdImagingGLEngine or Python bindings). The
+scene itself is built with plain AiNode() calls rather than AiSceneLoad() of a .usda
+file: this test statically links USD directly into the executable (via render_delegate),
+and AiBegin() auto-loads every plugin under ARNOLD_PLUGIN_PATH, including usd_proc.dylib
+-- which embeds its own private static copy of USD and crashes the process if loaded
+alongside it. ARNOLD_PLUGIN_PATH is cleared at the top of main() so nothing gets
+auto-loaded; the scene's AA_samples/resolution are deliberately high so the render stays
+busy long enough for the test to reliably observe it mid-flight.
+
+Requires BUILD_RENDER_DELEGATE=1 (the default). USD_BUILD_MODE=static configurations
+also required a fix to tools/utils/dependencies.py:render_delegate(), which had no
+static-build case (unlike dependencies.py:translator()) and so could never link against
+a statically-built USD -- likely a pre-existing, previously-unexercised gap rather than
+something specific to this test.
+
+Fixes #2719
+
+author: cyril.pichard@autodesk.com

--- a/testsuite/test_2719/README
+++ b/testsuite/test_2719/README
@@ -1,4 +1,4 @@
-HdArnoldRenderDelegate's paused state must survive/clear correctly around scene edits, Resume() and Stop()
+HdArnoldRenderDelegate's paused/stopped state must survive/clear correctly around scene edits, Resume() and Stop()
 
 Pause() (the resumable AiRenderPause() gate added for #2719) left HdArnoldRenderParam's
 internal _paused flag stuck reporting "paused" once any scene edit (a plain Interrupt(),
@@ -9,19 +9,33 @@ nothing cleared the bookkeeping to match. HdArnoldRenderDelegate::IsPaused() (ne
 overridden here, since Houdini and other Hydra hosts query it) would therefore keep
 reporting a stale "paused" state.
 
+The mirror image of that is also covered here: Stop() only interrupts the render, which
+leaves the session at AI_RENDER_STATUS_PAUSED, and UpdateRender() resumes anything it
+finds sitting there -- so without a latched stop the render restarted by itself on the
+next tick, with no host involvement, while IsStopSupported() still claimed stopping
+worked. The test ticks UpdateRender() after Stop() (and after a scene edit) to check the
+render actually stays stopped until Restart().
+
 This test constructs HdArnoldRenderDelegate directly (rather than through a UsdStage +
-Hydra render index) and drives Pause()/Interrupt()/Resume()/Stop()/IsPaused() against a
-live render, since HdRenderDelegate::IsPaused() isn't reachable from a normal
-scene.usda-driven test (not exposed through UsdImagingGLEngine or Python bindings). The
+Hydra render index) and drives Pause()/Interrupt()/Resume()/Stop()/IsPaused()/IsStopped()
+against a live render, since HdRenderDelegate::IsPaused() isn't reachable from a normal
+scene.usda-driven test (not exposed through UsdImagingGLEngine or Python bindings). Where
+the render is expected to be paused the test asserts against Arnold's own AiRenderIsPaused()
+as well as our bookkeeping: a gated render keeps reporting AI_RENDER_STATUS_RENDERING, so
+a render status check alone would pass whether or not the pause ever took effect. The
 scene itself is built with plain AiNode() calls rather than AiSceneLoad() of a .usda
 file: this test statically links USD directly into the executable (via render_delegate),
 and AiBegin() auto-loads every plugin under ARNOLD_PLUGIN_PATH, including usd_proc.dylib
 -- which embeds its own private static copy of USD and crashes the process if loaded
 alongside it. ARNOLD_PLUGIN_PATH is cleared at the top of main() so nothing gets
 auto-loaded; the scene's AA_samples/resolution are deliberately high so the render stays
-busy long enough for the test to reliably observe it mid-flight.
+busy long enough for the test to reliably observe it mid-flight, and are trimmed back
+before the final convergence check (converging at that quality takes ~8s on a 10-core M1
+Max, and Restart() starts over from scratch).
 
-Requires BUILD_RENDER_DELEGATE=1 (the default). USD_BUILD_MODE=static configurations
+Needs libs/render_delegate, so it is skipped in configurations that don't build it (see
+testsuite/SConscript) -- including the cmake `testsuite` target, which runs abuild with
+BUILD_RENDER_DELEGATE=0. USD_BUILD_MODE=static configurations
 also required a fix to tools/utils/dependencies.py:render_delegate(), which had no
 static-build case (unlike dependencies.py:translator()) and so could never link against
 a statically-built USD -- likely a pre-existing, previously-unexercised gap rather than

--- a/testsuite/test_2719/data/test.cpp
+++ b/testsuite/test_2719/data/test.cpp
@@ -1,0 +1,193 @@
+// Regression test for #2719: HdArnoldRenderDelegate's pause/resume state
+// machine (_paused, driving IsPaused()) could get stuck reporting "paused"
+// while the render was actually active again, because a scene edit (any
+// Interrupt() call, e.g. from a camera/mesh/light Sync()) cancels an
+// in-flight pause without clearing the bookkeeping. Stop() had the same gap.
+//
+// This talks to HdArnoldRenderDelegate/HdArnoldRenderParam directly rather
+// than through a UsdStage + Hydra render index: the state machine under test
+// lives entirely in those two classes, and HdRenderDelegate::IsPaused() isn't
+// exposed through UsdImagingGLEngine or Python bindings, so there is no way
+// to observe it from a normal scene.usda-driven test.
+//
+// The scene is built with plain AiNode() calls rather than AiSceneLoad() of a
+// .usda file: this test statically links USD (via render_delegate) directly
+// into this executable, and AiBegin() auto-loads every plugin under
+// ARNOLD_PLUGIN_PATH -- including usd_proc.dylib, which embeds its own private
+// static copy of USD. Having two independent copies of USD's global registries
+// (TfEnvSetting, TfType, ...) in one process crashes ("Multiple definitions of
+// TfEnvSetting variable detected", then SIGSEGV). Since this test needs no USD
+// scene reading at all, ARNOLD_PLUGIN_PATH is cleared below so no plugin
+// (usd_proc.dylib or otherwise) gets loaded in the first place.
+#include <ai.h>
+
+#include <render_delegate.h>
+#include <render_param.h>
+
+#include <pxr/base/tf/token.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+bool g_success = true;
+
+bool Check(bool condition, const char* message)
+{
+    if (!condition) {
+        AiMsgError("[test_2719] %s", message);
+        g_success = false;
+    }
+    return condition;
+}
+
+// Waits (bounded) for the render session to reach a specific Arnold render status,
+// pumping UpdateRender() every iteration exactly like a real render pass would on
+// every Sync()/Execute() tick. This matters after Interrupt(): the actual
+// AiRenderRestart() call that resumes the render lives inside UpdateRender()'s
+// PAUSED-case, not in Arnold's own background threads, so nothing advances the
+// render session unless something keeps calling UpdateRender().
+bool WaitForStatus(HdArnoldRenderParam* renderParam, AtRenderSession* session, AtRenderStatus status, int timeoutMs)
+{
+    const auto start = std::chrono::steady_clock::now();
+    while (AiRenderGetStatus(session) != status) {
+        renderParam->UpdateRender();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        if (elapsed.count() > timeoutMs) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
+}
+
+// Drives UpdateRender() until it reports Converged/Aborted or the timeout elapses.
+HdArnoldRenderParam::Status RunToCompletion(HdArnoldRenderParam* renderParam, int timeoutMs)
+{
+    const auto start = std::chrono::steady_clock::now();
+    HdArnoldRenderParam::Status status = HdArnoldRenderParam::Status::Converging;
+    while (status == HdArnoldRenderParam::Status::Converging) {
+        status = renderParam->UpdateRender();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        if (elapsed.count() > timeoutMs) {
+            break;
+        }
+    }
+    return status;
+}
+
+// Builds a small, deliberately expensive scene directly with AiNode() calls (see the
+// top-of-file comment for why this doesn't load a .usda file instead). The high
+// AA_samples/resolution keep the render busy long enough for the Pause()/Interrupt()
+// sequence in main() to reliably land while AiRenderGetStatus() still reports
+// RENDERING. Do not lower these to "optimize" the test -- that would make it flaky.
+void BuildScene(AtUniverse* universe)
+{
+    AtNode* options = AiUniverseGetOptions(universe);
+    AiNodeSetInt(options, AtString("xres"), 320);
+    AiNodeSetInt(options, AtString("yres"), 240);
+    AiNodeSetInt(options, AtString("AA_samples"), 32);
+    AiNodeSetInt(options, AtString("GI_diffuse_depth"), 2);
+
+    AtNode* camera = AiNode(universe, AtString("persp_camera"), AtString("test_2719_camera"));
+    AiNodeSetVec(camera, AtString("position"), 0.f, 0.f, 6.f);
+    AiNodeSetVec(camera, AtString("look_at"), 0.f, 0.f, 0.f);
+    AiNodeSetPtr(options, AtString("camera"), camera);
+
+    AtNode* light = AiNode(universe, AtString("distant_light"), AtString("test_2719_light"));
+    AiNodeSetFlt(light, AtString("intensity"), 1.5f);
+
+    AtNode* shader = AiNode(universe, AtString("standard_surface"), AtString("test_2719_shader"));
+    AiNodeSetRGB(shader, AtString("base_color"), 0.6f, 0.1f, 0.1f);
+    AiNodeSetFlt(shader, AtString("specular_roughness"), 0.4f);
+
+    AtNode* sphere = AiNode(universe, AtString("sphere"), AtString("test_2719_sphere"));
+    AiNodeSetFlt(sphere, AtString("radius"), 1.f);
+    AiNodeSetPtr(sphere, AtString("shader"), shader);
+
+    AiNode(universe, AtString("gaussian_filter"), AtString("test_2719_filter"));
+    AtNode* driver = AiNode(universe, AtString("driver_tiff"), AtString("test_2719_driver"));
+    AiNodeSetStr(driver, AtString("filename"), AtString("testrender.tif"));
+
+    AtArray* outputs = AiArray(1, 1, AI_TYPE_STRING, AtString("RGBA RGBA test_2719_filter test_2719_driver"));
+    AiNodeSetArray(options, AtString("outputs"), outputs);
+}
+
+} // namespace
+
+int main(int, char**)
+{
+    // See the top-of-file comment: this test needs no Arnold plugins (no USD scene
+    // reading, no custom shaders), and loading one (usd_proc.dylib in particular)
+    // crashes since it embeds its own private static copy of USD alongside the one
+    // statically linked directly into this executable.
+    unsetenv("ARNOLD_PLUGIN_PATH");
+
+    AiBegin(AI_SESSION_INTERACTIVE);
+    AiMsgSetConsoleFlags(nullptr, AI_LOG_ALL);
+
+    {
+        HdArnoldRenderDelegate delegate(false, TfToken());
+        BuildScene(delegate.GetUniverse());
+
+        auto* renderParam = static_cast<HdArnoldRenderParam*>(delegate.GetRenderParam());
+        AtRenderSession* session = delegate.GetRenderSession();
+
+        // Kick off the render (NOT_STARTED -> RENDERING) and wait for it to actually
+        // be in flight: Pause()/Interrupt() below need to observe a live
+        // AI_RENDER_STATUS_RENDERING session for this test to be meaningful. If the
+        // scene renders too fast for this to ever be observed, it needs to be made
+        // heavier (more samples/resolution), not left silently un-tested.
+        renderParam->UpdateRender();
+        if (Check(WaitForStatus(renderParam, session, AI_RENDER_STATUS_RENDERING, 5000),
+                "Render never reached RENDERING status -- BuildScene() may need to be heavier/slower "
+                "for this test to be meaningful")) {
+
+            // --- A scene edit while paused must cancel the pause, not leave it stuck ---
+            // Arnold's AiRenderPause() gate (Arnold 7.5.4+) has no mechanism to discard
+            // accumulated samples across a scene edit, so any edit forces a real
+            // interrupt+restart, which must be reflected in IsPaused() rather than left
+            // claiming "paused" while the render is actually active again.
+            delegate.Pause();
+            Check(delegate.IsPaused(), "IsPaused() should be true right after Pause()");
+
+            renderParam->Interrupt(); // stand-in for a camera/mesh/light Sync() edit
+            Check(!delegate.IsPaused(),
+                "IsPaused() stayed true after a scene-edit Interrupt() cancelled the pause (#2719)");
+
+            Check(WaitForStatus(renderParam, session, AI_RENDER_STATUS_RENDERING, 5000),
+                "Render did not resume after the edit-cancelled pause");
+
+            // --- Resume() must clear the flag when there was no edit in between ---
+            delegate.Pause();
+            Check(delegate.IsPaused(), "IsPaused() should be true right after a second Pause()");
+            delegate.Resume();
+            Check(!delegate.IsPaused(), "IsPaused() should be false right after Resume()");
+
+            // --- Stop() must clear the flag too, matching Restart()'s existing contract ---
+            delegate.Pause();
+            Check(delegate.IsPaused(), "IsPaused() should be true right after a third Pause()");
+#if PXR_VERSION >= 2203
+            delegate.Stop(true);
+#else
+            delegate.Stop();
+#endif
+            Check(!delegate.IsPaused(), "IsPaused() stayed true after Stop() (#2719)");
+        }
+
+        // Let the render actually finish so the delegate tears down cleanly.
+        delegate.Restart();
+        const auto finalStatus = RunToCompletion(renderParam, 30000);
+        Check(finalStatus == HdArnoldRenderParam::Status::Converged, "Render did not converge by the end of the test");
+    }
+
+    AiEnd();
+    return g_success ? 0 : 1;
+}

--- a/testsuite/test_2719/data/test.cpp
+++ b/testsuite/test_2719/data/test.cpp
@@ -67,7 +67,9 @@ bool WaitForStatus(HdArnoldRenderParam* renderParam, AtRenderSession* session, A
     return true;
 }
 
-// Drives UpdateRender() until it reports Converged/Aborted or the timeout elapses.
+// Drives UpdateRender() until it reports Converged/Aborted or the timeout elapses. Sleeps between ticks like
+// WaitForStatus() does: a tight spin loop here would steal a core from the render itself, which on a low-core
+// machine is the difference between converging inside the timeout and not.
 HdArnoldRenderParam::Status RunToCompletion(HdArnoldRenderParam* renderParam, int timeoutMs)
 {
     const auto start = std::chrono::steady_clock::now();
@@ -79,15 +81,50 @@ HdArnoldRenderParam::Status RunToCompletion(HdArnoldRenderParam* renderParam, in
         if (elapsed.count() > timeoutMs) {
             break;
         }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     return status;
+}
+
+// IsPaused()/IsStopped() are only part of HdRenderDelegate from USD 22.03 on; query the override where it exists
+// (that is the API hosts actually call) and fall back to the render param that backs it otherwise.
+bool IsPaused(const HdArnoldRenderDelegate& delegate, HdArnoldRenderParam* renderParam)
+{
+#if PXR_VERSION >= 2203
+    return delegate.IsPaused();
+#else
+    return renderParam->IsPaused();
+#endif
+}
+
+bool IsStopped(const HdArnoldRenderDelegate& delegate, HdArnoldRenderParam* renderParam)
+{
+#if PXR_VERSION >= 2203
+    return delegate.IsStopped();
+#else
+    return renderParam->IsStopped();
+#endif
+}
+
+// True when Arnold reports the render threads as parked at the AiRenderPause() gate. Unlike IsPaused() above this
+// is Arnold's own view of it, so it catches a pause that our bookkeeping claims but never actually established
+// (or vice versa). Before 7.5.4 there is no gate and Pause() interrupts the render instead, so the equivalent
+// observable is the render status.
+bool ArnoldIsPaused(AtRenderSession* session)
+{
+#if ARNOLD_VERSION_NUM >= 70504
+    return AiRenderIsPaused(session);
+#else
+    return AiRenderGetStatus(session) == AI_RENDER_STATUS_PAUSED;
+#endif
 }
 
 // Builds a small, deliberately expensive scene directly with AiNode() calls (see the
 // top-of-file comment for why this doesn't load a .usda file instead). The high
 // AA_samples/resolution keep the render busy long enough for the Pause()/Interrupt()
-// sequence in main() to reliably land while AiRenderGetStatus() still reports
-// RENDERING. Do not lower these to "optimize" the test -- that would make it flaky.
+// sequence in main() to reliably land while the render is still in flight. Do not lower
+// these to "optimize" the test -- that would make it flaky. main() drops AA_samples once
+// it is done with the pause checks, so the final convergence check stays quick.
 void BuildScene(AtUniverse* universe)
 {
     AtNode* options = AiUniverseGetOptions(universe);
@@ -140,6 +177,16 @@ int main(int, char**)
         auto* renderParam = static_cast<HdArnoldRenderParam*>(delegate.GetRenderParam());
         AtRenderSession* session = delegate.GetRenderSession();
 
+        // Pausing is only advertised where Arnold provides the resumable AiRenderPause()/AiRenderResume() API.
+#if ARNOLD_VERSION_NUM >= 70504
+        Check(delegate.IsPauseSupported(), "IsPauseSupported() should be true with Arnold 7.5.4+");
+#else
+        Check(!delegate.IsPauseSupported(), "IsPauseSupported() should be false before Arnold 7.5.4");
+#endif
+        Check(!IsPaused(delegate, renderParam), "IsPaused() should be false on a fresh delegate");
+        Check(!IsStopped(delegate, renderParam) || AiRenderGetStatus(session) == AI_RENDER_STATUS_NOT_STARTED,
+            "IsStopped() should only report a not-yet-started render on a fresh delegate");
+
         // Kick off the render (NOT_STARTED -> RENDERING) and wait for it to actually
         // be in flight: Pause()/Interrupt() below need to observe a live
         // AI_RENDER_STATUS_RENDERING session for this test to be meaningful. If the
@@ -151,40 +198,78 @@ int main(int, char**)
                 "for this test to be meaningful")) {
 
             // --- A scene edit while paused must cancel the pause, not leave it stuck ---
-            // Arnold's AiRenderPause() gate (Arnold 7.5.4+) has no mechanism to discard
+            // Arnold's AiRenderPause() gate (Arnold 7.5.4+) has no mechanism to preserve
             // accumulated samples across a scene edit, so any edit forces a real
             // interrupt+restart, which must be reflected in IsPaused() rather than left
             // claiming "paused" while the render is actually active again.
             delegate.Pause();
-            Check(delegate.IsPaused(), "IsPaused() should be true right after Pause()");
+            Check(IsPaused(delegate, renderParam), "IsPaused() should be true right after Pause()");
+            // Assert against Arnold's own view too, not just our bookkeeping: a gated render keeps reporting
+            // AI_RENDER_STATUS_RENDERING, so a status check alone cannot tell a paused render from a running one
+            // and would pass whether or not Pause() actually did anything.
+            Check(ArnoldIsPaused(session), "Arnold does not report the render as paused after Pause()");
 
             renderParam->Interrupt(); // stand-in for a camera/mesh/light Sync() edit
-            Check(!delegate.IsPaused(),
+            Check(!IsPaused(delegate, renderParam),
                 "IsPaused() stayed true after a scene-edit Interrupt() cancelled the pause (#2719)");
+            Check(!ArnoldIsPaused(session), "The interrupt did not unpark the render gated by AiRenderPause()");
 
-            Check(WaitForStatus(renderParam, session, AI_RENDER_STATUS_RENDERING, 5000),
+            Check(WaitForStatus(renderParam, session, AI_RENDER_STATUS_RENDERING, 5000) && !ArnoldIsPaused(session),
                 "Render did not resume after the edit-cancelled pause");
 
             // --- Resume() must clear the flag when there was no edit in between ---
             delegate.Pause();
-            Check(delegate.IsPaused(), "IsPaused() should be true right after a second Pause()");
+            Check(IsPaused(delegate, renderParam), "IsPaused() should be true right after a second Pause()");
             delegate.Resume();
-            Check(!delegate.IsPaused(), "IsPaused() should be false right after Resume()");
+            Check(!IsPaused(delegate, renderParam), "IsPaused() should be false right after Resume()");
+            // Pumped rather than checked immediately: on Arnold 7.5.4+ Resume() lifts the gate itself, but on the
+            // interrupt-based fallback path the AiRenderResume() call lives in UpdateRender()'s PAUSED branch.
+            Check(WaitForStatus(renderParam, session, AI_RENDER_STATUS_RENDERING, 5000) && !ArnoldIsPaused(session),
+                "Render did not resume after Resume()");
 
-            // --- Stop() must clear the flag too, matching Restart()'s existing contract ---
+            // --- Stop() must clear the pause flag, and must actually keep the render stopped ---
             delegate.Pause();
-            Check(delegate.IsPaused(), "IsPaused() should be true right after a third Pause()");
+            Check(IsPaused(delegate, renderParam), "IsPaused() should be true right after a third Pause()");
 #if PXR_VERSION >= 2203
             delegate.Stop(true);
 #else
             delegate.Stop();
 #endif
-            Check(!delegate.IsPaused(), "IsPaused() stayed true after Stop() (#2719)");
+            Check(!IsPaused(delegate, renderParam), "IsPaused() stayed true after Stop() (#2719)");
+            Check(IsStopped(delegate, renderParam), "IsStopped() should be true right after Stop()");
+            // The regression this guards: Stop() only interrupts the render, which leaves the session at
+            // AI_RENDER_STATUS_PAUSED -- and UpdateRender()'s PAUSED branch resumes anything it finds sitting
+            // there. Without a latched stop the render therefore restarts by itself on the very next tick, with no
+            // host involvement at all, while IsStopSupported() still claims stopping works.
+            bool stayedStopped = true;
+            for (int i = 0; i < 20 && stayedStopped; ++i) {
+                renderParam->UpdateRender();
+                stayedStopped = IsStopped(delegate, renderParam) &&
+                    AiRenderGetStatus(session) != AI_RENDER_STATUS_RENDERING &&
+                    AiRenderGetStatus(session) != AI_RENDER_STATUS_RESTARTING;
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            Check(stayedStopped, "Render restarted on its own after Stop(), without a Restart() (#2719)");
+
+            // A scene edit must not resurrect a stopped render either.
+            renderParam->Interrupt();
+            for (int i = 0; i < 20 && stayedStopped; ++i) {
+                renderParam->UpdateRender();
+                stayedStopped = IsStopped(delegate, renderParam) &&
+                    AiRenderGetStatus(session) != AI_RENDER_STATUS_RENDERING &&
+                    AiRenderGetStatus(session) != AI_RENDER_STATUS_RESTARTING;
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            Check(stayedStopped, "A scene edit restarted a stopped render, without a Restart() (#2719)");
         }
 
-        // Let the render actually finish so the delegate tears down cleanly.
+        // Let the render actually finish so the delegate tears down cleanly, and check Restart() lifts the stop.
+        // The heavy AA_samples above exist purely to keep the render in flight long enough for the checks above to
+        // land; converging at that quality takes ~8s on a 10-core M1 Max and Restart() starts over from scratch, so
+        // trim it back rather than making the timeout below absorb a loaded CI machine's slowdown.
+        AiNodeSetInt(AiUniverseGetOptions(delegate.GetUniverse()), AtString("AA_samples"), 3);
         delegate.Restart();
-        const auto finalStatus = RunToCompletion(renderParam, 30000);
+        const auto finalStatus = RunToCompletion(renderParam, 60000);
         Check(finalStatus == HdArnoldRenderParam::Status::Converged, "Render did not converge by the end of the test");
     }
 

--- a/tools/utils/dependencies.py
+++ b/tools/utils/dependencies.py
@@ -49,8 +49,21 @@ def add_plugin_deps(env, sources, libs, needs_dl):
         return (source_files, add_optional_libs(env, usd_deps))
 
 # Returns a list of usd dependencies and source files.
-# This only works with monolithic and shared usd dependencies.
 def render_delegate(env, sources):
+    if env['USD_BUILD_MODE'] == 'static':
+        # Static builds rely on a single monolithic static library, same as
+        # translator() below -- there are no per-module usd_<lib> archives to link
+        # against individually.
+        if system.is_windows:
+            usd_deps = [
+                '-WHOLEARCHIVE:libusd_m',
+                get_tbb_lib(env),
+            ]
+        else:
+            usd_deps = ['libusd_m', get_tbb_lib(env)]
+            if system.is_linux:
+                usd_deps = usd_deps + ['dl']
+        return (sources, add_optional_libs(env, usd_deps))
     usd_libs = [
         'arch',
         'plug',


### PR DESCRIPTION
## Summary

Implements resumable pause/resume in the Hydra render delegate (#2719). Until now `HdArnoldRenderDelegate` advertised `IsPauseSupported() == false` and every "pause" path went through `AiRenderInterrupt()`, which tears down the in-flight render and loses all accumulated samples. With Arnold 7.5.4+ we can instead park the render threads at a gate with `AiRenderPause()` / `AiRenderResume()`, preserving render progress.

## Changes

**`libs/render_delegate/render_param.{h,cpp}`**
- `Pause()` now issues `AiRenderPause()` on Arnold >= 7.5.4, keeping the render alive; the previous interrupt-based behaviour is kept as the fallback for older Arnold.
- `Resume()` explicitly calls `AiRenderResume()` instead of waiting for the next `UpdateRender()` poll — `AiRenderGetStatus()` keeps reporting `RENDERING` while gated, so `UpdateRender()` has no other signal to act on.
- `Interrupt()` gains a `clearPaused` parameter (default `true`). Arnold's pause gate has no way to discard accumulated samples across a scene edit, so any real interrupt resumes/tears down a gated render; the `_paused` bookkeeping is now cleared to match. Without this the flag stayed stuck at `true` forever, since nothing else clears it on that path. `Pause()`'s pre-7.5.4 fallback passes `clearPaused=false`, since there the interrupt *is* the pause mechanism.
- New `IsPaused()` accessor.
- `UpdateRender()` re-issues `AiRenderPause()` when it observes status `RENDERING`, covering the case where `Pause()` raced a brief `RESTARTING` window (during which `AiRenderPause()` silently no-ops).

**`libs/render_delegate/render_delegate.{h,cpp}`**
- `IsPauseSupported()` returns `true` on Arnold >= 7.5.4.
- New `Pause()` and `IsPaused()` overrides (Houdini and other Hydra hosts query `IsPaused()`).
- `Stop()`, the Houdini COP-texture-changed path, and the `flush_texture` command now call `Interrupt(false, false)` directly rather than `Pause()`: they need a hard stop so the subsequent cache flush is safe, and `Pause()` no longer provides one.

**`testsuite/test_2719/`** — new C++ test that constructs `HdArnoldRenderDelegate` directly and drives `Pause()`/`Interrupt()`/`Resume()`/`Stop()`/`IsPaused()` against a live render, asserting that a scene edit and a `Stop()` both clear the paused state. `HdRenderDelegate::IsPaused()` isn't reachable from a normal `scene.usda`-driven test (not exposed through `UsdImagingGLEngine` or the Python bindings), hence the direct approach. The scene is built with plain `AiNode()` calls and `ARNOLD_PLUGIN_PATH` is cleared in `main()`: the test statically links USD via `render_delegate`, and letting `AiBegin()` auto-load `usd_proc` would put a second private copy of USD's global registries in the process and crash. See `testsuite/test_2719/README` for the full rationale.

**`testsuite/SConscript`** — link `render_delegate` + `common` and their USD dependencies into `test.cpp` builds when `BUILD_RENDER_DELEGATE=1`. There's no per-test env override hook in `Test.prepare()`, so this applies to every `test.cpp`; harmless for tests that reference none of those symbols, as unused static library members aren't pulled in at link time.

**`tools/utils/dependencies.py`** — `render_delegate()` had no `USD_BUILD_MODE == 'static'` case (unlike `translator()`), so it could never link against a statically-built USD. Likely a pre-existing, previously-unexercised gap rather than something specific to this test.

## Notes

- Behaviour on Arnold < 7.5.4 is unchanged: `IsPauseSupported()` still returns `false` and `Pause()` still interrupts.
- `CHANGELOG.md` entry added under a new `7.5.4.0 Tentative` section.

Fixes #2719
