### PR TITLE
Enable USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX  by default with hydra2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug fixes
 
 - [usd#2722](https://github.com/Autodesk/arnold-usd/issues/2722) - Fix MSVC Linking error in NormalsPruningDataSource scene index.
+- [usd#2728](https://github.com/Autodesk/arnold-usd/issues/2728) - Default USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX to enabled when unset, matching USD 26.03+ behavior.
 
 
 ## [7.5.3.2] (Unreleased)

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -26,6 +26,7 @@
 #include <pxr/usd/usdRender/tokens.h>
 #include "render_delegate.h"
 #include "render_pass.h"
+#include "utils.h"
 
 #include "rendersettings_utils.h"
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -173,17 +174,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     static AtMutex s_renderIndexCreationMutex;
     static AtMutex s_renderDelegateCreationMutex;
 #ifdef ARNOLD_SCENE_INDEX
-    if (ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX")) 
-    {
-        // The environment variable is defined, it takes precedence on any other setting
-        std::string useSceneIndex = ArchGetEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX");
-        std::string::size_type i = useSceneIndex.find(" ");
-        while(i != std::string::npos) {
-            useSceneIndex.erase(i, 1);
-            i = useSceneIndex.find(" ");
-        }
-        _useSceneIndex = (useSceneIndex != "0");
-    }
+    _useSceneIndex = HdArnoldIsSceneIndexEnabled();
 #endif
 
     //

--- a/libs/render_delegate/render_settings.cpp
+++ b/libs/render_delegate/render_settings.cpp
@@ -464,7 +464,7 @@ void HdArnoldRenderSettings::_ReadUsdRenderSettings(HdSceneDelegate* sceneDelega
 void HdArnoldRenderSettings::_Sync(
     HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, const HdDirtyBits* dirtyBits)
 {
-    if (std::getenv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX") == nullptr)
+    if (!HdArnoldIsSceneIndexEnabled())
         return;
 
     // If we're not using the hydra render settings, we shouldn't do anything here

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -31,6 +31,7 @@
 // limitations under the License.
 #include "utils.h"
 
+#include <pxr/base/arch/env.h>
 #include <pxr/base/gf/vec2d.h>
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec2h.h>
@@ -80,6 +81,20 @@ inline bool _TokenStartsWithToken(const TfToken& t0, const TfToken& t1)
 }
 
 } // namespace
+
+bool HdArnoldIsSceneIndexEnabled()
+{
+    if (!ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX"))
+        return true;
+
+    std::string useSceneIndex = ArchGetEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX");
+    std::string::size_type i = useSceneIndex.find(" ");
+    while (i != std::string::npos) {
+        useSceneIndex.erase(i, 1);
+        i = useSceneIndex.find(" ");
+    }
+    return useSceneIndex != "0";
+}
 
 void HdArnoldSetTransform(AtNode* node, HdSceneDelegate* sceneDelegate, const SdfPath& id, GfVec2f samplingInterval)
 {

--- a/libs/render_delegate/utils.h
+++ b/libs/render_delegate/utils.h
@@ -622,6 +622,11 @@ void HdArnoldGetPrimvars(
 HDARNOLD_API
 AtArray* HdArnoldGetShidxs(const HdGeomSubsets& subsets, int numFaces, HdArnoldSubsets& arnoldSubsets);
 
+/// Returns whether the Hydra scene index should be used, based on the
+/// USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX environment variable. Defaults to
+/// true, matching USD's own default (26.03+), when the variable is unset.
+HDARNOLD_API
+bool HdArnoldIsSceneIndexEnabled();
 
 /// Use the velocities and accelerations primvars to extrapolate the positions.
 ///


### PR DESCRIPTION
**Changes proposed in this pull request**
This change makes it so that we don't need to explicitely set the `USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX ` variable

**Issues fixed in this pull request**
Fixes #2728
