### PR TITLE
Use the OCIO config file path from the settings map when $OCIO is not set (#2730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [usd#2705](https://github.com/Autodesk/arnold-usd/issues/2705) - Bind volume shaders on step-sized meshes
 - [usd#2719](https://github.com/Autodesk/arnold-usd/issues/2719) - Add support for resumable rendering in the render delegate.
+- [usd#2730](https://github.com/Autodesk/arnold-usd/issues/2730) - Use the OCIO config file path from the settings map when $OCIO is not set
 
 ### Bug fixes
 

--- a/libs/common/api_adapter.h
+++ b/libs/common/api_adapter.h
@@ -55,6 +55,15 @@ public:
     virtual AtNode* LookupTargetNode(const char *targetName, const AtNode* source, ConnectionType c) = 0;
     virtual const AtString& GetPxrMtlxPath() = 0;
 
+    /// Path to the OCIO config file, as provided by the host application. It is only meant
+    /// to be used when the OCIO environment variable is not set, which always takes
+    /// precedence (#2730). Only hydra hosts can provide it, hence the empty default.
+    virtual const std::string& GetOcioConfigPath() const
+    {
+        static const std::string empty;
+        return empty;
+    }
+
     virtual void ProcessConnections()
     {
         std::lock_guard<AtMutex> lock(_connectionMutex);

--- a/libs/common/rendersettings_utils.cpp
+++ b/libs/common/rendersettings_utils.cpp
@@ -864,7 +864,9 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
 
     UsdArnoldNodeGraphConnection(options, renderSettingsPrim, renderSettingsPrim.GetAttribute(_tokens->globalOperator), "operator", context, time);
 
-    // Setup color manager
+    // Setup color manager. The OCIO environment variable takes precedence over everything
+    // else, then comes an explicit color_manager:node_entry authored in the scene, and
+    // finally the config path the host application gave us (#2730)
     AtNode* colorManager = nullptr;
     const char *ocio_path = std::getenv("OCIO");
     if (ocio_path) {
@@ -878,6 +880,15 @@ AtNode* ReadRenderSettings(const UsdPrim &renderSettingsPrim, ArnoldAPIAdapter &
             std::string colorManagerEntry = VtValueGetString(colorManagerEntryValue);
             colorManager = context.CreateArnoldNode(colorManagerEntry.c_str(), colorManagerEntry.c_str());
         }
+    }
+
+    if (colorManager == nullptr && !context.GetOcioConfigPath().empty()) {
+        // The render delegate creates this same color manager when it receives the config
+        // path, in which case we reuse it instead of ending up with two of them
+        colorManager = static_cast<AtNode*>(AiNodeGetPtr(options, str::color_manager));
+        if (colorManager == nullptr || !AiNodeIs(colorManager, str::color_manager_ocio))
+            colorManager = context.CreateArnoldNode("color_manager_ocio", "color_manager_ocio");
+        AiNodeSetStr(colorManager, str::config, AtString(context.GetOcioConfigPath().c_str()));
     }
 
     if (colorManager == nullptr) {

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -115,6 +115,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (resolution)
     (renderSettingsSrc)
     (hydraSceneRenderSettingsSrc)
+    (ocioConfigPath)
 
     // The following tokens are also defined in read_options.cpp, we need them
     // here for the conversion from TfToken to HdFormat, while in read_options they
@@ -522,6 +523,11 @@ const AtString& HydraArnoldAPI::GetPxrMtlxPath()
     return _renderDelegate->GetPxrMtlxPath();
 }
 
+const std::string& HydraArnoldAPI::GetOcioConfigPath() const
+{
+    return _renderDelegate->GetOcioConfigPath();
+}
+
 HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &context, AtUniverse *universe, AtSessionMode renderSessionType, AtNode* procParent) : 
     _apiAdapter(this),
     _universe(universe),
@@ -709,26 +715,44 @@ const TfTokenVector& HdArnoldRenderDelegate::GetSupportedSprimTypes() const { re
 
 const TfTokenVector& HdArnoldRenderDelegate::GetSupportedBprimTypes() const { return _SupportedBprimTypes(_renderDelegateOwnsUniverse); }
 
-void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValue& _value)
-{    
-    // function to get or create the color manager and set it on the options node
-    auto getOrCreateColorManager = [](HdArnoldRenderDelegate *renderDelegate, AtNode* options) -> AtNode* {
-        AtNode* colorManager = static_cast<AtNode*>(AiNodeGetPtr(options, str::color_manager));
-        if (colorManager == nullptr) {
-            const char *ocio_path = std::getenv("OCIO");
-            if (ocio_path) {
-                colorManager = renderDelegate->CreateArnoldNode(str::color_manager_ocio, 
-                    str::color_manager_ocio);
-                AiNodeSetPtr(options, str::color_manager, colorManager);
-                AiNodeSetStr(colorManager, str::config, AtString(ocio_path));
-            }
-            else
-                // use the default color manager
-                colorManager = renderDelegate->LookupNode("ai_default_color_manager_ocio");
-        }
+AtNode* HdArnoldRenderDelegate::_GetOrCreateColorManager()
+{
+    AtNode* colorManager = static_cast<AtNode*>(AiNodeGetPtr(_options, str::color_manager));
+    if (colorManager != nullptr)
         return colorManager;
-    };
 
+    // The OCIO environment variable takes precedence over everything else, then comes the
+    // config path the host application gave us through the render settings (#2730).
+    const char* ocio_path = std::getenv("OCIO");
+    const AtString config(ocio_path ? ocio_path : _ocioConfigPath.c_str());
+    if (!config.empty()) {
+        // The reading paths create the same color manager when they read the render settings
+        // prim, we must not end up with two of them
+        colorManager = FindOrCreateArnoldNode(str::color_manager_ocio, str::color_manager_ocio);
+        AiNodeSetPtr(_options, str::color_manager, colorManager);
+        AiNodeSetStr(colorManager, str::config, config);
+        // The color spaces might have been received before we had a config to create this
+        // color manager, in which case they were applied to the default color manager.
+        _ApplyColorSpaces(colorManager);
+    } else {
+        // use the default color manager
+        colorManager = LookupNode("ai_default_color_manager_ocio");
+    }
+    return colorManager;
+}
+
+void HdArnoldRenderDelegate::_ApplyColorSpaces(AtNode* colorManager)
+{
+    if (colorManager == nullptr)
+        return;
+    if (!_colorSpaceLinear.empty())
+        AiNodeSetStr(colorManager, str::color_space_linear, AtString(_colorSpaceLinear.c_str()));
+    if (!_colorSpaceNarrow.empty())
+        AiNodeSetStr(colorManager, str::color_space_narrow, AtString(_colorSpaceNarrow.c_str()));
+}
+
+void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValue& _value)
+{
     // When husk/houdini changes frame, they set the new frame number via the render settings.
     if (_key == str::t_houdiniFrame) {
         if (_value.IsHolding<double>()) {
@@ -763,6 +787,23 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             TfToken renderSettingsSrc = _value.UncheckedGet<TfToken>();
             _useHydraRenderSettings = (renderSettingsSrc == _tokens->hydraSceneRenderSettingsSrc);
         }
+    }
+    // The host application can tell us where its OCIO config file resides, e.g. maya
+    // reads it from its color management preferences (#2730). We only use it when the OCIO
+    // environment variable is not set, as it always takes precedence.
+    if (_key == _tokens->ocioConfigPath) {
+        if (_value.IsHolding<std::string>()) {
+            _ocioConfigPath = _value.UncheckedGet<std::string>();
+            if (!_ocioConfigPath.empty() && std::getenv("OCIO") == nullptr) {
+                // Create the color manager right away, the color spaces might never be set.
+                AtNode* colorManager = _GetOrCreateColorManager();
+                // The color manager could already exist, in which case the above returned it
+                // as-is and we still need to apply the config we just received.
+                if (colorManager != nullptr && AiNodeIs(colorManager, str::color_manager_ocio))
+                    AiNodeSetStr(colorManager, str::config, AtString(_ocioConfigPath.c_str()));
+            }
+        }
+        return;
     }
     TfToken key;
     _RemoveArnoldGlobalPrefix(_key, key);
@@ -902,18 +943,20 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         });
     } else if (key == str::color_space_linear) {
         if (value.IsHolding<std::string>()) {
-            // getOrCreateColorManager returns nullptr when there is no OCIO env
-            // var and the ai_default_color_manager_ocio lookup fails; dereferencing
+            _colorSpaceLinear = value.UncheckedGet<std::string>();
+            // _GetOrCreateColorManager returns nullptr when there is no OCIO config
+            // and the ai_default_color_manager_ocio lookup fails; dereferencing
             // it crashes inside AiNodeSetStr.
-            AtNode* colorManager = getOrCreateColorManager(this, _options);
+            AtNode* colorManager = _GetOrCreateColorManager();
             if (colorManager != nullptr)
-                AiNodeSetStr(colorManager, str::color_space_linear, AtString(value.UncheckedGet<std::string>().c_str()));
+                AiNodeSetStr(colorManager, str::color_space_linear, AtString(_colorSpaceLinear.c_str()));
         }
     } else if (key == str::color_space_narrow) {
         if (value.IsHolding<std::string>()) {
-            AtNode* colorManager = getOrCreateColorManager(this, _options);
+            _colorSpaceNarrow = value.UncheckedGet<std::string>();
+            AtNode* colorManager = _GetOrCreateColorManager();
             if (colorManager != nullptr)
-                AiNodeSetStr(colorManager, str::color_space_narrow, AtString(value.UncheckedGet<std::string>().c_str()));
+                AiNodeSetStr(colorManager, str::color_space_narrow, AtString(_colorSpaceNarrow.c_str()));
         }
     } else if (key == _tokens->dataWindowNDC) {
         if (value.IsHolding<GfVec4f>()) {
@@ -961,7 +1004,7 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
         }
     } else if (TfStringStartsWith(key.GetString(), _tokens->colorManagerNamespace)) {
         const char* cmParamCStr = key.GetText() + _tokens->colorManagerNamespace.GetString().size();
-        AtNode* colorManager = getOrCreateColorManager(this, _options);
+        AtNode* colorManager = _GetOrCreateColorManager();
         if (colorManager != nullptr) {
             AtString cmParamStr(cmParamCStr);
             if (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(colorManager), cmParamStr) != nullptr) {

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -101,6 +101,7 @@ public:
     AtNode* LookupTargetNode(const char *targetName, const AtNode* source, ConnectionType c) override; 
     const AtNode *GetProceduralParent() const;
     const AtString& GetPxrMtlxPath() override;
+    const std::string& GetOcioConfigPath() const override;
 
     HdArnoldRenderDelegate *_renderDelegate;
     // To be removed
@@ -772,11 +773,28 @@ public:
     bool IsAcceleratedViewport() const {return _acceleratedViewport;}
     bool IsUsingHydraRenderSettings() const {return _useHydraRenderSettings;}
 
+    /// Path to the OCIO config file, as provided by the host application through the
+    /// "ocioConfigPath" render setting. It is only meant to be used when the OCIO
+    /// environment variable is not set, which always takes precedence (#2730).
+    const std::string& GetOcioConfigPath() const {return _ocioConfigPath;}
+
 private:    
     HdArnoldRenderDelegate(const HdArnoldRenderDelegate&) = delete;
     HdArnoldRenderDelegate& operator=(const HdArnoldRenderDelegate&) = delete;
 
     void _SetRenderSetting(const TfToken& _key, const VtValue& value);
+
+    /// Returns the color manager to be used for this render, creating it if needed.
+    ///
+    /// The OCIO config is looked up in the OCIO environment variable first, then in the
+    /// "ocioConfigPath" render setting (#2730). When neither is set, arnold's default
+    /// color manager is returned, which can be a null pointer if it doesn't exist.
+    AtNode* _GetOrCreateColorManager();
+
+    /// Applies the color spaces received through the render settings to the given color
+    /// manager. This is needed as the color manager can be created after the color spaces
+    /// were set, in which case they would otherwise be lost.
+    void _ApplyColorSpaces(AtNode* colorManager);
 
     void _ParseDelegateRenderProducts(const VtValue& value);
 
@@ -868,6 +886,12 @@ private:
     std::string _reportFile;
     std::string _statsFile;
     std::string _profileFile;
+    /// OCIO config file path set by the host application, see GetOcioConfigPath.
+    std::string _ocioConfigPath;
+    /// Color spaces received through the render settings, kept so that they can be applied
+    /// to a color manager that is created after them.
+    std::string _colorSpaceLinear;
+    std::string _colorSpaceNarrow;
     AtString _pxrMtlxPath;
 
     std::mutex _meshLightsMutex;

--- a/libs/render_delegate/render_settings.cpp
+++ b/libs/render_delegate/render_settings.cpp
@@ -319,17 +319,21 @@ void HdArnoldRenderSettings::_UpdateRenderingColorSpace(HdSceneDelegate* sceneDe
     // Get USD rendering color space from the data source
     UsdImagingUsdRenderSettingsSchema usdRss = UsdImagingUsdRenderSettingsSchema::GetFromParent(prim.dataSource);
 
-    // Setup color manager - check for OCIO environment variable first
+    // Setup color manager - the OCIO environment variable takes precedence, then comes the
+    // config path the host application gave us through the render settings (#2730)
     AtNode* colorManager = nullptr;
     const char* ocio_path = std::getenv("OCIO");
-    if (ocio_path) {
-        colorManager = _renderDelegate->CreateArnoldNode(AtString("color_manager_ocio"), AtString("color_manager_ocio"));
+    const AtString ocioConfig(ocio_path ? ocio_path : _renderDelegate->GetOcioConfigPath().c_str());
+    if (!ocioConfig.empty()) {
+        // This is called on every render settings update, and the render delegate might have
+        // created this color manager already, so we must not create a new one every time
+        colorManager = _renderDelegate->FindOrCreateArnoldNode(str::color_manager_ocio, str::color_manager_ocio);
         if (colorManager) {
-            AiNodeSetStr(colorManager, str::config, AtString(ocio_path));
+            AiNodeSetStr(colorManager, str::config, ocioConfig);
         }
     }
 
-    // If no OCIO environment variable, use the default color manager
+    // If we have no OCIO config, use the default color manager
     if (colorManager == nullptr) {
         colorManager = AiNodeLookUpByName(AiNodeGetUniverse(options), str::ai_default_color_manager_ocio);
     }

--- a/testsuite/test_2730/README
+++ b/testsuite/test_2730/README
@@ -1,0 +1,17 @@
+Use the OCIO config file path from the settings map when $OCIO is not set
+
+When the OCIO environment variable is not set, the render delegate now takes the OCIO
+config file path from the "ocioConfigPath" render setting, which host applications such
+as maya set from their color management preferences. The environment variable keeps
+precedence over that setting.
+
+The "ocioConfigPath" setting can only be pushed by a host application through the Hydra
+settings map, which kick cannot do, so this test covers the environment variable leg of
+the rule: $OCIO creates a color_manager_ocio configured with it, and no config is applied
+when neither the environment variable nor the setting is present.
+
+See #2730
+
+author: cyril.pichard@autodesk.com
+
+PARAMS: {}

--- a/testsuite/test_2730/data/test.py
+++ b/testsuite/test_2730/data/test.py
@@ -1,0 +1,113 @@
+import os
+import re
+import sys
+
+# Regression test for arnold-usd #2730.
+#
+# The render delegate needs to know where the OCIO config file resides in order to apply
+# the correct color space. The OCIO environment variable takes precedence over everything
+# else, and when it is not set the config path is taken from the "ocioConfigPath" render
+# setting, which host applications such as maya set from their color management
+# preferences.
+#
+# The "ocioConfigPath" render setting can only be pushed by a host application through the
+# settings map, which kick has no way of doing, so this test covers the other half of the
+# rule: the OCIO environment variable creates a color_manager_ocio configured with it, and
+# nothing is configured when there is neither an environment variable nor a setting. This
+# runs once per pass (usd / hydra / hydra2) with the pass-specific environment, so it
+# guards the color manager setup of all the reading paths.
+
+# A minimal but valid OCIO config, with a single color space named after the
+# renderingColorSpace authored in test.usda.
+OCIO_CONFIG = '''ocio_profile_version: 1
+
+search_path:
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: lin_test
+  reference: lin_test
+  scene_linear: lin_test
+  data: lin_test
+  color_timing: lin_test
+  compositing_log: lin_test
+
+displays:
+  sRGB:
+    - !<View> {name: raw, colorspace: lin_test}
+
+active_displays: [sRGB]
+active_views: [raw]
+
+colorspaces:
+  - !<ColorSpace>
+    name: lin_test
+    bitdepth: 32f
+    isdata: false
+    allocation: lg2
+    allocationvars: [-15, 6]
+'''
+
+configPath = os.path.abspath('config.ocio')
+with open(configPath, 'w') as f:
+    f.write(OCIO_CONFIG)
+
+kick = os.path.join(os.environ['ARNOLD_BINARIES'], 'kick')
+
+
+def resave(scene, ocioEnvVar):
+    '''Loads test.usda with kick and returns the contents of the resaved ass file'''
+    if ocioEnvVar is None:
+        os.environ.pop('OCIO', None)
+    else:
+        os.environ['OCIO'] = ocioEnvVar
+
+    cmd = '{} test.usda -resave {} -r 16 16 -dw -dp -v 2 2>&1'.format(kick, scene)
+    print(cmd)
+    print(os.popen(cmd).read())
+
+    if not os.path.exists(scene):
+        return None
+    with open(scene, 'r') as f:
+        return f.read()
+
+
+def getColorManagerConfig(content):
+    '''Returns the config of the color_manager_ocio in the resaved scene, or None'''
+    match = re.search(r'^color_manager_ocio\n\{(.*?)^\}', content, re.DOTALL | re.MULTILINE)
+    if match is None:
+        return None
+    config = re.search(r'^\s*config\s+"([^"]*)"', match.group(1), re.MULTILINE)
+    return config.group(1) if config else ''
+
+
+errors = []
+
+# 1) With the OCIO environment variable set, the color manager must use it
+content = resave('with_env.ass', configPath)
+if content is None:
+    errors.append('kick did not resave the scene with the OCIO environment variable set')
+else:
+    config = getColorManagerConfig(content)
+    if config is None:
+        errors.append('no color_manager_ocio was created with the OCIO environment variable set')
+    elif config != configPath:
+        errors.append('color_manager_ocio config is "{}", expected "{}"'.format(config, configPath))
+    if not re.search(r'^\s*color_manager\s+"', content, re.MULTILINE):
+        errors.append('the options node does not reference the color manager')
+
+# 2) Without an OCIO environment variable and without an "ocioConfigPath" render setting,
+#    we fall back to arnold's default color manager and nothing points at our config
+content = resave('without_env.ass', None)
+if content is None:
+    errors.append('kick did not resave the scene without the OCIO environment variable')
+elif getColorManagerConfig(content) == configPath:
+    errors.append('the OCIO config is used even though the environment variable is not set')
+
+if errors:
+    for e in errors:
+        print('Failure! {}'.format(e))
+    sys.exit(-1)
+
+print('Success! The OCIO config path is resolved from the environment variable.')

--- a/testsuite/test_2730/data/test.usda
+++ b/testsuite/test_2730/data/test.usda
@@ -1,0 +1,52 @@
+#usda 1.0
+(
+    defaultPrim = "sphere1"
+    endTimeCode = 1
+    framesPerSecond = 24
+    metersPerUnit = 1
+    startTimeCode = 1
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+def Sphere "sphere1"
+{
+    double radius = 1
+    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+    uniform token[] xformOpOrder = ["xformOp:transform"]
+}
+
+def Xform "lights"
+{
+    def DistantLight "distantlight1"
+    {
+        float inputs:intensity = 1
+        matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+}
+
+def Xform "cameras"
+{
+    def Camera "camera1"
+    {
+        float2 clippingRange = (1, 1000000)
+        float focalLength = 50
+        float horizontalAperture = 20.955
+        token projection = "perspective"
+        float verticalAperture = 15.2908
+        matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 8, 1) )
+        uniform token[] xformOpOrder = ["xformOp:transform"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "rendersettings1"
+    {
+        custom int arnold:global:AA_samples = 1
+        rel camera = </cameras/camera1>
+        uniform token renderingColorSpace = "lin_test"
+        int2 resolution = (16, 16)
+    }
+}


### PR DESCRIPTION
Fixes #2730.

Render delegates had no way of knowing where the host application's OCIO config file resides: they only looked at the `OCIO` environment variable and otherwise fell back to arnold's default color manager. Host applications such as maya read that path from their color management preferences and pass it through the `ocioConfigPath` render setting ([maya-hydra#485](https://github.com/Autodesk/maya-hydra/pull/485)).

The config is now resolved as:

1. the `OCIO` environment variable, which takes precedence over everything else
2. the `ocioConfigPath` render setting
3. arnold's default color manager

## Changes

- `libs/render_delegate/render_delegate.{h,cpp}` — handle the `ocioConfigPath` render setting. The `getOrCreateColorManager` lambda became `_GetOrCreateColorManager()`, which applies the precedence above. The color manager is created as soon as the config path is received, as the color spaces might never be set.
- `libs/render_delegate/render_settings.cpp` — same fallback for the hydra render settings prim path, which is the one maya uses for batch rendering.
- `libs/common/api_adapter.h`, `libs/common/rendersettings_utils.cpp` — `ReadRenderSettings` is also used by the hydra reading path, where it ran after the render delegate and overwrote `options.color_manager` with the default color manager. It now gets the config path through a new `ArnoldAPIAdapter::GetOcioConfigPath`, which returns an empty string by default so that only hydra hosts provide it. There, an explicit `color_manager:node_entry` authored in the scene keeps precedence over the host's config path, as it selects the color manager type.

The color spaces received through the render settings are kept on the delegate so that they can be re-applied when the color manager is created after them, making the order in which the host pushes its settings irrelevant.

The color manager is now looked up before being created. The previous `CreateArnoldNode` calls unconditionally created a new node, so a second `color_manager_ocio` would be renamed to an empty string, leaving the options `color_manager` dangling. This also avoids creating a new color manager on every render settings update in the hydra render settings path.

## Testing

The `ocioConfigPath` setting can only be pushed by a host application through the hydra settings map, which kick cannot do. `testsuite/test_2730` therefore covers the environment variable leg of the rule: `$OCIO` creates a `color_manager_ocio` configured with it, and no config is applied when neither the environment variable nor the setting is present. It runs in the usd, hydra and hydra2 passes.

The settings map leg was verified manually, by temporarily injecting the setting from the reader (not committed):

| Case | hydra | hydra2 |
|---|---|---|
| setting only, no `$OCIO` | config applied, single color manager referenced by the options | same |
| both set | `$OCIO` wins, single color manager | `$OCIO` wins, single color manager |
| `color_space_linear` pushed before `ocioConfigPath` | color space preserved on the color manager created afterwards | n/a |

Full testsuite: 414 tests, 0 failed, 1 crashed. The crash is `test_0107` (Per-camera AOVs), an arnold core assert on duplicate output filenames which reproduces without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)