### PR TITLE
Add build variable for hydra2 and remove legacy ones

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -127,7 +127,7 @@ vars.AddVariables(
     BoolVariable('DISABLE_CXX11_ABI', 'Disable the use of the CXX11 abi for gcc/clang', False),
     BoolVariable('ENABLE_HYDRA_IN_USD_PROCEDURAL', 'Enable building hydra render delegate in the usd procedural', True),
     BoolVariable('ENABLE_SHARED_ARRAYS', 'Enable the use of shared arrays in hydra', False),
-    BoolVariable('ENABLE_HYDRA2_RENDERSETTINGS', 'Enable the use of RenderSettings hydra prim', False),
+    BoolVariable('ENABLE_HYDRA2', 'Traverse the stage with the scene index (Hydra 2) by default. The USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX environment variable overrides this at runtime. Unrelated to BUILD_SCENE_INDEX_PLUGIN, which must stay enabled either way since Hydra 1 needs the scene index filters too.', True),
     BoolVariable('ENABLE_TRACING', 'Enable USD trace instrumentation (TRACE_FUNCTION/TRACE_SCOPE).', False),
     BoolVariable('BUILD_USDGENSCHEMA_ARNOLD', 'Whether or not to build the simplified usdgenschema', False),
     BoolVariable('IGNORE_ARCH_FLAGS', 'Ignore the arch flags when compiling usdgenschema', False),

--- a/cmake/utils/options.cmake
+++ b/cmake/utils/options.cmake
@@ -50,6 +50,10 @@ option(BUILD_TURNTABLE "Build the turntable tool" OFF)
 # Configurations:
 option(ENABLE_HYDRA_IN_USD_PROCEDURAL "Enable hydra in the procedural" ON)
 option(ENABLE_SHARED_ARRAYS "Enable using shared arrays" OFF)
+# Unrelated to BUILD_SCENE_INDEX_PLUGIN / ENABLE_SCENE_INDEX_IN_BUNDLE: those say whether the
+# scene index filters are compiled in, which Hydra 1 needs too. This one only picks the
+# default traversal mode, and USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX still overrides it.
+option(ENABLE_HYDRA2 "Traverse the stage with the scene index (Hydra 2) by default" ON)
 option(ENABLE_SCENE_INDEX_IN_BUNDLE "Add the scene index filters in the bundle" OFF)
 # The bundle embeds the procedural alongside the USD/Hydra plugins. Hosts that ship the
 # procedural from an Arnold distribution instead only want the plugins, and embedding a

--- a/libs/render_delegate/CMakeLists.txt
+++ b/libs/render_delegate/CMakeLists.txt
@@ -89,4 +89,11 @@ target_compile_definitions(render_delegate PRIVATE "HDARNOLD_EXPORTS=1")
 if (BUILD_SCENE_INDEX_PLUGIN OR ENABLE_SCENE_INDEX_IN_BUNDLE)
     target_compile_definitions(render_delegate PUBLIC ENABLE_SCENE_INDEX=1)
 endif()
+# Whether Hydra 2 is the default traversal mode. Only HdArnoldIsSceneIndexEnabled() in
+# utils.cpp reads this, so it is enough to define it for this library.
+if (ENABLE_HYDRA2)
+    target_compile_definitions(render_delegate PUBLIC ARNOLD_ENABLE_HYDRA2=1)
+else()
+    target_compile_definitions(render_delegate PUBLIC ARNOLD_ENABLE_HYDRA2=0)
+endif()
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC} ${HDR})

--- a/libs/render_delegate/SConscript
+++ b/libs/render_delegate/SConscript
@@ -62,6 +62,10 @@ if local_env['ENABLE_SHARED_ARRAYS']:
 if local_env['BUILD_SCENE_INDEX_PLUGIN']:
     local_env.Append(CPPDEFINES = ['ENABLE_SCENE_INDEX'])
 
+# Whether Hydra 2 is the default traversal mode. Only HdArnoldIsSceneIndexEnabled() in
+# utils.cpp reads this, so it is enough to define it for this library.
+local_env.Append(CPPDEFINES = [('ARNOLD_ENABLE_HYDRA2', '1' if local_env['ENABLE_HYDRA2'] else '0')])
+
 if local_env['USD_HAS_HGI_GL']:
     # Appended to the shared 'env' (not local_env) so this define is visible to
     # any SConscript compiling against render_buffer.h after this one runs,

