### PR TITLE
Support shader imagers with proper updates

### DIFF
--- a/libs/render_delegate/node_graph.cpp
+++ b/libs/render_delegate/node_graph.cpp
@@ -174,6 +174,26 @@ HdArnoldNodeGraph::~HdArnoldNodeGraph()
 
 }
 
+bool HdArnoldNodeGraph::_TerminalsOnlyFeedImagers() const
+{
+#if ARNOLD_VERSION_NUM >= 70504
+    // Nothing translated yet: there is no shader to ask about, and the first translation of a graph
+    // can't be an edit to one an imager already reads.
+    if (_nodeGraphCache.terminals.empty())
+        return false;
+
+    for (const auto& terminal : _nodeGraphCache.terminals) {
+        // A null terminal, or one Arnold reports as reachable from something other than an imager
+        // (or as not being in an imager tree at all), means this graph may affect the beauty pass.
+        if (!AiShaderInImagerTree(terminal.second))
+            return false;
+    }
+    return true;
+#else
+    return false;
+#endif
+}
+
 // Root function called to translate a shading NodeGraph primitive
 void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits)
 {
@@ -186,6 +206,13 @@ void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
 
     if ((*dirtyBits & HdMaterial::DirtyResource) && !id.IsEmpty()) {
         HdArnoldRenderParamInterrupt param(renderParam);
+        // Editing a graph nothing but an imager reads doesn't invalidate the image already
+        // rendered, so instead of interrupting and restarting the render we quiesce the imagers,
+        // edit, and let Arnold re-run them over that image (#2452). This covers the imager graph
+        // itself as well as a shading tree an imager_shader points at. Resumed by the destructor,
+        // at the end of this scope.
+        HdArnoldImagerInterrupt imagerParam(_renderDelegate);
+        const bool imagerOnly = _imagerGraph || _TerminalsOnlyFeedImagers();
         const VtValue value = sceneDelegate->GetMaterialResource(GetId());
         bool nodeGraphChanged = false;
 
@@ -209,9 +236,12 @@ void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
         }
 
         if (value.IsHolding<HdMaterialNetworkMap>()) {
-            // Do not interrupt the render if this is an imager graph, as imagers
-            // can be refreshed independantly of the render itself
-            if (!_imagerGraph)
+            // Do not interrupt the render if only imagers read this graph, as imagers
+            // can be refreshed independantly of the render itself. We still have to stop
+            // them from reading the nodes we're about to edit, see imagerParam above.
+            if (imagerOnly)
+                imagerParam.Interrupt();
+            else
                 param.Interrupt();
 
             const HdMaterialNetworkMap& materialNetworkmap = value.UncheckedGet<HdMaterialNetworkMap>();
@@ -317,10 +347,6 @@ void HdArnoldNodeGraph::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* rend
         if (_wasSyncedOnce && nodeGraphChanged) {
             _renderDelegate->DirtyDependency(id);
         }
-        // If this node graph is an imager graph, the render won't be interrupted / restarted
-        // and instead we just call this render hint that updates the imagers #2452
-        if (_imagerGraph)
-            AiRenderSetHintBool(_renderDelegate->GetRenderSession(), str::request_imager_update, true);
     }
     *dirtyBits = HdMaterial::Clean;
     _wasSyncedOnce = true;

--- a/libs/render_delegate/node_graph.h
+++ b/libs/render_delegate/node_graph.h
@@ -344,6 +344,17 @@ protected:
         using Terminals = std::vector<Terminal>;
         Terminals terminals; ///< Terminal entries to the node graph.
     };
+    /// Whether every terminal of this graph is consumed exclusively by imager nodes, so editing it
+    /// only affects the imager pipeline and the render doesn't need to be interrupted and restarted
+    /// (see AiShaderInImagerTree and HdArnoldImagerInterrupt). This is about a shading tree an
+    /// imager_shader points at; the imager graph itself is flagged by SetImagerGraph() instead,
+    /// since its terminal is an imager node rather than a shader.
+    ///
+    /// Answered from the terminals of the previous translation, because the decision has to be made
+    /// before this graph is re-translated. Returns false before the first one, and false on Arnold
+    /// versions without AiShaderInImagerTree().
+    bool _TerminalsOnlyFeedImagers() const;
+
     /// Convert a Hydra Material Network to an Arnold Shader Network.
     ///
     /// The newly created Arnold Nodes are stored in the class instance. Every

