### PR TITLE
Fix nodes destruction during interactive sessions under a procedural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [usd#2745](https://github.com/Autodesk/arnold-usd/issues/2745) - Support renderingColorSpace in the hydra2 render_settings
 - [usd#2710](https://github.com/Autodesk/arnold-usd/issues/2710) - Support uv_camera ray_direction / ray_origin in hydra
 - [usd#2731](https://github.com/Autodesk/arnold-usd/issues/2731) - Per-renderVar EXR compression
-
+- [usd#2747](https://github.com/Autodesk/arnold-usd/issues/2747) - Fix nodes destruction during interactive sessions under a procedural
 
 ### Bug fixes
 

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -180,11 +180,23 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     //
     // Create the render delegate using the plugin system. This allows the correct initialisation of the scene indices in hydra1
     //
+    // Determine the actual session mode of the parent render we're expanding into,
+    // so that the render delegate knows whether it runs inside a batch or an
+    // interactive render. We used to hardcode is_batch=true / session_type=INTERACTIVE
+    // here, which was wrong: an interactive Maya render also goes through this
+    // procedural path, and reporting it as batch prevented nodes from being properly
+    // destroyed on regeneration (naming conflicts). The procedural-specific behavior
+    // that relied on these values is now guarded on the procedural_parent instead.
+    const AtRenderSession* parentRenderSession = AiUniverseGetRenderSession(_universe);
+    const AtSessionMode parentSessionMode =
+        parentRenderSession ? AiGetSessionMode(parentRenderSession) : AI_SESSION_INTERACTIVE;
+    const bool parentIsBatch = (parentSessionMode == AI_SESSION_BATCH);
+
     HdRenderSettingsMap settingsMap;
-    settingsMap[TfToken("arnold:is_batch")] = VtValue(true);
+    settingsMap[TfToken("arnold:is_batch")] = VtValue(parentIsBatch);
     settingsMap[TfToken("arnold:context")] = VtValue(TfToken("kick"));
     settingsMap[TfToken("arnold:universe")] = VtValue(static_cast<void*>(_universe));
-    settingsMap[TfToken("arnold:session_type")] = VtValue(AI_SESSION_INTERACTIVE);
+    settingsMap[TfToken("arnold:session_type")] = VtValue(parentSessionMode);
     settingsMap[TfToken("arnold:procedural_parent")] = VtValue(static_cast<void*>(procParent));
     {
         // We must lock the render delegate creation as if multiple procedurals create HdArnoldRendererPlugin, we end up with a messed up plugin registry.

--- a/libs/render_delegate/render_delegate.cpp
+++ b/libs/render_delegate/render_delegate.cpp
@@ -536,7 +536,7 @@ HdArnoldRenderDelegate::HdArnoldRenderDelegate(bool isBatch, const TfToken &cont
     _context(context),
     _isBatch(isBatch), 
     _renderDelegateOwnsUniverse(universe==nullptr)
-{     
+{
 
     _lightLinkingChanged.store(false, std::memory_order_release);
     _meshLightsChanged.store(false, std::memory_order_release);
@@ -877,14 +877,14 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
             AiProfileSetFileName(_profileFile.c_str());
         }
     } else if (key == str::t_enable_progressive_render) {
-        if (!_isBatch) {
+        if (!_isBatch && _procParent == nullptr) {
             _CheckForBoolValue(value, [&](const bool b) {
                 AiRenderSetHintBool(GetRenderSession(), str::progressive, b);
                 AiNodeSetBool(_options, str::enable_progressive_render, b);
             });
         }
     } else if (key == str::t_progressive_min_AA_samples) {
-        if (!_isBatch) {
+        if (!_isBatch && _procParent == nullptr) {
             _CheckForIntValue(value, [&](const int i) {
                 AiRenderSetHintInt(GetRenderSession(), str::progressive_min_AA_samples, i);
             });
@@ -892,19 +892,19 @@ void HdArnoldRenderDelegate::_SetRenderSetting(const TfToken& _key, const VtValu
     } else if (key == str::t_interactive_target_fps) {
         // _CheckForFloatValue handles double and GfHalf as well as float, so
         // hosts that don't normalise to float don't get their FPS setting dropped.
-        if (!_isBatch) {
+        if (!_isBatch && _procParent == nullptr) {
             _CheckForFloatValue(value, [&](const float f) {
                 AiRenderSetHintFlt(GetRenderSession(), str::interactive_target_fps, f);
             });
         }
     } else if (key == str::t_interactive_target_fps_min) {
-        if (!_isBatch) {
+        if (!_isBatch && _procParent == nullptr) {
             _CheckForFloatValue(value, [&](const float f) {
                 AiRenderSetHintFlt(GetRenderSession(), str::interactive_target_fps_min, f);
             });
         }
     } else if (key == str::t_interactive_fps_min) {
-        if (!_isBatch) {
+        if (!_isBatch && _procParent == nullptr) {
             _CheckForFloatValue(value, [&](const float f) {
                 AiRenderSetHintFlt(GetRenderSession(), str::interactive_fps_min, f);
             });
@@ -1779,6 +1779,12 @@ bool HdArnoldRenderDelegate::CanUpdateScene()
     // For interactive renders, it is always possible to update the scene
     if (_renderSessionType == AI_SESSION_INTERACTIVE)
         return true;
+    // When running under a procedural parent, we translate the scene during the
+    // procedural expansion, while the parent render is already active (status
+    // RENDERING). We must be allowed to update the scene regardless of that
+    // status, otherwise no node would ever get translated in a batch render.
+    if (_procParent != nullptr)
+        return true;
     // For batch renders, only update the scene if the render hasn't started yet,
     // or if it's finished. We must use GetRenderSession() rather than _renderSession
     // directly: when we don't own the universe (procedural / external) _renderSession
@@ -2159,7 +2165,9 @@ void HdArnoldRenderDelegate::TrackRenderTag(AtNode* node, const TfToken& tag)
 
 void HdArnoldRenderDelegate::SetDrivers(HdDriverVector const& drivers)
 {
-    if (_isBatch)
+    // Skip in batch renders, and when we run under a procedural parent: in that
+    // case we don't own the render loop and shouldn't grab the host's Hgi driver.
+    if (_isBatch || _procParent != nullptr)
         return;
 
     for (HdDriver* driver : drivers) {

--- a/libs/render_delegate/render_delegate.h
+++ b/libs/render_delegate/render_delegate.h
@@ -655,10 +655,12 @@ public:
             if (nodeIt != _nodeNames.end())
                 _nodeNames.erase(nodeIt);
         }
-        // if we have a procedural parent, we should avoid deleting nodes
-        // as this can happen in batch sessions during procedural_update, 
-        // which is not allowed
-        if (_procParent) {
+        // If we have a procedural parent and the parent render is a batch render,
+        // we must avoid deleting nodes: this can happen during procedural_update,
+        // which is not allowed in batch sessions. For interactive renders we do
+        // want to destroy the node, otherwise regenerating a node with the same
+        // name later on causes naming conflicts (see #2277).
+        if (_procParent && _isBatch) {
             AiNodeSetDisabled(node, true);
         }
         else
@@ -913,7 +915,7 @@ private:
     int _nodeId = 0;
     /// Top level render context using Hydra. Ie. Hydra, Solaris, Husk.
     TfToken _context;
-    bool _isBatch = false; // are we in a batch rendering context (e.g. Husk)
+    bool _isBatch = false; // are we in a batch rendering context (e.g. Husk, or a batch parent render when running under a procedural)
     int _verbosityLogFlags = AI_LOG_WARNINGS | AI_LOG_ERRORS;
     std::unordered_set<AtString, AtStringHash> _cryptomatteDrivers;
     std::string _outputOverride;

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -230,7 +230,11 @@ HdArnoldRenderParam::Status HdArnoldRenderParam::UpdateRender()
 
 void HdArnoldRenderParam::Interrupt(bool needsRestart, bool clearStatus, bool clearPaused)
 {
-    if (_delegate == nullptr || _delegate->IsBatchContext()) return;
+    // Skip in batch renders, and when we run under a procedural parent: in that
+    // case we don't own the render loop and must not interrupt the host's render
+    // session (which would otherwise happen now that the procedural reports its
+    // real, interactive session type).
+    if (_delegate == nullptr || _delegate->IsBatchContext() || _delegate->GetProceduralParent() != nullptr) return;
     const auto status = AiRenderGetStatus(_delegate->GetRenderSession());
     if (status == AI_RENDER_STATUS_RENDERING ||
         status == AI_RENDER_STATUS_RESTARTING ||
@@ -263,7 +267,7 @@ void HdArnoldRenderParam::Pause()
     // only takes effect while the status is exactly RENDERING and silently no-ops in every other state, and the
     // `_paused` store below is what makes the request stick until UpdateRender() can establish the gate.
     _paused.store(true, std::memory_order_release);
-    if (_delegate != nullptr && !_delegate->IsBatchContext()) {
+    if (_delegate != nullptr && !_delegate->IsBatchContext() && _delegate->GetProceduralParent() == nullptr) {
         AiRenderPause(_delegate->GetRenderSession());
     }
 #else
@@ -289,7 +293,7 @@ void HdArnoldRenderParam::Resume()
     // Explicitly lift the pause gate here rather than waiting for the next
     // UpdateRender poll, since AiRenderGetStatus() keeps reporting RENDERING
     // while paused and UpdateRender has no other signal to act on.
-    if (_delegate != nullptr && !_delegate->IsBatchContext()) {
+    if (_delegate != nullptr && !_delegate->IsBatchContext() && _delegate->GetProceduralParent() == nullptr) {
         AiRenderResume(_delegate->GetRenderSession());
     }
 #endif


### PR DESCRIPTION
**Changes proposed in this pull request**
We were previously skipping nodes destruction as soon as we had a procedural parent, but we should also have added the condition of the session being a batch one. Unfortunately, some investigation showed that we were not setting properly the flags `isBatch` and `renderSessionType` were not set properly in some code paths.

This PR fixes it by setting the flags properly and also handles the different parts of the code that were reading those flags so that we keep having the desired behaviour

**Issues fixed in this pull request**
Fixes ARNOLD-17930