--- a/libs/render_delegate/reader.cpp
+++ b/libs/render_delegate/reader.cpp
@@ -173,7 +173,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
 {
     static AtMutex s_renderIndexCreationMutex;
     static AtMutex s_renderDelegateCreationMutex;
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
     _useSceneIndex = HdArnoldIsSceneIndexEnabled();
 #endif
 
@@ -215,7 +215,7 @@ HydraArnoldReader::HydraArnoldReader(AtUniverse *universe, AtNode *procParent) :
     _sceneDelegateId = SdfPath::AbsoluteRootPath();
 
     if (_useSceneIndex) {
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
         UsdImagingCreateSceneIndicesInfo info;
         info.displayUnloadedPrimsWithBounds = false;
         info.overridesSceneIndexCallback =
@@ -481,7 +481,7 @@ void HydraArnoldReader::SetPurpose(const std::string &p) { _purpose = TfToken(p.
 void HydraArnoldReader::SetId(unsigned int id) { _id = id; }
 void HydraArnoldReader::SetRenderSettings(const std::string &renderSettings) {_renderSettings = renderSettings;}
 void HydraArnoldReader::SetRenderPass(const std::string &renderPass) {
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
     if (_sceneGlobalsSceneIndex) {
         SdfPath renderPassPrimPath(renderPass);
         if (!renderPassPrimPath.IsEmpty()) {
@@ -495,7 +495,7 @@ void HydraArnoldReader::Update()
 {
     HdArnoldRenderDelegate *arnoldRenderDelegate = GetArnoldRenderDelegate();
     if (_useSceneIndex) {
-#ifdef ARNOLD_SCENE_INDEX        
+#ifdef ENABLE_SCENE_INDEX
         _stageSceneIndex->ApplyPendingUpdates();
 #endif
     }
@@ -522,7 +522,7 @@ void HydraArnoldReader::WriteDebugScene() const
 }
 
 
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
 
 HdSceneIndexBaseRefPtr
 HydraArnoldReader::_AppendOverridesSceneIndices(

--- a/libs/render_delegate/reader.h
+++ b/libs/render_delegate/reader.h
@@ -14,7 +14,6 @@
 #include "render_delegate.h"
 
 #ifdef ENABLE_SCENE_INDEX
-#define ARNOLD_SCENE_INDEX
 
 #include "pxr/usdImaging/usdImaging/sceneIndices.h"
 #include "pxr/imaging/hdsi/legacyDisplayStyleOverrideSceneIndex.h"
@@ -79,7 +78,7 @@ private:
     HdsiLegacyDisplayStyleOverrideSceneIndexRefPtr _displayStyleSceneIndex;
     HdsiPrimTypePruningSceneIndexRefPtr _materialPruningSceneIndex;
     HdsiPrimTypePruningSceneIndexRefPtr _lightPruningSceneIndex;
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
     HdsiSceneGlobalsSceneIndexRefPtr _sceneGlobalsSceneIndex;
 #endif
     AtUniverse *_universe = nullptr;
@@ -94,7 +93,7 @@ private:
     TimeSettings _time;
     SdfPath _renderCameraPath;
 
-#ifdef ARNOLD_SCENE_INDEX
+#ifdef ENABLE_SCENE_INDEX
     HdSceneIndexBaseRefPtr
     _AppendOverridesSceneIndices(
         const HdSceneIndexBaseRefPtr &inputScene);

--- a/libs/render_delegate/utils.cpp
+++ b/libs/render_delegate/utils.cpp
@@ -82,10 +82,20 @@ inline bool _TokenStartsWithToken(const TfToken& t0, const TfToken& t1)
 
 } // namespace
 
+// Build-time default for the Hydra 1 / Hydra 2 choice, set from the ENABLE_HYDRA2 build
+// option. This is deliberately independent of ENABLE_SCENE_INDEX: that one says whether the
+// scene index filters are compiled in at all, and Hydra 1 needs them just as much as Hydra 2
+// does (HdRenderIndex applies the per-renderer filters under scene index emulation, which is
+// on by default in either mode). Hosts that are not ready for Hydra 2 build with
+// ENABLE_HYDRA2=False and must keep BUILD_SCENE_INDEX_PLUGIN enabled.
+#ifndef ARNOLD_ENABLE_HYDRA2
+#define ARNOLD_ENABLE_HYDRA2 1
+#endif
+
 bool HdArnoldIsSceneIndexEnabled()
 {
     if (!ArchHasEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX"))
-        return true;
+        return ARNOLD_ENABLE_HYDRA2 != 0;
 
     std::string useSceneIndex = ArchGetEnv("USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX");
     std::string::size_type i = useSceneIndex.find(" ");


### PR DESCRIPTION
The existing build variable BUILD_SCENE_INDEX_PLUGIN doesn't actually say if we're building for hydra2 or hydra1, since scene index plugins are also used for hydra1.
Now that we changed the default value of USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX we need to provide another build variable to explicitely enable hydra2 or not. This PR adds it, and it also removes some of the other defines & variables that were no longer used in the code to avoid adding too many variables