--- a/libs/render_delegate/render_param.cpp
+++ b/libs/render_delegate/render_param.cpp
@@ -446,4 +446,34 @@ const SdfPath& HdArnoldRenderParam::GetHydraRenderSettingsPrimPath() const
     return _hydraRenderSettingsPrimPath;
 }
 
+void HdArnoldImagerInterrupt::Interrupt()
+{
+    if (_hasInterrupted || _delegate == nullptr || _delegate->IsBatchContext() ||
+        _delegate->GetProceduralParent() != nullptr) {
+        return;
+    }
+    _hasInterrupted = true;
+#if ARNOLD_VERSION_NUM >= 70504
+    // Blocks until no thread is inside an imager evaluation, so the imager nodes and the shading
+    // trees they read can be edited safely.
+    AiImagerInterrupt(_delegate->GetRenderSession());
+#endif
+}
+
+void HdArnoldImagerInterrupt::Resume()
+{
+    if (!_hasInterrupted) {
+        return;
+    }
+    _hasInterrupted = false;
+#if ARNOLD_VERSION_NUM >= 70504
+    AiImagerResume(_delegate->GetRenderSession());
+#else
+    // Before AiImagerInterrupt()/AiImagerResume() existed, this hint was the only way to refresh the
+    // imagers without restarting the render (#2452), and the edits above raced whatever imager was
+    // evaluating at the time.
+    AiRenderSetHintBool(_delegate->GetRenderSession(), str::request_imager_update, true);
+#endif
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/libs/render_delegate/render_param.h
+++ b/libs/render_delegate/render_param.h
@@ -288,4 +288,51 @@ private:
     HdArnoldRenderParam* _param = nullptr;
 };
 
+/// Utility class to bracket edits to nodes that are only read by imagers.
+///
+/// An imager evaluation reads the imager nodes and, for imager_shader, the shading tree they point
+/// at. Those nodes must not be mutated while an evaluation is in flight, for the same reason the
+/// render has to be interrupted before editing render nodes - but unlike a render node, editing them
+/// does not invalidate what has already been rendered. So instead of interrupting and restarting the
+/// render (HdArnoldRenderParamInterrupt), Interrupt() quiesces imager evaluation only, and Resume()
+/// re-runs the imagers over the image already computed. The render threads keep going throughout.
+///
+/// Resume() is also called by the destructor, so the barrier Interrupt() closes is always reopened -
+/// leaving it closed would hold the render at its next pass. Like HdArnoldRenderParamInterrupt, only
+/// the first Interrupt() of an instance does anything, so it can be called on every edit.
+class HdArnoldImagerInterrupt {
+public:
+    /// Constructor for HdArnoldImagerInterrupt.
+    ///
+    /// @param delegate Pointer to the Render Delegate owning the render session.
+    HdArnoldImagerInterrupt(const HdArnoldRenderDelegate* delegate) : _delegate(delegate) {}
+
+    /// Resumes imager evaluation if this instance interrupted it.
+    ~HdArnoldImagerInterrupt() { Resume(); }
+
+    HdArnoldImagerInterrupt(const HdArnoldImagerInterrupt&) = delete;
+    HdArnoldImagerInterrupt& operator=(const HdArnoldImagerInterrupt&) = delete;
+
+    /// Pauses imager evaluation, blocking until nothing is reading the imager shaders.
+    ///
+    /// Does nothing when called more than once, and nothing at all in a batch render or under a
+    /// procedural parent, matching HdArnoldRenderParam::Interrupt(): there we don't own the render
+    /// loop, and the host brackets its own edits. It would also deadlock under a procedural parent,
+    /// where this runs from inside the render's scene update, which Arnold counts as an imager
+    /// reader - so it would be waiting on itself.
+    HDARNOLD_API
+    void Interrupt();
+
+    /// Resumes imager evaluation and requests an imager refresh, so the edits show up. Does nothing
+    /// unless a preceding Interrupt() on this instance actually paused the imagers.
+    HDARNOLD_API
+    void Resume();
+
+private:
+    /// The render delegate, used to reach the render session. Never dereferenced without a null check.
+    const HdArnoldRenderDelegate* _delegate = nullptr;
+    /// Indicate if this instance paused imager evaluation, and so owes a Resume().
+    bool _hasInterrupted = false;
+};
+
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Latest versions of arnold now have an API AiImagerInterrupt / AiImagerResume, that should be used during imager updates.
Also, when an imager shader is present, it will include a shading tree in the same node graph. This PR adds support for it