### PR TITLE
Fix scene index filter linking issue on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 ## [7.5.4.0] (Unreleased)
 
+### Features
+
 - [usd#2705](https://github.com/Autodesk/arnold-usd/issues/2705) - Bind volume shaders on step-sized meshes
+
+### Bug fixes
+
+- [usd#2722](https://github.com/Autodesk/arnold-usd/issues/2722) - Fix MSVC Linking error in NormalsPruningDataSource scene index.
 
 ## [7.5.3.1] (Unreleased)
 

--- a/plugins/scene_index/extComputationPrimvarPruningSIP.cpp
+++ b/plugins/scene_index/extComputationPrimvarPruningSIP.cpp
@@ -25,7 +25,6 @@ public:
 
     _NormalsPruningDataSource(HdContainerDataSourceHandle const &input) : _input(input) {}
 
-    HDSCENEINDEX_API
     TfTokenVector GetNames() override
     {
         if (!_input) {
@@ -37,7 +36,6 @@ public:
         return names;
     }
 
-    HDSCENEINDEX_API
     HdDataSourceBaseHandle Get(const TfToken &name) override
     {
         if (!_input) {


### PR DESCRIPTION
**Changes proposed in this pull request**
- Remove the unwanted export declaration in the _NormalsPruning scene index filter.

**Issues fixed in this pull request**
Fixes #2722 

